### PR TITLE
Use realpath, so the feature receives the cwd prefixed.

### DIFF
--- a/src/Behat/Gherkin/Filter/PathsFilter.php
+++ b/src/Behat/Gherkin/Filter/PathsFilter.php
@@ -50,7 +50,7 @@ class PathsFilter extends SimpleFilter
     public function isFeatureMatch(FeatureNode $feature)
     {
         foreach ($this->filterPaths as $path) {
-            if (0 === strpos($feature->getFile(), $path)) {
+            if (0 === strpos(realpath($feature->getFile()), $path)) {
                 return true;
             }
         }


### PR DESCRIPTION
See the PR in the Behat repo for more context: behat/behat#1056.

As the path filter checks that the feature's file path _starts_ with a given whitelist of directories, we wrap the feature file in a realpath call -- this will either:

1. return false if the Feature file path is relative, but does not exist
2. return the full path to the Feature file, if it exists within the `cwd`
3. return the same thing if the Feature file path is already absolute and pointing to an existing file

This fixes a bug raised in the behat/behat repo, with another PR to implement part 2 of the fix.