### PR TITLE
Refactored the YamlFileLoader to remove duplication

### DIFF
--- a/src/Behat/Gherkin/Loader/YamlFileLoader.php
+++ b/src/Behat/Gherkin/Loader/YamlFileLoader.php
@@ -51,7 +51,7 @@ class YamlFileLoader extends AbstractFileLoader
     public function load($path)
     {
         $path = $this->findAbsolutePath($path);
-        $hash = Yaml::parse($path);
+        $hash = Yaml::parse(file_get_contents($path));
 
         $features = $this->loader->load($hash);
         $filename = $this->findRelativePath($path);

--- a/tests/Behat/Gherkin/Keywords/CucumberKeywordsTest.php
+++ b/tests/Behat/Gherkin/Keywords/CucumberKeywordsTest.php
@@ -18,7 +18,7 @@ class CucumberKeywordsTest extends KeywordsTest
 
     protected function getKeywordsArray()
     {
-        return Yaml::parse(__DIR__ . '/../Fixtures/i18n.yml');
+        return Yaml::parse(file_get_contents(__DIR__ . '/../Fixtures/i18n.yml'));
     }
 
     protected function getSteps($keywords, $text, &$line)


### PR DESCRIPTION
The YamlFileLoader now uses the ArrayLoader by composition rather than inheritance, allowing to extend from the AbstractFileLoader, which is way more logical.
