### PR TITLE
Make master 4.1-dev branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
 
     "extra": {
         "branch-alias": {
-            "dev-master": "4.0-dev"
+            "dev-master": "4.1-dev"
         }
     }
 }


### PR DESCRIPTION
Since `master` was tagged as `v4.1.0` it would be nice to update alias to `4.1-dev`
