### PR TITLE
Enforce that table nodes have same number of columns on every row

### DIFF
--- a/src/Behat/Gherkin/Node/TableNode.php
+++ b/src/Behat/Gherkin/Node/TableNode.php
@@ -35,12 +35,23 @@ class TableNode implements ArgumentInterface, IteratorAggregate
      * Initializes table.
      *
      * @param array $table Table in form of [$rowLineNumber => [$val1, $val2, $val3]]
+     * 
+     * @throws NodeException If the number of columns is not the same in each row
      */
     public function __construct(array $table)
     {
         $this->table = $table;
+        $columnCount = null;
 
         foreach ($this->getRows() as $row) {
+            if ($columnCount === null) {
+                $columnCount = count($row);
+            }
+
+            if (count($row) !== $columnCount) {
+                throw new NodeException('Table does not have same number of columns in every row.');
+            }
+
             foreach ($row as $column => $string) {
                 if (!isset($this->maxLineLength[$column])) {
                     $this->maxLineLength[$column] = 0;

--- a/tests/Behat/Gherkin/Node/TableNodeTest.php
+++ b/tests/Behat/Gherkin/Node/TableNodeTest.php
@@ -6,6 +6,18 @@ use Behat\Gherkin\Node\TableNode;
 
 class TableNodeTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @expectedException \Behat\Gherkin\Exception\NodeException
+     */
+    public function testConstructorExpectsSameNumberOfColumnsInEachRow()
+    {
+        new TableNode(array(
+            array('username', 'password'),
+            array('everzet'),
+            array('antono', 'pa$sword')
+        ));
+    }
+
     public function testHashTable()
     {
         $table = new TableNode(array(


### PR DESCRIPTION
_Was_ _previously:_ Behat/Gherkin#90 _(Accidentally_ _closed)_

The TableNode should throw an exception when it's not a valid table (i.e. when it doesn't have the same number of columns in every row).

Requested in Behat/Gherkin#89 by @everzet 

As TableNodes are entities that represent a specific concept in Gherkin, the table, so it's important that we ensure they cannot possess an representation that would be invalid in Gherkin.

For example:

``` Gherkin
Given I am user:
  | username | password |
  | ever.zet | 
  | antono   | pa$sword |
```

Is not a valid table in Gherkin, so we shouldn't allow this object to represent that. 

Now that translates to this PHP, note the unequal column count in each row.

``` php
new TableNode(array(
    array('username', 'password'),
    array('everzet'),
    array('antono', 'pa$sword')
));
//=> throws \Behat\Gherkin\Exception\NodeException('Table does not have same number of columns in every row.')
```

This PR makes TableNode throw an exception on construction when the column count is not equal on every row.
