### PR TITLE
Updated the badges displayed in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,9 @@ Behat Gherkin Parser
 This is the php Gherkin parser for Behat. It comes bundled with more than 40 native languages
 (see `i18n.php`) support & clean architecture.
 
-- [master](https://github.com/Behat/Gherkin/tree/master) ([![master Build
-Status](https://secure.travis-ci.org/Behat/Gherkin.png?branch=master)](http://travis-ci.org/Behat/Gherkin)) - Latest 4.0 version of the parser.
-- [3.1](https://github.com/Behat/Gherkin/tree/3.1) ([![3.1 Build
-Status](https://secure.travis-ci.org/Behat/Gherkin.png?branch=3.1)](http://travis-ci.org/Behat/Gherkin)) - Previous 3.1 version of the parser.
-- [3.0](https://github.com/Behat/Gherkin/tree/3.0) ([![3.0 Build
-Status](https://secure.travis-ci.org/Behat/Gherkin.png?branch=3.0)](http://travis-ci.org/Behat/Gherkin)) - Previous 3.0 version of the parser.
-- [2.3](https://github.com/Behat/Gherkin/tree/2.3) ([![2.3 Build
-  Status](https://secure.travis-ci.org/Behat/Gherkin.png?branch=2.3)](http://travis-ci.org/Behat/Gherkin)) - Previous 2.3 version of the parser.
+[![Build Status](https://travis-ci.org/Behat/Gherkin.svg?branch=master)](https://travis-ci.org/Behat/Gherkin)
+[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/Behat/Gherkin/badges/quality-score.png?s=04d9d0237c89f4c45a94ba5304234db861dfd036)](https://scrutinizer-ci.com/g/Behat/Gherkin/)
+[![Code Coverage](https://scrutinizer-ci.com/g/Behat/Gherkin/badges/coverage.png?s=204ca44800469d295b73d18c91011cb9d2dc99fc)](https://scrutinizer-ci.com/g/Behat/Gherkin/)
 
 Useful Links
 ------------


### PR DESCRIPTION
This adds the scrutinizer badges and removes the travis badges for old branches as they are not expected to be updated anymore
