### PR TITLE
Allow `null` values in TableNode

### DIFF
--- a/src/Behat/Gherkin/Node/TableNode.php
+++ b/src/Behat/Gherkin/Node/TableNode.php
@@ -61,7 +61,7 @@ class TableNode implements ArgumentInterface, IteratorAggregate
                     $this->maxLineLength[$column] = 0;
                 }
 
-                if (!is_scalar($string)) {
+                if (null !== $string && !is_scalar($string)) {
                     throw new NodeException('Table is not two-dimensional.');
                 }
 

--- a/tests/Behat/Gherkin/Node/TableNodeTest.php
+++ b/tests/Behat/Gherkin/Node/TableNodeTest.php
@@ -266,4 +266,12 @@ TABLE;
         ));
     }
 
+    public function testTableWithNullValues()
+    {
+        new TableNode(array(
+            array('Foo', 'Bar'),
+            array('foo', null)
+        ));
+    }
 }
+


### PR DESCRIPTION
This PR allows tables to be constructed with `null` values within the cells.