### PR TITLE
Fixed mocking for PHPUnit 3.7

### DIFF
--- a/tests/Behat/Gherkin/GherkinTest.php
+++ b/tests/Behat/Gherkin/GherkinTest.php
@@ -32,23 +32,22 @@ class GherkinTest extends \PHPUnit_Framework_TestCase
             ->with($resource)
             ->will($this->returnValue(array($feature)));
 
-        $filterFeature = clone $feature;
         $nameFilter
             ->expects($this->once())
             ->method('filterFeature')
-            ->with($filterFeature);
+            ->with($this->identicalTo($feature));
         $tagFilter
             ->expects($this->once())
             ->method('filterFeature')
-            ->with($filterFeature);
+            ->with($this->identicalTo($feature));
         $customFilter1
             ->expects($this->once())
             ->method('filterFeature')
-            ->with($filterFeature);
+            ->with($this->identicalTo($feature));
         $customFilter2
             ->expects($this->once())
             ->method('filterFeature')
-            ->with($filterFeature);
+            ->with($this->identicalTo($feature));
 
         $features = $gherkin->load($resource, array($customFilter1, $customFilter2));
         $this->assertEquals(1, count($features));


### PR DESCRIPTION
Since the last build - [106](https://travis-ci.org/#!/Behat/Gherkin/jobs/2568218), Travis has switched from PHPUnit 3.6.12 to PHPUnit 3.7.7 in the [107th](https://travis-ci.org/#!/Behat/Gherkin/jobs/2928235) build

The change is that parameters for mock objects do not get cloned anymore, so comparing objects has to be done like [this](http://www.phpunit.de/manual/3.7/en/test-doubles.html#test-doubles.mock-objects.examples.clone-object-parameters-usecase.php)
