### PR TITLE
[WIP] Add step to reproduce for maximum nested level error

### DIFF
--- a/tests/Behat/Gherkin/ParserTest.php
+++ b/tests/Behat/Gherkin/ParserTest.php
@@ -144,4 +144,16 @@ FEATURE
             $feature->getLine()
         );
     }
+
+    public function testParsingManyCommentsShouldPass()
+    {
+        if (! extension_loaded('xdebug')) {
+            $this->markTestSkipped('xdebug extension must be enabled.');
+        }
+        $defaultPHPSetting = 256;
+        $this->iniSet('xdebug.max_nesting_level', $defaultPHPSetting);
+
+        $lineCount = 150; // 119 is the real threshold, higher just in case
+        $this->assertNull($this->getGherkinParser()->parse(str_repeat("# \n", $lineCount)));
+    }
 }


### PR DESCRIPTION
Hi, I just encountered the maximum nested level error when commenting a lot of lines in my .feature file.
I successfully reproduced it, but I'm wondering how we could resolve this error:

1. Increase the maximum nested level
2. Warn the user whith an exception when a sequence of X comment is found.
3. Issue will not be fixed 

**Option 1**: As mentioned in behat issues [727](https://github.com/Behat/Behat/issues/727) and [897](https://github.com/Behat/Behat/issues/897), the user may increase the maximum nested level in its (PHP.ini). 
But it can take some time and some research to understand that it was caused by the commenting of code.
**Option 2**: This option is probably not efficient, since the X could depend on the user's machine maximum nested level. And what would be the X value?
**Option 3**: Its just hard for a user to figure out why this happened.
**Other options**: ???

I would gladly fix this issue, but i need more input form you. thanks.
