### PR TITLE
Use new PHPUnit Framework TestCase and expectException in unit test code

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,13 +14,13 @@
     ],
 
     "require": {
-        "php": ">=5.3.1"
+        "php": ">=5.6"
     },
 
     "require-dev": {
         "symfony/yaml": "~2.3|~3|~4",
         "symfony/phpunit-bridge": "~2.7|~3|~4",
-        "phpunit/phpunit": "~4.5|~5"
+        "phpunit/phpunit": "~5"
     },
 
     "suggest": {

--- a/tests/Behat/Gherkin/Cache/FileCacheTest.php
+++ b/tests/Behat/Gherkin/Cache/FileCacheTest.php
@@ -6,8 +6,9 @@ use Behat\Gherkin\Cache\FileCache;
 use Behat\Gherkin\Node\FeatureNode;
 use Behat\Gherkin\Node\ScenarioNode;
 use Behat\Gherkin\Gherkin;
+use PHPUnit\Framework\TestCase;
 
-class FileCacheTest extends \PHPUnit\Framework\TestCase
+class FileCacheTest extends TestCase
 {
     private $path;
     private $cache;

--- a/tests/Behat/Gherkin/Cache/FileCacheTest.php
+++ b/tests/Behat/Gherkin/Cache/FileCacheTest.php
@@ -7,7 +7,7 @@ use Behat\Gherkin\Node\FeatureNode;
 use Behat\Gherkin\Node\ScenarioNode;
 use Behat\Gherkin\Gherkin;
 
-class FileCacheTest extends \PHPUnit_Framework_TestCase
+class FileCacheTest extends \PHPUnit\Framework\TestCase
 {
     private $path;
     private $cache;
@@ -48,7 +48,7 @@ class FileCacheTest extends \PHPUnit_Framework_TestCase
 
     public function testBrokenCacheRead()
     {
-        $this->setExpectedException('Behat\Gherkin\Exception\CacheException');
+        $this->expectException('Behat\Gherkin\Exception\CacheException');
 
         touch($this->path . '/v' . Gherkin::VERSION . '/' . md5('broken_feature') . '.feature.cache');
         $this->cache->read('broken_feature');
@@ -56,7 +56,7 @@ class FileCacheTest extends \PHPUnit_Framework_TestCase
 
     public function testUnwriteableCacheDir()
     {
-        $this->setExpectedException('Behat\Gherkin\Exception\CacheException');
+        $this->expectException('Behat\Gherkin\Exception\CacheException');
 
         new FileCache('/dev/null/gherkin-test');
     }

--- a/tests/Behat/Gherkin/Cache/MemoryCacheTest.php
+++ b/tests/Behat/Gherkin/Cache/MemoryCacheTest.php
@@ -6,7 +6,7 @@ use Behat\Gherkin\Cache\MemoryCache;
 use Behat\Gherkin\Node\FeatureNode;
 use Behat\Gherkin\Node\ScenarioNode;
 
-class MemoryCacheTest extends \PHPUnit_Framework_TestCase
+class MemoryCacheTest extends \PHPUnit\Framework\TestCase
 {
     private $cache;
 

--- a/tests/Behat/Gherkin/Cache/MemoryCacheTest.php
+++ b/tests/Behat/Gherkin/Cache/MemoryCacheTest.php
@@ -5,8 +5,9 @@ namespace Tests\Behat\Gherkin\Cache;
 use Behat\Gherkin\Cache\MemoryCache;
 use Behat\Gherkin\Node\FeatureNode;
 use Behat\Gherkin\Node\ScenarioNode;
+use PHPUnit\Framework\TestCase;
 
-class MemoryCacheTest extends \PHPUnit\Framework\TestCase
+class MemoryCacheTest extends TestCase
 {
     private $cache;
 

--- a/tests/Behat/Gherkin/Filter/FilterTest.php
+++ b/tests/Behat/Gherkin/Filter/FilterTest.php
@@ -5,8 +5,9 @@ namespace Tests\Behat\Gherkin\Filter;
 use Behat\Gherkin\Keywords\ArrayKeywords;
 use Behat\Gherkin\Lexer;
 use Behat\Gherkin\Parser;
+use PHPUnit\Framework\TestCase;
 
-abstract class FilterTest extends \PHPUnit\Framework\TestCase
+abstract class FilterTest extends TestCase
 {
     protected function getParser()
     {

--- a/tests/Behat/Gherkin/Filter/FilterTest.php
+++ b/tests/Behat/Gherkin/Filter/FilterTest.php
@@ -6,7 +6,7 @@ use Behat\Gherkin\Keywords\ArrayKeywords;
 use Behat\Gherkin\Lexer;
 use Behat\Gherkin\Parser;
 
-abstract class FilterTest extends \PHPUnit_Framework_TestCase
+abstract class FilterTest extends \PHPUnit\Framework\TestCase
 {
     protected function getParser()
     {

--- a/tests/Behat/Gherkin/Filter/NameFilterTest.php
+++ b/tests/Behat/Gherkin/Filter/NameFilterTest.php
@@ -5,8 +5,9 @@ namespace Tests\Behat\Gherkin\Filter;
 use Behat\Gherkin\Filter\NameFilter;
 use Behat\Gherkin\Node\FeatureNode;
 use Behat\Gherkin\Node\ScenarioNode;
+use PHPUnit\Framework\TestCase;
 
-class NameFilterTest extends \PHPUnit\Framework\TestCase
+class NameFilterTest extends TestCase
 {
     public function testFilterFeature()
     {

--- a/tests/Behat/Gherkin/Filter/NameFilterTest.php
+++ b/tests/Behat/Gherkin/Filter/NameFilterTest.php
@@ -6,7 +6,7 @@ use Behat\Gherkin\Filter\NameFilter;
 use Behat\Gherkin\Node\FeatureNode;
 use Behat\Gherkin\Node\ScenarioNode;
 
-class NameFilterTest extends \PHPUnit_Framework_TestCase
+class NameFilterTest extends \PHPUnit\Framework\TestCase
 {
     public function testFilterFeature()
     {

--- a/tests/Behat/Gherkin/Filter/TagFilterTest.php
+++ b/tests/Behat/Gherkin/Filter/TagFilterTest.php
@@ -5,8 +5,9 @@ namespace Tests\Behat\Gherkin\Filter;
 use Behat\Gherkin\Filter\TagFilter;
 use Behat\Gherkin\Node\FeatureNode;
 use Behat\Gherkin\Node\ScenarioNode;
+use PHPUnit\Framework\TestCase;
 
-class TagFilterTest extends \PHPUnit\Framework\TestCase
+class TagFilterTest extends TestCase
 {
     public function testFilterFeature()
     {

--- a/tests/Behat/Gherkin/Filter/TagFilterTest.php
+++ b/tests/Behat/Gherkin/Filter/TagFilterTest.php
@@ -6,7 +6,7 @@ use Behat\Gherkin\Filter\TagFilter;
 use Behat\Gherkin\Node\FeatureNode;
 use Behat\Gherkin\Node\ScenarioNode;
 
-class TagFilterTest extends \PHPUnit_Framework_TestCase
+class TagFilterTest extends \PHPUnit\Framework\TestCase
 {
     public function testFilterFeature()
     {

--- a/tests/Behat/Gherkin/GherkinTest.php
+++ b/tests/Behat/Gherkin/GherkinTest.php
@@ -5,8 +5,9 @@ namespace Tests\Behat\Gherkin;
 use Behat\Gherkin\Gherkin;
 use Behat\Gherkin\Node\FeatureNode;
 use Behat\Gherkin\Node\ScenarioNode;
+use PHPUnit\Framework\TestCase;
 
-class GherkinTest extends \PHPUnit\Framework\TestCase
+class GherkinTest extends TestCase
 {
     public function testLoader()
     {

--- a/tests/Behat/Gherkin/GherkinTest.php
+++ b/tests/Behat/Gherkin/GherkinTest.php
@@ -6,7 +6,7 @@ use Behat\Gherkin\Gherkin;
 use Behat\Gherkin\Node\FeatureNode;
 use Behat\Gherkin\Node\ScenarioNode;
 
-class GherkinTest extends \PHPUnit_Framework_TestCase
+class GherkinTest extends \PHPUnit\Framework\TestCase
 {
     public function testLoader()
     {

--- a/tests/Behat/Gherkin/Keywords/KeywordsDumperTest.php
+++ b/tests/Behat/Gherkin/Keywords/KeywordsDumperTest.php
@@ -5,7 +5,7 @@ namespace Tests\Behat\Gherkin\Keywords;
 use Behat\Gherkin\Keywords\ArrayKeywords;
 use Behat\Gherkin\Keywords\KeywordsDumper;
 
-class KeywordsDumperTest extends \PHPUnit_Framework_TestCase
+class KeywordsDumperTest extends \PHPUnit\Framework\TestCase
 {
     private $keywords;
 

--- a/tests/Behat/Gherkin/Keywords/KeywordsDumperTest.php
+++ b/tests/Behat/Gherkin/Keywords/KeywordsDumperTest.php
@@ -4,8 +4,9 @@ namespace Tests\Behat\Gherkin\Keywords;
 
 use Behat\Gherkin\Keywords\ArrayKeywords;
 use Behat\Gherkin\Keywords\KeywordsDumper;
+use PHPUnit\Framework\TestCase;
 
-class KeywordsDumperTest extends \PHPUnit\Framework\TestCase
+class KeywordsDumperTest extends TestCase
 {
     private $keywords;
 

--- a/tests/Behat/Gherkin/Keywords/KeywordsTest.php
+++ b/tests/Behat/Gherkin/Keywords/KeywordsTest.php
@@ -11,7 +11,7 @@ use Behat\Gherkin\Node\OutlineNode;
 use Behat\Gherkin\Node\ScenarioNode;
 use Behat\Gherkin\Parser;
 
-abstract class KeywordsTest extends \PHPUnit_Framework_TestCase
+abstract class KeywordsTest extends \PHPUnit\Framework\TestCase
 {
     abstract protected function getKeywords();
     abstract protected function getKeywordsArray();

--- a/tests/Behat/Gherkin/Keywords/KeywordsTest.php
+++ b/tests/Behat/Gherkin/Keywords/KeywordsTest.php
@@ -10,8 +10,9 @@ use Behat\Gherkin\Node\FeatureNode;
 use Behat\Gherkin\Node\OutlineNode;
 use Behat\Gherkin\Node\ScenarioNode;
 use Behat\Gherkin\Parser;
+use PHPUnit\Framework\TestCase;
 
-abstract class KeywordsTest extends \PHPUnit\Framework\TestCase
+abstract class KeywordsTest extends TestCase
 {
     abstract protected function getKeywords();
     abstract protected function getKeywordsArray();

--- a/tests/Behat/Gherkin/Loader/ArrayLoaderTest.php
+++ b/tests/Behat/Gherkin/Loader/ArrayLoaderTest.php
@@ -4,7 +4,7 @@ namespace Tests\Behat\Gherkin\Loader;
 
 use Behat\Gherkin\Loader\ArrayLoader;
 
-class ArrayLoaderTest extends \PHPUnit_Framework_TestCase
+class ArrayLoaderTest extends \PHPUnit\Framework\TestCase
 {
     private $loader;
 

--- a/tests/Behat/Gherkin/Loader/ArrayLoaderTest.php
+++ b/tests/Behat/Gherkin/Loader/ArrayLoaderTest.php
@@ -3,8 +3,9 @@
 namespace Tests\Behat\Gherkin\Loader;
 
 use Behat\Gherkin\Loader\ArrayLoader;
+use PHPUnit\Framework\TestCase;
 
-class ArrayLoaderTest extends \PHPUnit\Framework\TestCase
+class ArrayLoaderTest extends TestCase
 {
     private $loader;
 

--- a/tests/Behat/Gherkin/Loader/DirectoryLoaderTest.php
+++ b/tests/Behat/Gherkin/Loader/DirectoryLoaderTest.php
@@ -4,7 +4,7 @@ namespace Tests\Behat\Gherkin\Loader;
 
 use Behat\Gherkin\Loader\DirectoryLoader;
 
-class DirectoryLoaderTest extends \PHPUnit_Framework_TestCase
+class DirectoryLoaderTest extends \PHPUnit\Framework\TestCase
 {
     private $gherkin;
     private $loader;

--- a/tests/Behat/Gherkin/Loader/DirectoryLoaderTest.php
+++ b/tests/Behat/Gherkin/Loader/DirectoryLoaderTest.php
@@ -3,8 +3,9 @@
 namespace Tests\Behat\Gherkin\Loader;
 
 use Behat\Gherkin\Loader\DirectoryLoader;
+use PHPUnit\Framework\TestCase;
 
-class DirectoryLoaderTest extends \PHPUnit\Framework\TestCase
+class DirectoryLoaderTest extends TestCase
 {
     private $gherkin;
     private $loader;

--- a/tests/Behat/Gherkin/Loader/GherkinFileLoaderTest.php
+++ b/tests/Behat/Gherkin/Loader/GherkinFileLoaderTest.php
@@ -6,8 +6,9 @@ use Behat\Gherkin\Keywords\CucumberKeywords;
 use Behat\Gherkin\Lexer;
 use Behat\Gherkin\Loader\GherkinFileLoader;
 use Behat\Gherkin\Parser;
+use PHPUnit\Framework\TestCase;
 
-class GherkinFileLoaderTest extends \PHPUnit\Framework\TestCase
+class GherkinFileLoaderTest extends TestCase
 {
     /**
      * @var GherkinFileLoader

--- a/tests/Behat/Gherkin/Loader/GherkinFileLoaderTest.php
+++ b/tests/Behat/Gherkin/Loader/GherkinFileLoaderTest.php
@@ -7,7 +7,7 @@ use Behat\Gherkin\Lexer;
 use Behat\Gherkin\Loader\GherkinFileLoader;
 use Behat\Gherkin\Parser;
 
-class GherkinFileLoaderTest extends \PHPUnit_Framework_TestCase
+class GherkinFileLoaderTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var GherkinFileLoader

--- a/tests/Behat/Gherkin/Loader/YamlFileLoaderTest.php
+++ b/tests/Behat/Gherkin/Loader/YamlFileLoaderTest.php
@@ -3,8 +3,9 @@
 namespace Tests\Behat\Gherkin\Loader;
 
 use Behat\Gherkin\Loader\YamlFileLoader;
+use PHPUnit\Framework\TestCase;
 
-class YamlFileLoaderTest extends \PHPUnit\Framework\TestCase
+class YamlFileLoaderTest extends TestCase
 {
     private $loader;
 

--- a/tests/Behat/Gherkin/Loader/YamlFileLoaderTest.php
+++ b/tests/Behat/Gherkin/Loader/YamlFileLoaderTest.php
@@ -4,7 +4,7 @@ namespace Tests\Behat\Gherkin\Loader;
 
 use Behat\Gherkin\Loader\YamlFileLoader;
 
-class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
+class YamlFileLoaderTest extends \PHPUnit\Framework\TestCase
 {
     private $loader;
 

--- a/tests/Behat/Gherkin/Node/ExampleNodeTest.php
+++ b/tests/Behat/Gherkin/Node/ExampleNodeTest.php
@@ -8,7 +8,7 @@ use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\StepNode;
 use Behat\Gherkin\Node\TableNode;
 
-class ExampleNodeTest extends \PHPUnit_Framework_TestCase
+class ExampleNodeTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreateExampleSteps()
     {

--- a/tests/Behat/Gherkin/Node/ExampleNodeTest.php
+++ b/tests/Behat/Gherkin/Node/ExampleNodeTest.php
@@ -7,8 +7,9 @@ use Behat\Gherkin\Node\OutlineNode;
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\StepNode;
 use Behat\Gherkin\Node\TableNode;
+use PHPUnit\Framework\TestCase;
 
-class ExampleNodeTest extends \PHPUnit\Framework\TestCase
+class ExampleNodeTest extends TestCase
 {
     public function testCreateExampleSteps()
     {

--- a/tests/Behat/Gherkin/Node/OutlineNodeTest.php
+++ b/tests/Behat/Gherkin/Node/OutlineNodeTest.php
@@ -5,8 +5,9 @@ namespace Tests\Behat\Gherkin\Node;
 use Behat\Gherkin\Node\ExampleTableNode;
 use Behat\Gherkin\Node\OutlineNode;
 use Behat\Gherkin\Node\StepNode;
+use PHPUnit\Framework\TestCase;
 
-class OutlineNodeTest extends \PHPUnit\Framework\TestCase
+class OutlineNodeTest extends TestCase
 {
     public function testCreatesExamplesForExampleTable()
     {

--- a/tests/Behat/Gherkin/Node/OutlineNodeTest.php
+++ b/tests/Behat/Gherkin/Node/OutlineNodeTest.php
@@ -6,7 +6,7 @@ use Behat\Gherkin\Node\ExampleTableNode;
 use Behat\Gherkin\Node\OutlineNode;
 use Behat\Gherkin\Node\StepNode;
 
-class OutlineNodeTest extends \PHPUnit_Framework_TestCase
+class OutlineNodeTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreatesExamplesForExampleTable()
     {

--- a/tests/Behat/Gherkin/Node/PyStringNodeTest.php
+++ b/tests/Behat/Gherkin/Node/PyStringNodeTest.php
@@ -3,8 +3,9 @@
 namespace Tests\Behat\Gherkin\Node;
 
 use Behat\Gherkin\Node\PyStringNode;
+use PHPUnit\Framework\TestCase;
 
-class PyStringNodeTest extends \PHPUnit\Framework\TestCase
+class PyStringNodeTest extends TestCase
 {
     public function testGetStrings()
     {

--- a/tests/Behat/Gherkin/Node/PyStringNodeTest.php
+++ b/tests/Behat/Gherkin/Node/PyStringNodeTest.php
@@ -4,7 +4,7 @@ namespace Tests\Behat\Gherkin\Node;
 
 use Behat\Gherkin\Node\PyStringNode;
 
-class PyStringNodeTest extends \PHPUnit_Framework_TestCase
+class PyStringNodeTest extends \PHPUnit\Framework\TestCase
 {
     public function testGetStrings()
     {

--- a/tests/Behat/Gherkin/Node/StepNodeTest.php
+++ b/tests/Behat/Gherkin/Node/StepNodeTest.php
@@ -5,8 +5,9 @@ namespace Tests\Behat\Gherkin\Node;
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\StepNode;
 use Behat\Gherkin\Node\TableNode;
+use PHPUnit\Framework\TestCase;
 
-class StepNodeTest extends \PHPUnit\Framework\TestCase
+class StepNodeTest extends TestCase
 {
     public function testThatStepCanHaveOnlyOneArgument()
     {

--- a/tests/Behat/Gherkin/Node/StepNodeTest.php
+++ b/tests/Behat/Gherkin/Node/StepNodeTest.php
@@ -6,11 +6,11 @@ use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\StepNode;
 use Behat\Gherkin\Node\TableNode;
 
-class StepNodeTest extends \PHPUnit_Framework_TestCase
+class StepNodeTest extends \PHPUnit\Framework\TestCase
 {
     public function testThatStepCanHaveOnlyOneArgument()
     {
-        $this->setExpectedException('Behat\Gherkin\Exception\NodeException');
+        $this->expectException('Behat\Gherkin\Exception\NodeException');
 
         new StepNode('Gangway!', 'I am on the page:', array(
             new PyStringNode(array('one', 'two'), 11),

--- a/tests/Behat/Gherkin/Node/TableNodeTest.php
+++ b/tests/Behat/Gherkin/Node/TableNodeTest.php
@@ -4,7 +4,7 @@ namespace Tests\Behat\Gherkin\Node;
 
 use Behat\Gherkin\Node\TableNode;
 
-class TableNodeTest extends \PHPUnit_Framework_TestCase
+class TableNodeTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @expectedException \Behat\Gherkin\Exception\NodeException

--- a/tests/Behat/Gherkin/Node/TableNodeTest.php
+++ b/tests/Behat/Gherkin/Node/TableNodeTest.php
@@ -3,8 +3,9 @@
 namespace Tests\Behat\Gherkin\Node;
 
 use Behat\Gherkin\Node\TableNode;
+use PHPUnit\Framework\TestCase;
 
-class TableNodeTest extends \PHPUnit\Framework\TestCase
+class TableNodeTest extends TestCase
 {
     /**
      * @expectedException \Behat\Gherkin\Exception\NodeException

--- a/tests/Behat/Gherkin/ParserExceptionsTest.php
+++ b/tests/Behat/Gherkin/ParserExceptionsTest.php
@@ -5,8 +5,9 @@ namespace Tests\Behat\Gherkin;
 use Behat\Gherkin\Lexer;
 use Behat\Gherkin\Parser;
 use Behat\Gherkin\Keywords\ArrayKeywords;
+use PHPUnit\Framework\TestCase;
 
-class ParserExceptionsTest extends \PHPUnit\Framework\TestCase
+class ParserExceptionsTest extends TestCase
 {
     /**
      * @var Parser

--- a/tests/Behat/Gherkin/ParserExceptionsTest.php
+++ b/tests/Behat/Gherkin/ParserExceptionsTest.php
@@ -6,7 +6,7 @@ use Behat\Gherkin\Lexer;
 use Behat\Gherkin\Parser;
 use Behat\Gherkin\Keywords\ArrayKeywords;
 
-class ParserExceptionsTest extends \PHPUnit_Framework_TestCase
+class ParserExceptionsTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Parser

--- a/tests/Behat/Gherkin/ParserTest.php
+++ b/tests/Behat/Gherkin/ParserTest.php
@@ -7,8 +7,9 @@ use Behat\Gherkin\Lexer;
 use Behat\Gherkin\Parser;
 use Behat\Gherkin\Keywords\ArrayKeywords;
 use Behat\Gherkin\Loader\YamlFileLoader;
+use PHPUnit\Framework\TestCase;
 
-class ParserTest extends \PHPUnit\Framework\TestCase
+class ParserTest extends TestCase
 {
     private $gherkin;
     private $yaml;

--- a/tests/Behat/Gherkin/ParserTest.php
+++ b/tests/Behat/Gherkin/ParserTest.php
@@ -8,7 +8,7 @@ use Behat\Gherkin\Parser;
 use Behat\Gherkin\Keywords\ArrayKeywords;
 use Behat\Gherkin\Loader\YamlFileLoader;
 
-class ParserTest extends \PHPUnit_Framework_TestCase
+class ParserTest extends \PHPUnit\Framework\TestCase
 {
     private $gherkin;
     private $yaml;


### PR DESCRIPTION
So that the unit test code is more up-to-date in preparation for phpunit6.

Note: On PHP 5.6 the Travis CI runs with PHPUnit 5.7.27 - so actually there is no CI any more that run with PHPUnit 4.5 (which is mentioned in `composer.json`. But I guess we leave that in `composer.json` because somebody might try to locally run the unit tests with some more ancient version of PHP.

Note 2: removed PHPUnit 4 and PHP 5.3 5.4 5.5 support.