### PR TITLE
Fixed GherkinDumper for multiple keywords

### DIFF
--- a/src/Behat/Gherkin/Dumper/GherkinDumper.php
+++ b/src/Behat/Gherkin/Dumper/GherkinDumper.php
@@ -130,9 +130,8 @@ class GherkinDumper
      */
     public function dumpKeyword($keyword, $text, $indent = 0)
     {
-        if (preg_match('!(^.*)\|!', $keyword, $matches)) {
-            $keyword = $matches[1];
-        }
+        $keywords = explode('|', $keyword);
+        $keyword = reset($keywords);
 
         return $this->dumpIndent($indent) . $keyword . ':'
             . ((strlen($text) > 0) ? ' ' . ltrim($this->dumpText($text, $indent + 1)) : '')

--- a/tests/Behat/Gherkin/Dumper/GherkinDumperTest.php
+++ b/tests/Behat/Gherkin/Dumper/GherkinDumperTest.php
@@ -24,7 +24,7 @@ class GherkinDumperTest extends \PHPUnit_Framework_TestCase
         $this->keywords = new ArrayKeywords(
             array(
                 'en' => array(
-                    'feature' => 'Feature',
+                    'feature' => 'Feature|Business Need|Ability',
                     'background' => 'Background',
                     'scenario' => 'Scenario',
                     'scenario_outline' => 'Scenario Outline|Scenario Template',


### PR DESCRIPTION
Dumper does not dump keywords correctly if there are more than 2 of them.

When it was f.e. for feature "Feature|Business Need" then it worked ok but if it is "Feature|Business Need|Ability" like now then it dumps not the "Feature" keyword but "Feature|Business Need" instead.
