### PR TITLE
Handle special chars in keywords

### DIFF
--- a/src/Behat/Gherkin/Lexer.php
+++ b/src/Behat/Gherkin/Lexer.php
@@ -324,8 +324,8 @@ class Lexer
                 $padded = array();
                 foreach (explode('|', $keywords) as $keyword) {
                     $padded[] = false !== mb_strpos($keyword, '<', 0, 'utf8')
-                        ? mb_substr($keyword, 0, -1, 'utf8') . '\s*'
-                        : $keyword . '\s+';
+                        ? preg_quote(mb_substr($keyword, 0, -1, 'utf8'), '/') . '\s*'
+                        : preg_quote($keyword, '/') . '\s+';
                 }
 
                 $keywords = implode('|', $padded);

--- a/tests/Behat/Gherkin/Keywords/ArrayKeywordsTest.php
+++ b/tests/Behat/Gherkin/Keywords/ArrayKeywordsTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Behat\Gherkin\Keywords;
+
+use Behat\Gherkin\Keywords\ArrayKeywords;
+use Behat\Gherkin\Node\StepNode;
+
+class ArrayKeywordsTest extends KeywordsTest
+{
+    protected function getKeywords()
+    {
+        return new ArrayKeywords($this->getKeywordsArray());
+    }
+
+    protected function getKeywordsArray()
+    {
+        return array(
+            'with_special_chars' => array(
+                'and' => 'And/foo',
+                'background' => 'Background.',
+                'but' => 'But[',
+                'examples' => 'Examples|Scenarios',
+                'feature' => 'Feature|Business Need|Ability',
+                'given' => 'Given',
+                'name' => 'English',
+                'native' => 'English',
+                'scenario' => 'Scenario',
+                'scenario_outline' => 'Scenario Outline|Scenario Template',
+                'then' => 'Then',
+                'when' => 'When',
+            ),
+        );
+    }
+
+    protected function getSteps($keywords, $text, &$line, $keywordType)
+    {
+        $steps = array();
+        foreach (explode('|', $keywords) as $keyword) {
+            if (false !== mb_strpos($keyword, '<')) {
+                $keyword = mb_substr($keyword, 0, -1);
+            }
+
+            $steps[] = new StepNode($keyword, $text, array(), $line++, $keywordType);
+        }
+
+        return $steps;
+    }
+}


### PR DESCRIPTION
I detected this issue when reviewing #107, as it included a ``/`` in a translation.