### PR TITLE
Remove PHP version from description

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name":         "behat/gherkin",
-    "description":  "Gherkin DSL parser for PHP 5.3",
+    "description":  "Gherkin DSL parser for PHP",
     "keywords":     ["BDD", "parser", "DSL", "Behat", "Gherkin", "Cucumber"],
     "homepage":     "http://behat.org/",
     "type":         "library",


### PR DESCRIPTION
PHP 5.3 is now out-of-date in the description.

The "require" section has `"php": ">=5.6"`

I have removed the version number from the description. My thinking is that it is a parser for some range of PHP versions, not just one. So it is easier not to even mention the PHP version in the description.