### PR TITLE
Require at least phpunit 5.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require-dev": {
         "symfony/yaml": "~2.3|~3|~4",
         "symfony/phpunit-bridge": "~2.7|~3|~4",
-        "phpunit/phpunit": "~5|~6|~7"
+        "phpunit/phpunit": "~5.7|~6|~7"
     },
 
     "suggest": {


### PR DESCRIPTION
Because the unit test code uses `PHPUnit\Framework\TestCase` which only became available from phpunit 5.7 onwards.

~And allow CI to use the newer phpunit 8 or 9 if it wants.~

~And do not test with PHP 8.0 yet. See test done in PR #185 - we are not quite ready for PHP 8.0 yet.~
That has already been done now.