### PR TITLE
Support features located through symlink

### DIFF
--- a/src/Behat/Gherkin/Loader/AbstractFileLoader.php
+++ b/src/Behat/Gherkin/Loader/AbstractFileLoader.php
@@ -58,6 +58,10 @@ abstract class AbstractFileLoader implements FileLoaderInterface
             return realpath($path);
         }
 
+        if (is_link($path)) {
+            return readlink($path);
+        }
+
         if (null === $this->basePath) {
             return false;
         }
@@ -65,6 +69,10 @@ abstract class AbstractFileLoader implements FileLoaderInterface
         if (is_file($this->basePath . DIRECTORY_SEPARATOR . $path)
                || is_dir($this->basePath . DIRECTORY_SEPARATOR . $path)) {
             return realpath($this->basePath . DIRECTORY_SEPARATOR . $path);
+        }
+
+        if (is_link($this->basePath . DIRECTORY_SEPARATOR . $path)) {
+            return readlink($this->basePath . DIRECTORY_SEPARATOR . $path);
         }
 
         return false;


### PR DESCRIPTION
Hello,

At Akeneo, we've been working on an enterprise edition of the PIM which will have the community edition features and a bunch of new ones.
Thus, it makes sense for us to launch the community edition scenarios in our enterprise build to make sure we provide the same subset of features both in CE and EE.
The solution we've found to allow that is to create symlink of the features directory from the CE in the EE features folder.
This could look hackish, but we don't want to duplicate common scenarios (more than 300) and have to maintain them in both editions.

Problem is that Gherkin loader currently does not support loading feature files through symbolic link.
I don't know if this is made on purpose, but as it makes sense in my opinion, here's my PR.

Tell me what you think, I'll add tests if it makes sense.

Cheers!