### PR TITLE
Azerbijani scenario translation

### DIFF
--- a/i18n.php
+++ b/i18n.php
@@ -117,7 +117,7 @@ return array (
     'name' => 'Azerbaijani',
     'native' => 'Azərbaycanca',
     'rule' => 'Rule',
-    'scenario' => 'Nümunələr|Ssenari',
+    'scenario' => 'Nümunə|Ssenari',
     'scenario_outline' => 'Ssenarinin strukturu',
     'then' => 'O halda|*',
     'when' => 'Nə vaxt ki|Əgər|*',

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,6 +6,7 @@
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
+         failOnWarning="true"
          processIsolation="false"
          stopOnFailure="false"
          syntaxCheck="false"


### PR DESCRIPTION
Issue #145 
1) make tests fail on warning so that stuff is noticed in CI
2) The ``az`` Azerbaijani translation of ``scenario`` translated to the identical word for ``examples``. That confuses the parser because when it sees ``Nümunələr`` it does not know if that keyword means ``examples`` or ``scenario``.

Fix the translation for ``scenario`` so it uses the singular ``Nümunə`` (Example)

That makes the unit tests happy, and also might help people writing scenarios an example tables in Azerbaijani.