### PR TITLE
Add "Zakładając że" keyword to polish translation

### DIFF
--- a/i18n.php
+++ b/i18n.php
@@ -638,7 +638,7 @@
     'scenario' => 'Scenariusz',
     'scenario_outline' => 'Szablon scenariusza',
     'examples' => 'Przykłady',
-    'given' => 'Zakładając|Mając',
+    'given' => 'Zakładając|Mając|Zakładając że',
     'when' => 'Jeżeli|Kiedy|Jeśli|Gdy',
     'then' => 'Wtedy',
     'and' => 'Oraz|I',


### PR DESCRIPTION
"Zakładając że" means in polish "Given that". 
The main difference between Polish and English is that adding "że" completely changes the order of the sentence.

Sometimes it's more natural to use `zakładając że` rather just `zakładając|mając`, e.g. 
`Zakładając że jestem zalogowany jako "administrator"` (Given that I am logged in as an "administrator"). 

If you remove "że" from this sentence it has to become something like: 
`Zakładając zalogowanego użytkownika jako "administrator"` (Given there is a user logged in as an "administrator"), which in Polish sounds odd.

There is no easy way to just remove "że", as you could do it in English with removing "that" word.

We could of course always write `że` after a keyword, when we need it, but this leads to another issue - unnecessary `ze` in method names and annotations.
This code after my change:

```
    /**
     * @Given jestem zalogowany jako :name
     */
    public function jestemZalogowanyJako($name)
    {
    }
```

looks more natural than:

```
    /**
     * @Given że jestem zalogowany jako :name
     */
    public function zeJestemZalogowanyJako($name)
    {
    }
```

which contains unnecessary `ze` in method name and annotation
