### PR TITLE
Add TableNode::fromList() method

### DIFF
--- a/src/Behat/Gherkin/Node/TableNode.php
+++ b/src/Behat/Gherkin/Node/TableNode.php
@@ -63,6 +63,27 @@ class TableNode implements ArgumentInterface, IteratorAggregate
     }
 
     /**
+     * Creates a table from a given list.
+     *
+     * @param array $list One-dimensional array
+     *
+     * @return TableNode
+     *
+     * @throws NodeException If the given list is not a one-dimensional array
+     */
+    public static function fromList(array $list)
+    {
+        if (count($list) !== count($list, COUNT_RECURSIVE)) {
+            throw new NodeException('List is not a one-dimensional array.');
+        }
+
+        array_walk($list, function (&$item) {
+            $item = array($item);
+        });
+        return new self($list);
+    }
+
+    /**
      * Returns node type.
      *
      * @return string

--- a/tests/Behat/Gherkin/Node/TableNodeTest.php
+++ b/tests/Behat/Gherkin/Node/TableNodeTest.php
@@ -219,4 +219,30 @@ class TableNodeTest extends \PHPUnit_Framework_TestCase
 TABLE;
         $this->assertEquals($expected, $table->getTableAsString());
     }
+
+    public function testFromList()
+    {
+        $table = TableNode::fromList(array(
+            'everzet',
+            'antono'
+        ));
+
+        $expected = new TableNode(array(
+            array('everzet'),
+            array('antono'),
+        ));
+        $this->assertEquals($expected, $table);
+    }
+
+    /**
+     * @expectedException \Behat\Gherkin\Exception\NodeException
+     */
+    public function testGetTableFromListWithMultidimensionalArrayArgument()
+    {
+        TableNode::fromList(array(
+            array(1, 2, 3),
+            array(4, 5, 6)
+        ));
+    }
+
 }


### PR DESCRIPTION
I frequently want to create a `TableNode`, for comparison, from a flat list (or a one-dimensional array). A simple little factory method would be very helpful.