### PR TITLE
Simplified the Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,20 @@
 language: php
 
-php: [5.3, 5.4, 5.5, hhvm]
+php: [5.3, 5.4, 5.5, 5.6, hhvm]
 
-env:
-  - SYMFONY_VERSION='2.1.*'
-  - SYMFONY_VERSION='2.2.*'
-  - SYMFONY_VERSION='2.3.*'
-  - SYMFONY_VERSION='2.4.*'
+matrix:
+  include:
+    - php: 5.5
+      env: SYMFONY_VERSION='2.1.*'
+    - php: 5.5
+      env: SYMFONY_VERSION='2.2.*'
+    - php: 5.5
+      env: SYMFONY_VERSION='2.3.*'
+    - php: 5.5
+      env: SYMFONY_VERSION='2.5.*@dev'
 
 before_script:
-  - composer require --no-update symfony/symfony=$SYMFONY_VERSION
+  - sh -c 'if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update symfony/symfony=$SYMFONY_VERSION; fi;'
   - composer install --prefer-source
 
 script: vendor/bin/phpunit -v --coverage-clover=coverage.clover


### PR DESCRIPTION
Testing against older symfony versions is now done only for 1 version of PHP rather than all of them.
