### PR TITLE
Allow PHPUnit 6 and 7 for testing and run CI with PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
   directories:
     - $HOME/.composer/cache/files
 
-php: [5.6, 7.0, 7.1, 7.2, 7.3]
+php: [5.6, 7.0, 7.1, 7.2, 7.3, 7.4]
 
 matrix:
   include:

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require-dev": {
         "symfony/yaml": "~2.3|~3|~4",
         "symfony/phpunit-bridge": "~2.7|~3|~4",
-        "phpunit/phpunit": "~5"
+        "phpunit/phpunit": "~5|~6|~7"
     },
 
     "suggest": {


### PR DESCRIPTION
PHP 5.6 uses PHPUnit 5

PHP 7.0 uses PHPunit 6

PHP 7.1 onwards uses PHPunit 7

and add a Travis CI matrix entry for PHP 7.4