### PR TITLE
Fail if table has no right border

### DIFF
--- a/src/Behat/Gherkin/Lexer.php
+++ b/src/Behat/Gherkin/Lexer.php
@@ -468,7 +468,7 @@ class Lexer
         }
 
         $line = $this->getTrimmedLine();
-        if (!isset($line[0]) || '|' !== $line[0]) {
+        if (!isset($line[0]) || '|' !== $line[0] || '|' !== substr($line, -1)) {
             return null;
         }
 

--- a/tests/Behat/Gherkin/ParserExceptionsTest.php
+++ b/tests/Behat/Gherkin/ParserExceptionsTest.php
@@ -271,4 +271,21 @@ GHERKIN;
 
         $this->gherkin->parse($feature);
     }
+
+    /**
+     * @expectedException \Behat\Gherkin\Exception\ParserException
+     */
+    public function testTableWithoutRightBorder()
+    {
+        $feature = <<<GHERKIN
+Feature:
+
+    Scenario:
+        Given something with:
+        | foo | bar
+        | 42  | 42
+GHERKIN;
+
+        $this->gherkin->parse($feature);
+    }
 }


### PR DESCRIPTION
Lexer should fail if table has no right border, otherwise table node contains corrupt data.