### PR TITLE
Rewrite the i18n tests to parse in the test rather than the data provider

### DIFF
--- a/tests/Behat/Gherkin/Keywords/KeywordsTest.php
+++ b/tests/Behat/Gherkin/Keywords/KeywordsTest.php
@@ -20,8 +20,6 @@ abstract class KeywordsTest extends \PHPUnit_Framework_TestCase
     public function translationTestDataProvider()
     {
         $keywords = $this->getKeywords();
-        $lexer = new Lexer($keywords);
-        $parser = new Parser($lexer);
         $dumper = new KeywordsDumper($keywords);
         $keywordsArray = $this->getKeywordsArray();
 
@@ -110,16 +108,8 @@ DESC
             }
 
             $dumped = $dumper->dump($lang, false, true);
-            $parsed = array();
-            try {
-                foreach ($dumped as $num => $dumpedFeature) {
-                    $parsed[] = $parser->parse($dumpedFeature, $lang . '_' . ($num + 1) . '.feature');
-                }
-            } catch (\Exception $e) {
-                throw new \Exception($e->getMessage() . ":\n" . json_encode($dumped), 0, $e);
-            }
 
-            $data[] = array($lang, $features, $parsed);
+            $data[] = array($lang, $features, $dumped);
         }
 
         return $data;
@@ -128,12 +118,25 @@ DESC
     /**
      * @dataProvider translationTestDataProvider
      *
-     * @param string $language language name
-     * @param array  $etalon   etalon features (to test against)
-     * @param array  $features array of parsed feature(s)
+     * @param string   $language language name
+     * @param array    $etalon   etalon features (to test against)
+     * @param string[] $features gherkin features
      */
     public function testTranslation($language, array $etalon, array $features)
     {
-        $this->assertEquals($etalon, $features);
+        $keywords = $this->getKeywords();
+        $lexer = new Lexer($keywords);
+        $parser = new Parser($lexer);
+
+        $parsed = array();
+        try {
+            foreach ($features as $num => $dumpedFeature) {
+                $parsed[] = $parser->parse($dumpedFeature, $language . '_' . ($num + 1) . '.feature');
+            }
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage() . ":\n" . json_encode($features), 0, $e);
+        }
+
+        $this->assertEquals($etalon, $parsed);
     }
 }

--- a/tests/Behat/Gherkin/Keywords/KeywordsTest.php
+++ b/tests/Behat/Gherkin/Keywords/KeywordsTest.php
@@ -109,7 +109,9 @@ DESC
 
             $dumped = $dumper->dump($lang, false, true);
 
-            $data[] = array($lang, $features, $dumped);
+            foreach ($dumped as $num => $dumpedFeature) {
+                $data[] = array($lang, $num, $features[$num], $dumpedFeature);
+            }
         }
 
         return $data;
@@ -118,23 +120,21 @@ DESC
     /**
      * @dataProvider translationTestDataProvider
      *
-     * @param string   $language language name
-     * @param array    $etalon   etalon features (to test against)
-     * @param string[] $features gherkin features
+     * @param string      $language language name
+     * @param int         $num      Fixture index for that language
+     * @param FeatureNode $etalon   etalon features (to test against)
+     * @param string      $source   gherkin source
      */
-    public function testTranslation($language, array $etalon, array $features)
+    public function testTranslation($language, $num, FeatureNode $etalon, $source)
     {
         $keywords = $this->getKeywords();
         $lexer = new Lexer($keywords);
         $parser = new Parser($lexer);
 
-        $parsed = array();
         try {
-            foreach ($features as $num => $dumpedFeature) {
-                $parsed[] = $parser->parse($dumpedFeature, $language . '_' . ($num + 1) . '.feature');
-            }
+            $parsed = $parser->parse($source, $language . '_' . ($num + 1) . '.feature');
         } catch (\Exception $e) {
-            throw new \Exception($e->getMessage() . ":\n" . json_encode($features), 0, $e);
+            throw new \Exception($e->getMessage() . ":\n" . $source, 0, $e);
         }
 
         $this->assertEquals($etalon, $parsed);


### PR DESCRIPTION
A failure in a data provider triggers a PHPUnit warning and skips all the tests. This does not allow to properly test for cases where some languages are triggering an error during parsing.
The test is now rewritten to perform the parsing in the test, allowing each language test to run separately.

Refs #145 