### PR TITLE
Added branch alias 2.2-dev.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,5 +30,10 @@
         "psr-0": {
             "Behat\\Gherkin":   "src/"
         }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-develop": "2.2-dev"
+        }
     }
 }


### PR DESCRIPTION
Allows to install Behat in Symfony 2.2. 
