### PR TITLE
Add outlineTitle to ExampleNode

### DIFF
--- a/src/Behat/Gherkin/Node/ExampleNode.php
+++ b/src/Behat/Gherkin/Node/ExampleNode.php
@@ -41,23 +41,29 @@ class ExampleNode implements ScenarioInterface
      * @var null|StepNode[]
      */
     private $steps;
+    /**
+     * @var string
+     */
+    private $outlineTitle;
 
     /**
      * Initializes outline.
      *
-     * @param string     $title
-     * @param string[]   $tags
-     * @param StepNode[] $outlineSteps
-     * @param string[]   $tokens
-     * @param integer    $line
+     * @param string      $title
+     * @param string[]    $tags
+     * @param StepNode[]  $outlineSteps
+     * @param string[]    $tokens
+     * @param integer     $line
+     * @param string|null $outlineTitle
      */
-    public function __construct($title, array $tags, $outlineSteps, array $tokens, $line)
+    public function __construct($title, array $tags, $outlineSteps, array $tokens, $line, $outlineTitle = null)
     {
         $this->title = $title;
         $this->tags = $tags;
         $this->outlineSteps = $outlineSteps;
         $this->tokens = $tokens;
         $this->line = $line;
+        $this->outlineTitle = $outlineTitle;
     }
 
     /**
@@ -160,6 +166,16 @@ class ExampleNode implements ScenarioInterface
     public function getLine()
     {
         return $this->line;
+    }
+
+    /**
+     * Returns outline title.
+     *
+     * @return string
+     */
+    public function getOutlineTitle()
+    {
+        return $this->outlineTitle;
     }
 
     /**

--- a/src/Behat/Gherkin/Node/OutlineNode.php
+++ b/src/Behat/Gherkin/Node/OutlineNode.php
@@ -208,7 +208,8 @@ class OutlineNode implements ScenarioInterface
                 $this->tags,
                 $this->getSteps(),
                 $row,
-                $this->table->getRowLine($rowNum + 1)
+                $this->table->getRowLine($rowNum + 1),
+                $this->getTitle()
             );
         }
 


### PR DESCRIPTION
It's needed for BeforeScenarioScope to get the title of the scenario, as at the moment there is only example title provided.