### PR TITLE
Fix the handling of file names in CucumberKeywords

### DIFF
--- a/src/Behat/Gherkin/Keywords/CucumberKeywords.php
+++ b/src/Behat/Gherkin/Keywords/CucumberKeywords.php
@@ -10,6 +10,7 @@
 
 namespace Behat\Gherkin\Keywords;
 
+use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Yaml;
 
 /**
@@ -24,11 +25,32 @@ class CucumberKeywords extends ArrayKeywords
     /**
      * Initializes holder with yaml string OR file.
      *
-     * @param string $yaml Yaml string
+     * @param string $yaml Yaml string or file path
      */
     public function __construct($yaml)
     {
-        parent::__construct(Yaml::parse($yaml));
+        // Handle filename explicitly for BC reasons, as Symfony Yaml 3.0 does not do it anymore
+        $file = null;
+        if (strpos($yaml, "\n") === false && is_file($yaml)) {
+            if (false === is_readable($yaml)) {
+                throw new ParseException(sprintf('Unable to parse "%s" as the file is not readable.', $yaml));
+            }
+
+            $file = $yaml;
+            $yaml = file_get_contents($file);
+        }
+
+        try {
+            $content = Yaml::parse($yaml);
+        } catch (ParseException $e) {
+            if ($file) {
+                $e->setParsedFile($file);
+            }
+
+            throw $e;
+        }
+
+        parent::__construct($content);
     }
 
     /**


### PR DESCRIPTION
The Yaml parser does not accept file names anymore in Symfony 3 (and this is deprecated in Symfony 2).
File names are now handled in the CucumberKeywords class directly now, copying the logic available in symfony/yaml 2.x, as we want to continue accepting a filename.

This was the reason of the test failure for the Symfony 3 jobs (and for other jobs after the addition of the phpunit-bridge)