### PR TITLE
Add some variations of tags and comments in tests

### DIFF
--- a/tests/Behat/Gherkin/Fixtures/etalons/tags_sample.yml
+++ b/tests/Behat/Gherkin/Fixtures/etalons/tags_sample.yml
@@ -59,5 +59,26 @@ feature:
         -
           tags:     [examples_tag3, examples_tag4]
           table:
-            33: [state]
-            34: [missing]
+            34: [state]
+            35: [missing]
+        -
+          tags:     [examples_tag5, examples_tag6]
+          table:
+            39: [state]
+            40: [something]
+
+    -
+      type:     scenario
+      title:    scenario with comment and tag after an outline
+      tags:     [sample_8]
+      line:     44
+      steps:
+        - { keyword_type: 'Given', type: 'Given',  text: 'the scenario has a comment and a tag and comes after an outline',  line: 45 }
+
+    -
+      type:     scenario
+      title:    scenario with tag and then comment
+      tags:     [sample_9]
+      line:     49
+      steps:
+        - { keyword_type: 'Given', type: 'Given',  text: 'the scenario has a tag and comment',  line: 50 }

--- a/tests/Behat/Gherkin/Fixtures/features/tags_sample.feature
+++ b/tests/Behat/Gherkin/Fixtures/features/tags_sample.feature
@@ -28,7 +28,23 @@ Feature: Tag samples
     @sample_6 @sample_7
     Scenario Outline: passing
         Given <state>
+        # comment before examples table tags
         @examples_tag3 @examples_tag4
         Examples:
             | state   |
             | missing |
+        @examples_tag5 @examples_tag6
+        # comment after examples table tags
+        Examples:
+            | state     |
+            | something |
+
+    # comment before tag
+    @sample_8
+    Scenario: scenario with comment and tag after an outline
+        Given the scenario has a comment and a tag and comes after an outline
+
+    @sample_9
+    # comment after tag
+    Scenario: scenario with tag and then comment
+        Given the scenario has a tag and comment


### PR DESCRIPTION
These combinations of comment lines and tag lines work OK. So maybe we can merge these extra test cases that pass.

1) I added some comments and extra examples tables to a Scenario Outline so that I demonstrates that kind of mix of stuff in a feature with tags.
2) Added a Scenario that has a comment, then tags, then the `Scenario` keyword, and put it after the complex Scenario Outline. That demonstrates that all is good when the comment and tag come in that order.
3) Added a Scenario that has a tag, then a comment. the the `Scenario` keyword, and it is not directly after a Scenario Outline. That case is also processed correctly.

I will make another PR that demonstrates the failing case (and maybe I can fix it?)