### PR TITLE
Fix to line/linefilter scenario runs which take relative paths to files

### DIFF
--- a/src/Behat/Gherkin/Filter/PathsFilter.php
+++ b/src/Behat/Gherkin/Filter/PathsFilter.php
@@ -53,6 +53,9 @@ class PathsFilter extends SimpleFilter
             if (0 === strpos($feature->getFile(), $path)) {
                 return true;
             }
+            if (is_file($path . basename($feature->getFile()))) {
+                return true;
+            }
         }
 
         return false;


### PR DESCRIPTION
This PR fixes the broken scenario line and line range runs. 

This means that currently when you run 
```
bin/behat features/herp.feature:5
```
you will receive this error:

```
  [Behat\Testwork\Tester\Exception\WrongPathsException]                                                                                       
  No specifications found at path(s) `features/donate.feature:128`. This might be because of incorrect paths configuration in your `suites`. 
```

The paths are correct. Two problems occur: 
1. The findAbsolutePath method in FilesystemFeatureLocator.php does not see the basePath since it's not correctly set. https://github.com/Behat/Behat/pull/1053 corrects this.
2. The isFeatureMatch method in PathsFilter.php fails to find the relative feature file. Fixed here