### PR TITLE
Fix issue 187 "Comment between tags and scenario"

### DIFF
--- a/src/Behat/Gherkin/Lexer.php
+++ b/src/Behat/Gherkin/Lexer.php
@@ -121,7 +121,7 @@ class Lexer
     }
 
     /**
-     * Predicts for number of tokens.
+     * Predicts the upcoming token without passing over it.
      *
      * @return array
      */
@@ -132,6 +132,16 @@ class Lexer
         }
 
         return $this->stashedToken;
+    }
+
+    /**
+     * Skips over the currently-predicted token, if any.
+     *
+     * @return void
+     */
+    public function skipPredictedToken()
+    {
+        $this->stashedToken = null;
     }
 
     /**

--- a/src/Behat/Gherkin/Parser.php
+++ b/src/Behat/Gherkin/Parser.php
@@ -442,7 +442,12 @@ class Parser
 
         array_push($this->passedNodesStack, 'Outline');
 
-        while (in_array($this->predictTokenType(), array('Step', 'Examples', 'Newline', 'Text', 'Comment', 'Tag'))) {
+        while (in_array($nextTokenType = $this->predictTokenType(), array('Step', 'Examples', 'Newline', 'Text', 'Comment', 'Tag'))) {
+            if ($nextTokenType === 'Comment') {
+                $this->lexer->skipPredictedToken();
+                continue;
+            }
+
             $node = $this->parseExpression();
 
             if ($node instanceof StepNode) {

--- a/tests/Behat/Gherkin/Fixtures/etalons/tags_sample.yml
+++ b/tests/Behat/Gherkin/Fixtures/etalons/tags_sample.yml
@@ -95,3 +95,11 @@ feature:
           table:
             56: [state]
             57: [more]
+
+    -
+      type:     scenario
+      title:    another scenario with tag and then comment
+      tags:     [sample_12]
+      line:     61
+      steps:
+        - { keyword_type: 'Given', type: 'Given',  text: 'this scenario has a tag and comment',  line: 62 }

--- a/tests/Behat/Gherkin/Fixtures/etalons/tags_sample.yml
+++ b/tests/Behat/Gherkin/Fixtures/etalons/tags_sample.yml
@@ -82,3 +82,16 @@ feature:
       line:     49
       steps:
         - { keyword_type: 'Given', type: 'Given',  text: 'the scenario has a tag and comment',  line: 50 }
+
+    -
+      type:     outline
+      title:    an outline followed by more scenarios
+      tags:     [sample_10, sample_11]
+      line:     53
+      steps:
+        - { keyword_type: 'Given', type: 'Given',  text: '<state>',  line: 54 }
+      examples:
+        -
+          table:
+            56: [state]
+            57: [more]

--- a/tests/Behat/Gherkin/Fixtures/features/tags_sample.feature
+++ b/tests/Behat/Gherkin/Fixtures/features/tags_sample.feature
@@ -55,3 +55,8 @@ Feature: Tag samples
         Examples:
             | state   |
             | more    |
+
+    @sample_12
+    # comment after tag
+    Scenario: another scenario with tag and then comment
+        Given this scenario has a tag and comment

--- a/tests/Behat/Gherkin/Fixtures/features/tags_sample.feature
+++ b/tests/Behat/Gherkin/Fixtures/features/tags_sample.feature
@@ -48,3 +48,10 @@ Feature: Tag samples
     # comment after tag
     Scenario: scenario with tag and then comment
         Given the scenario has a tag and comment
+
+    @sample_10 @sample_11
+    Scenario Outline: an outline followed by more scenarios
+        Given <state>
+        Examples:
+            | state   |
+            | more    |


### PR DESCRIPTION
Fixes issue #187 

1) New scenarios from PR #188 
2) Add another outline to tags_sample.feature ready for more failing tests (this outline passes fine)
3) Add failing test case to tags_sample.feature - this has, after a Scenario Outline, some tags, then a comment, then a Scenario.

That last commit fails with:
```
There was 1 error:

1) Tests\Behat\Gherkin\ParserTest::testParser with data set "tags_sample" ('tags_sample')
Behat\Gherkin\Exception\ParserException: Expected Step or Examples table, but got Scenario on line: 61 in file: /home/runner/work/Gherkin/Gherkin/tests/Behat/Gherkin/Fixtures/features/tags_sample.feature

/home/runner/work/Gherkin/Gherkin/src/Behat/Gherkin/Parser.php:478
/home/runner/work/Gherkin/Gherkin/src/Behat/Gherkin/Parser.php:194
/home/runner/work/Gherkin/Gherkin/src/Behat/Gherkin/Parser.php:245
/home/runner/work/Gherkin/Gherkin/src/Behat/Gherkin/Parser.php:188
/home/runner/work/Gherkin/Gherkin/src/Behat/Gherkin/Parser.php:608
/home/runner/work/Gherkin/Gherkin/src/Behat/Gherkin/Parser.php:208
/home/runner/work/Gherkin/Gherkin/src/Behat/Gherkin/Parser.php:83
/home/runner/work/Gherkin/Gherkin/tests/Behat/Gherkin/ParserTest.php:145
/home/runner/work/Gherkin/Gherkin/tests/Behat/Gherkin/ParserTest.php:39
```

The problem is that `Parser.php` `parseOutline()` does not know how to nicely stop consuming lines of the feature file after it finds more tags. It expects that there can be tags, and `Examples` table, more tags, another `Examples` table... After it finds the tags line, it then does `predictTokenType()` and finds a comment, so there could be another Examples table coming after the comment. So it does `parseExpression()` and sadly, rather than returning a comment string, it returns the next `Scenario`, and the code raises a `ParserException`.

The problem does not happen when the tags and scenario are not separated by a comment, because the `while` loop ends up being exited.

The code needs to "see what is next" after a comment, without actually "gobbling up" the next thing.

4) Explicitly skip comments when parsing a scenario outline - this avoids calling `parseExpression()` to "see what is next". The `while` loop will "see what is next" using `predictTokenType()` and that will correctly detect the upcoming Scenario and exit the while loop. The upcoming Scenario will be sitting in the Lexer as the `stashedToken` and will be happily found by the higher-level processing of the Parser.