### PR TITLE
Support for inline comments in tables

### DIFF
--- a/src/Behat/Gherkin/Lexer.php
+++ b/src/Behat/Gherkin/Lexer.php
@@ -434,7 +434,7 @@ class Lexer
             return;
         }
 
-        $line = trim($this->line);
+        $line = trim(preg_replace('/#([^\|]+)$/', '', trim($this->line)));
 
         if (isset($line[0]) && '|' === $line[0]) {
             $token = $this->takeToken('TableRow');

--- a/tests/Behat/Gherkin/Fixtures/features/tables.feature
+++ b/tests/Behat/Gherkin/Fixtures/features/tables.feature
@@ -16,5 +16,5 @@ Feature: A scenario outline
 #comment
     Examples:
       | a   | b   | c |
-      | 1   | \|2 | 3 |
+      | 1   | \|2 | 3 | #comment
       | 2   | 3   | 4 |


### PR DESCRIPTION
This adds supports for inline comments in tables. I've sometimes found the need to add extra information for other Gherkin authors for a particular table row, but currently it throws an error. For example:

```
  | column1 | column2 | column3 |
  | 1       | 1       | 1       |
  | 2       | 2       | 2       | # extra comment
  | 3       | 3       | 3       |
```
