### PR TITLE
Provide better messages for TableNode construct errors

### DIFF
--- a/src/Behat/Gherkin/Node/TableNode.php
+++ b/src/Behat/Gherkin/Node/TableNode.php
@@ -43,10 +43,14 @@ class TableNode implements ArgumentInterface, IteratorAggregate
         $this->table = $table;
         $columnCount = null;
 
-        foreach ($this->getRows() as $row) {
+        foreach ($this->getRows() as $ridx => $row) {
 
             if (!is_array($row)) {
-                throw new NodeException('Table is not two-dimensional.');
+                throw new NodeException(sprintf(
+                    "Table row '%s' is expected to be array, got %s",
+                    $ridx,
+                    gettype($row)
+                ));
             }
 
             if ($columnCount === null) {
@@ -54,11 +58,12 @@ class TableNode implements ArgumentInterface, IteratorAggregate
             }
 
             if (count($row) !== $columnCount) {
-                throw new NodeException('Table does not have same number of columns in every row.');
-            }
-
-            if (!is_array($row)) {
-                throw new NodeException('Table is not two-dimensional.');
+                throw new NodeException(sprintf(
+                    "Table row '%s' is expected to have %s columns, got %s",
+                    $ridx,
+                    $columnCount,
+                    count($row)
+                ));
             }
 
             foreach ($row as $column => $string) {
@@ -67,7 +72,12 @@ class TableNode implements ArgumentInterface, IteratorAggregate
                 }
 
                 if (!is_scalar($string)) {
-                    throw new NodeException('Table is not two-dimensional.');
+                    throw new NodeException(sprintf(
+                        "Table cell at row '%s', col '%s' is expected to be scalar, got %s",
+                        $ridx,
+                        $column,
+                        gettype($string)
+                    ));
                 }
 
                 $this->maxLineLength[$column] = max($this->maxLineLength[$column], mb_strlen($string, 'utf8'));

--- a/tests/Behat/Gherkin/Node/TableNodeTest.php
+++ b/tests/Behat/Gherkin/Node/TableNodeTest.php
@@ -18,25 +18,38 @@ class TableNodeTest extends \PHPUnit_Framework_TestCase
         ));
     }
 
-    public function constructorTestDataProvider() {
-        return array(
-            'One-dimensional array' => array(
-                array('everzet', 'antono')
-            ),
-            'Three-dimensional array' => array(
-                array(array(array('everzet', 'antono')))
-            )
-        );
+    /**
+     * @expectedException \Behat\Gherkin\Exception\NodeException
+     * @expectedExceptionMessage Table row '0' is expected to be array, got string
+     */
+    public function testConstructorExpectsTwoDimensionalArray()
+    {
+        new TableNode(array(
+            'everzet', 'antono'
+        ));
     }
 
     /**
-     * @dataProvider constructorTestDataProvider
      * @expectedException \Behat\Gherkin\Exception\NodeException
-     * @expectedExceptionMessage Table is not two-dimensional.
+     * @expectedExceptionMessage Table cell at row '0', col '0' is expected to be scalar, got array
      */
-    public function testConstructorExpectsTwoDimensionalArrays($table)
+    public function testConstructorExpectsScalarCellValue()
     {
-        new TableNode($table);
+        new TableNode(array(
+            array(array('everzet', 'antono'))
+        ));
+    }
+
+    /**
+     * @expectedException \Behat\Gherkin\Exception\NodeException
+     * @expectedExceptionMessage Table row '1' is expected to have 2 columns, got 1
+     */
+    public function testConstructorExpectsEqualRowLengths()
+    {
+        new TableNode(array(
+            array('everzet', 'antono'),
+            array('everzet'),
+        ));
     }
 
     public function testHashTable()


### PR DESCRIPTION
The 'array is not two dimensional' error message is returned when any of
the multitude construct checks fails. The message is too generic and
does not inform user about what is actually wrong with his data.

Remove one of of the duplicate checks for $row being array.

Construct specific error messages for each failure with indicating
row/column position of the error, expected invariant and what is wrong
with supplied data.