### PR TITLE
Add assert to PHPUnit testTextInBackground

### DIFF
--- a/tests/Behat/Gherkin/ParserExceptionsTest.php
+++ b/tests/Behat/Gherkin/ParserExceptionsTest.php
@@ -76,7 +76,12 @@ Feature: Behat bug test
 Scenario: bug user edit date
 GHERKIN;
 
-        $this->gherkin->parse($feature);
+        $feature = $this->gherkin->parse($feature);
+        $background = $feature->getBackground();
+        $this->assertEquals(
+            "remove X to couse bug\nStep is red form is not valid\nasd\nasd\nas\nda\nsd\nas\ndas\nd",
+            $background->getTitle()
+        );
     }
 
     public function testTextInScenario()


### PR DESCRIPTION
When we go to PHPUnit6 it will complain:
```
vendor/bin/phpunit
PHPUnit 6.5.14 by Sebastian Bergmann and contributors.

...............................................................  63 / 332 ( 18%)
............................................................... 126 / 332 ( 37%)
............................................................... 189 / 332 ( 56%)
............................................................... 252 / 332 ( 75%)
...................................R........................... 315 / 332 ( 94%)
.................                                               332 / 332 (100%)

Time: 3.16 seconds, Memory: 14.00MB

There was 1 risky test:

1) Tests\Behat\Gherkin\ParserExceptionsTest::testTextInBackground
This test did not perform any assertions

OK, but incomplete, skipped, or risky tests!
Tests: 332, Assertions: 705, Risky: 1.
```

`testTextInBackground` does not assert anything about the parse of the feature. At the moment it is just "testing" that there is no exception thrown (which is the "default" expectation of PHPUnit). PHPUnit6 notifies about a "risky" test in this case.

Actually we can easily test that the background title is as expected, so do that. Then when we move to PHPUnit6 all will be well.