### PR TITLE
Migrate to the new name for the travis jobs config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
 
 php: [5.6, 7.0, 7.1, 7.2, 7.3, 7.4]
 
-matrix:
+jobs:
   include:
     - php: 5.6
       env: SYMFONY_VERSION='2.3.*'


### PR DESCRIPTION
The matrix expansion of PHP version was not merged anymore with the explicitly included jobs (keeping only explicit ones). This tries to see whether this works fine when using the new name