### PR TITLE
Handle non-two-dimensional arrays in TableNode

### DIFF
--- a/src/Behat/Gherkin/Node/TableNode.php
+++ b/src/Behat/Gherkin/Node/TableNode.php
@@ -35,8 +35,8 @@ class TableNode implements ArgumentInterface, IteratorAggregate
      * Initializes table.
      *
      * @param array $table Table in form of [$rowLineNumber => [$val1, $val2, $val3]]
-     * 
-     * @throws NodeException If the number of columns is not the same in each row
+     *
+     * @throws NodeException If the given table is invalid
      */
     public function __construct(array $table)
     {
@@ -52,9 +52,17 @@ class TableNode implements ArgumentInterface, IteratorAggregate
                 throw new NodeException('Table does not have same number of columns in every row.');
             }
 
+            if (!is_array($row)) {
+                throw new NodeException('Table is not two-dimensional.');
+            }
+
             foreach ($row as $column => $string) {
                 if (!isset($this->maxLineLength[$column])) {
                     $this->maxLineLength[$column] = 0;
+                }
+
+                if (!is_scalar($string)) {
+                    throw new NodeException('Table is not two-dimensional.');
                 }
 
                 $this->maxLineLength[$column] = max($this->maxLineLength[$column], mb_strlen($string, 'utf8'));

--- a/tests/Behat/Gherkin/Node/TableNodeTest.php
+++ b/tests/Behat/Gherkin/Node/TableNodeTest.php
@@ -18,6 +18,27 @@ class TableNodeTest extends \PHPUnit_Framework_TestCase
         ));
     }
 
+    public function constructorTestDataProvider() {
+        return array(
+            'One-dimensional array' => array(
+                array('everzet', 'antono')
+            ),
+            'Three-dimensional array' => array(
+                array(array(array('everzet', 'antono')))
+            )
+        );
+    }
+
+    /**
+     * @dataProvider constructorTestDataProvider
+     * @expectedException \Behat\Gherkin\Exception\NodeException
+     * @expectedExceptionMessage Table is not two-dimensional.
+     */
+    public function testConstructorExpectsTwoDimensionalArrays($table)
+    {
+        new TableNode($table);
+    }
+
     public function testHashTable()
     {
         $table = new TableNode(array(


### PR DESCRIPTION
The UX around constructing a `TableNode()` could be improved in terms of ensuring two-dimensional arrays. Presently the errors are not very illuminating:

Given a one-dimensional array:
```
Invalid argument supplied for foreach()
 vendor/symfony/phpunit-bridge/DeprecationErrorHandler.php:73
 src/Behat/Gherkin/Node/TableNode.php:55
```

Given a three-dimensional (or deeper) array:
```
mb_strlen() expects parameter 1 to be string, array given
 vendor/symfony/phpunit-bridge/DeprecationErrorHandler.php:73
 src/Behat/Gherkin/Node/TableNode.php:65
```

I propose the much clearer `NodeException('Table is not two-dimensional.')`.