### PR TITLE
Add a reference to OutlineNode for ExampleNode

### DIFF
--- a/src/Behat/Gherkin/Node/ExampleNode.php
+++ b/src/Behat/Gherkin/Node/ExampleNode.php
@@ -41,23 +41,29 @@ class ExampleNode implements ScenarioInterface
      * @var null|StepNode[]
      */
     private $steps;
+    /**
+     * @var OutlineNode
+     */
+    private $outline;
 
     /**
      * Initializes outline.
      *
-     * @param string     $title
-     * @param string[]   $tags
-     * @param StepNode[] $outlineSteps
-     * @param string[]   $tokens
-     * @param integer    $line
+     * @param string      $title
+     * @param string[]    $tags
+     * @param StepNode[]  $outlineSteps
+     * @param string[]    $tokens
+     * @param integer     $line
+     * @param OutlineNode $outline
      */
-    public function __construct($title, array $tags, $outlineSteps, array $tokens, $line)
+    public function __construct($title, array $tags, $outlineSteps, array $tokens, $line, $outline)
     {
         $this->title = $title;
         $this->tags = $tags;
         $this->outlineSteps = $outlineSteps;
         $this->tokens = $tokens;
         $this->line = $line;
+        $this->outline = $outline;
     }
 
     /**
@@ -160,6 +166,16 @@ class ExampleNode implements ScenarioInterface
     public function getLine()
     {
         return $this->line;
+    }
+
+    /**
+     * Returns the OutlineNode
+     *
+     * @return OutlineNode
+     */
+    public function getOutline()
+    {
+        return $this->outline;
     }
 
     /**

--- a/src/Behat/Gherkin/Node/OutlineNode.php
+++ b/src/Behat/Gherkin/Node/OutlineNode.php
@@ -208,7 +208,8 @@ class OutlineNode implements ScenarioInterface
                 $this->tags,
                 $this->getSteps(),
                 $row,
-                $this->table->getRowLine($rowNum + 1)
+                $this->table->getRowLine($rowNum + 1),
+                $this
             );
         }
 

--- a/tests/Behat/Gherkin/Node/ExampleNodeTest.php
+++ b/tests/Behat/Gherkin/Node/ExampleNodeTest.php
@@ -89,4 +89,28 @@ class ExampleNodeTest extends \PHPUnit_Framework_TestCase
         $args = $steps[3]->getArguments();
         $this->assertEquals('| page | homepage |', $args[0]->getTableAsString());
     }
+
+    public function testExamplesIncludesTheOutlineNode()
+    {
+        $steps = array(
+            $step1 = new StepNode('Gangway!', 'I am <name>', array(), null, 'Given'),
+            $step2 = new StepNode('Aye!', 'my email is <email>', array(), null, 'And'),
+            $step3 = new StepNode('Blimey!', 'I open homepage', array(), null, 'When'),
+            $step4 = new StepNode('Let go and haul', 'website should recognise me', array(), null, 'Then'),
+        );
+
+        $table = new ExampleTableNode(array(
+            array('name', 'email'),
+            array('user1', 'user1@example.com'),
+            array('user2', 'user2@example.com'),
+        ), 'Examples');
+
+        $outline = new OutlineNode('outline test title', array(), $steps, $table, null, null);
+        $examples = $outline->getExamples();
+
+        for($i = 0; $i < count($examples); $i++) {
+            $this->assertTrue($examples[$i]->getOutline() instanceof OutlineNode);
+            $this->assertEquals('outline test title', $examples[$i]->getOutline()->getTitle());
+        }
+    }
 }


### PR DESCRIPTION
It is currently not possible to get the ScenarioOutline from an ExampleNode (like in a Scenario Hook)

This change adds a reference to the OutlineNode into the ExampleNode so there is a possibility to get the ScenarioOutline if it is needed so you could to this:

```php
public function afterScenario(AfterScenarioScope $scope)
    {
        if ($scope->getScenario() instanceof ExampleNode) {
            $title = $scope->getScenario()->getOutline()->getTitle();
        }
    }
```

there is a issue with the same basic requirements here, however with another approach: behat/behat#780