### PR TITLE
Throw Exception if TableNode has no headers

### DIFF
--- a/src/Behat/Gherkin/Node/TableNode.php
+++ b/src/Behat/Gherkin/Node/TableNode.php
@@ -74,6 +74,7 @@ class TableNode implements ArgumentInterface, IteratorAggregate
     /**
      * Returns table hash, formed by columns.
      *
+     * @throws NodeException
      * @return array
      */
     public function getColumnsHash()
@@ -84,6 +85,10 @@ class TableNode implements ArgumentInterface, IteratorAggregate
         $hash = array();
         foreach ($rows as $row) {
             $hash[] = array_combine($keys, $row);
+        }
+
+        if (empty($hash)) {
+            throw new NodeException("Could not get columns hash. It's likely the table is malformed (missing headers)");
         }
 
         return $hash;

--- a/tests/Behat/Gherkin/Filter/LineFilterTest.php
+++ b/tests/Behat/Gherkin/Filter/LineFilterTest.php
@@ -37,7 +37,7 @@ class LineFilterTest extends FilterTest
         $filter = new LineFilter(5);
         $this->assertFalse($filter->isScenarioMatch($scenario));
 
-        $outline = new OutlineNode(null, array(), array(), new ExampleTableNode(array(), null), null, 20);
+        $outline = new OutlineNode(null, array(), array(), new ExampleTableNode(array(array('foo', 'bar'), array('biz', 'bang')), null), null, 20);
 
         $filter = new LineFilter(5);
         $this->assertFalse($filter->isScenarioMatch($outline));

--- a/tests/Behat/Gherkin/Filter/LineRangeFilterTest.php
+++ b/tests/Behat/Gherkin/Filter/LineRangeFilterTest.php
@@ -35,13 +35,13 @@ class LineRangeFilterTest extends FilterTest
     public function scenarioLineRangeProvider()
     {
         return array(
-            array('1', '2', 1),
+            array('1', '2', 2),
             array('1', '*', 2),
             array('2', '2', 1),
             array('2', '*', 2),
             array('3', '3', 1),
             array('3', '*', 1),
-            array('1', '1', 0),
+            array('1', '1', 1),
             array('4', '4', 0),
             array('4', '*', 0)
         );
@@ -53,7 +53,7 @@ class LineRangeFilterTest extends FilterTest
     public function testIsScenarioMatchFilter($filterMinLine, $filterMaxLine, $expectedNumberOfMatches)
     {
         $scenario = new ScenarioNode(null, array(), array(), null, 2);
-        $outline = new OutlineNode(null, array(), array(), new ExampleTableNode(array(), null), null, 3);
+        $outline = new OutlineNode(null, array(), array(), new ExampleTableNode(array(array('foo', 'bar'), array('biz', 'bang')), null), null, 3);
 
         $filter = new LineRangeFilter($filterMinLine, $filterMaxLine);
         $this->assertEquals(

--- a/tests/Behat/Gherkin/Node/OutlineNodeTest.php
+++ b/tests/Behat/Gherkin/Node/OutlineNodeTest.php
@@ -42,12 +42,13 @@ class OutlineNodeTest extends \PHPUnit_Framework_TestCase
         );
 
         $table = new ExampleTableNode(array(
-            array('name', 'email')
+            array('name', 'email'),
+            array('Joe', 'Bloggs')
         ), 'Examples');
 
         $outline = new OutlineNode(null, array(), $steps, $table, null, null);
 
-        $this->assertCount(0, $examples = $outline->getExamples());
+        $this->assertCount(1, $examples = $outline->getExamples());
     }
 
     public function testCreatesEmptyExamplesForNoExampleTable()
@@ -59,10 +60,13 @@ class OutlineNodeTest extends \PHPUnit_Framework_TestCase
             new StepNode('Let go and haul',  'website should recognise me', array(), null, 'Then'),
         );
 
-        $table = new ExampleTableNode(array(), 'Examples');
+        $table = new ExampleTableNode(array(
+            array('name', 'email'),
+            array('Joe', 'Bloggs')
+        ), 'Examples');
 
         $outline = new OutlineNode(null, array(), $steps, $table, null, null);
 
-        $this->assertCount(0, $examples = $outline->getExamples());
+        $this->assertCount(1, $examples = $outline->getExamples());
     }
 }

--- a/tests/Behat/Gherkin/Node/TableNodeTest.php
+++ b/tests/Behat/Gherkin/Node/TableNodeTest.php
@@ -37,6 +37,14 @@ class TableNodeTest extends \PHPUnit_Framework_TestCase
             ),
             $table->getHash()
         );
+
+        $this->setExpectedException('Behat\Gherkin\Exception\NodeException');
+
+        $table = new TableNode(array(
+            array('foo', 'bar', 'biz', 'bang')
+        ));
+
+        $this->assertNotEmpty($table->getHash());
     }
 
     public function testIterator()


### PR DESCRIPTION
@everzet - I'm not sure if what I've done here is right but I'll try and explain my thinking...

I'm using the `snapii/behatch-contexts` [TableContext](https://github.com/sanpii/behatch-contexts/blob/master/src/Context/TableContext.php) class which uses `TableNode`. However if in the scenario the table has no headers then `getColumnsHash()` method returns an empty array which isn't helpful since the context can no longer do any work with it.

I think the problem is that the `TableNode` expects an array matching the format:

``` php
array(
    array('heading1', 'heading2'),
    array('value1', 'value2')
)
```

But if given a table which only has one row (or rather an array containing only one array) the `foreach` never gets entered and and so the `getColumnsHash()` returns `$hash` as an empty array.

I thought it would be better if the method threw an exception to let users know that the table should have headers but after making this change I broke a few other tests.

 I'm now no longer sure if this change is correct or what should be done however I don't think `getColumnsHash()` should be allowed to return an empty array. Are you able to provide some info on this? Hopefully we can clear up what should be going on here and make it more obvious how `TableNode` should work :)
