### PR TITLE
Removed the unused dev dependency to symfony/config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
 
 before_script:
   - composer self-update
-  - sh -c 'if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update symfony/symfony=$SYMFONY_VERSION; fi;'
+  - sh -c 'if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update symfony/yaml=$SYMFONY_VERSION; fi;'
   - composer install --prefer-source
 
 script: vendor/bin/phpunit -v --coverage-clover=coverage.clover

--- a/composer.json
+++ b/composer.json
@@ -19,13 +19,11 @@
 
     "require-dev": {
         "symfony/yaml":    "~2.1",
-        "symfony/config":  "~2.1",
         "phpunit/phpunit": "~4.0"
     },
 
     "suggest": {
-        "symfony/yaml":   "If you want to parse features, represented in YAML files",
-        "symfony/config": "If you want to use Config component to manage resources"
+        "symfony/yaml":   "If you want to parse features, represented in YAML files"
     },
 
     "autoload": {


### PR DESCRIPTION
This component is not used at all in Gherkin.

This actually also removes the need to install `symfony/filesystem`, which is required by `symfony/config`
