### PR TITLE
Remove unused syntaxCheck setting from phpunit.xml.dist

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
          bootstrap="vendor/autoload.php"
 >
     <testsuites>


### PR DESCRIPTION
PHPUnit 7 will report:
```
  Warning - The configuration file did not pass validation!
  The following problems have been detected:

  Line 13:
  - Element 'phpunit', attribute 'syntaxCheck': The attribute 'syntaxCheck' is not allowed.

  Test results may not be as expected.
```

Element 'phpunit', attribute 'syntaxCheck' has not done anything for "a long time" (tm) - ref https://github.com/dompdf/dompdf/issues/1823 https://stackoverflow.com/questions/44328114/phpunit-what-does-syntaxcheck-configuration-parameter-stands-for-exactly/44331140#44331140 - so remove it from `phpunit.xml.dist`

Actually this setting does nothing now. We can remove it.