### PR TITLE
Test against Cucumber ASTs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
     "require-dev": {
         "symfony/yaml": "~2.3|~3|~4",
         "symfony/phpunit-bridge": "~2.7|~3|~4",
-        "phpunit/phpunit": "~5.7|~6|~7"
+        "phpunit/phpunit": "~5.7|~6|~7",
+        "cucumber/cucumber": "dev-gherkin-16.0.0"
     },
 
     "suggest": {
@@ -43,5 +44,20 @@
         "branch-alias": {
             "dev-master": "4.4-dev"
         }
-    }
+    },
+
+    "repositories": [
+        {
+            "type": "package",
+            "package": {
+                "name": "cucumber/cucumber",
+                "version": "dev-gherkin-16.0.0",
+                "source": {
+                    "type": "git",
+                    "url": "https://github.com/cucumber/cucumber.git",
+                    "reference": "00f128c8dc2970a564d8a706567836700a7039f0"
+                }
+            }
+        }
+    ]
 }

--- a/src/Behat/Gherkin/Loader/CucumberNDJsonAstLoader.php
+++ b/src/Behat/Gherkin/Loader/CucumberNDJsonAstLoader.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace Behat\Gherkin\Loader;
+
+use Behat\Gherkin\Node\BackgroundNode;
+use Behat\Gherkin\Node\ExampleNode;
+use Behat\Gherkin\Node\ExampleTableNode;
+use Behat\Gherkin\Node\FeatureNode;
+use Behat\Gherkin\Node\OutlineNode;
+use Behat\Gherkin\Node\ScenarioInterface;
+use Behat\Gherkin\Node\ScenarioNode;
+use Behat\Gherkin\Node\StepNode;
+use Behat\Gherkin\Node\TableNode;
+
+/**
+ * Loads a feature from cucumber's protobuf JSON format
+ */
+class CucumberNDJsonAstLoader implements LoaderInterface
+{
+
+    public function supports($resource)
+    {
+        return is_string($resource);
+    }
+
+    public function load($resource)
+    {
+        $json = \json_decode(file_get_contents($resource), true);
+
+        $feature = self::getFeature($json, $resource);
+
+        return $feature ? array($feature) : array();
+    }
+
+    /**
+     * @return FeatureNode|null
+     */
+    private static function getFeature(array $json, string $filePath)
+    {
+        if (!isset($json['gherkinDocument']['feature'])) {
+            return null;
+        }
+
+        $featureJson = $json['gherkinDocument']['feature'];
+
+        $feature = new FeatureNode(
+            $featureJson['name'],
+            isset($featureJson['description']) ? trim($featureJson['description']) : null,
+            self::getTags($featureJson),
+            self::getBackground($featureJson),
+            self::getScenarios($featureJson),
+            $featureJson['keyword'],
+            $featureJson['language'],
+            preg_replace('/(?<=\\.feature).*$/', '', $filePath),
+            $featureJson['location']['line']
+        );
+
+        return $feature;
+    }
+
+    /**
+     * @return string[]
+     */
+    private static function getTags(array $json)
+    {
+        return array_map(
+            static function(array $tag) { return preg_replace('/^@/', '', $tag['name']); },
+            isset($json['tags']) ? $json['tags'] : []
+        );
+    }
+
+    /**
+     * @return ScenarioInterface[]
+     */
+    private static function getScenarios(array $json)
+    {
+
+        return array_values(
+            array_map(
+                static function ($child) {
+
+                    if (isset($child['scenario']['examples'])) {
+                        return new OutlineNode(
+                            $child['scenario']['name'],
+                            self::getTags($child['scenario']),
+                            self::getSteps(isset($child['scenario']['steps']) ? $child['scenario']['steps'] : []),
+                            self::getTables($child['scenario']['examples']),
+                            $child['scenario']['keyword'],
+                            $child['scenario']['location']['line']
+                        );
+                    }
+                    else {
+                        return new ScenarioNode(
+                            $child['scenario']['name'],
+                            self::getTags($child['scenario']),
+                            self::getSteps(isset($child['scenario']['steps']) ? $child['scenario']['steps'] : []),
+                            $child['scenario']['keyword'],
+                            $child['scenario']['location']['line']
+                        );
+                    }
+
+                },
+                array_filter(
+                    $json['children'] ? $json['children'] : [],
+                    static function ($child) {
+                        return isset($child['scenario']);
+                    }
+                )
+            )
+        );
+    }
+
+    /**
+     * @return BackgroundNode|null
+     */
+    private static function getBackground($json)
+    {
+        $backgrounds = array_values(
+            array_map(
+                static function ($child) {
+                    return new BackgroundNode(
+                        $child['background']['name'],
+                        self::getSteps(isset($child['background']['steps']) ? $child['background']['steps'] : []),
+                        $child['background']['keyword'],
+                        $child['background']['location']['line']
+                    );
+                },
+                array_filter(
+                    $json['children'] ? $json['children'] : [],
+                    static function ($child) {
+                        return isset($child['background']);
+                    }
+                )
+            )
+        );
+
+        return count($backgrounds) == 1 ? $backgrounds[0] : null;
+    }
+
+    /**
+     * @return StepNode[]
+     */
+    private static function getSteps(array $json)
+    {
+        return array_map(
+            static function(array $json) {
+                return new StepNode(
+                    trim($json['keyword']),
+                    $json['text'],
+                    [],
+                    $json['location']['line'],
+                    trim($json['keyword'])
+                );
+            },
+            $json
+        );
+    }
+
+    /**
+     * @return ExampleTableNode[]
+     */
+    private static function getTables(array $json)
+    {
+        return array_map(
+            static function($tableJson) {
+
+                $table = [];
+
+                $table[$tableJson['tableHeader']['location']['line']] = array_map(
+                    static function($cell) {
+                        return $cell['value'];
+                    },
+                    $tableJson['tableHeader']['cells']
+                );
+
+                foreach ($tableJson['tableBody'] as $bodyRow) {
+                    $table[$bodyRow['location']['line']] = array_map(
+                        static function($cell) {
+                            return $cell['value'];
+                        },
+                        $bodyRow['cells']
+                    );
+                }
+
+                return new ExampleTableNode(
+                    $table,
+                    $tableJson['keyword'],
+                    self::getTags($tableJson)
+                );
+            },
+            $json
+        );
+    }
+}

--- a/tests/Behat/Gherkin/Cucumber/CompatibilityTest.php
+++ b/tests/Behat/Gherkin/Cucumber/CompatibilityTest.php
@@ -7,29 +7,38 @@ use Behat\Gherkin\Keywords;
 use Behat\Gherkin\Lexer;
 use Behat\Gherkin\Loader\ArrayLoader;
 use Behat\Gherkin\Loader\CucumberNDJsonAstLoader;
+use Behat\Gherkin\Loader\LoaderInterface;
 use Behat\Gherkin\Node\FeatureNode;
+use Behat\Gherkin\Node\ScenarioInterface;
+use Behat\Gherkin\Node\ScenarioNode;
+use Behat\Gherkin\Node\StepNode;
 use Behat\Gherkin\Parser;
 use PHPUnit\Framework\TestCase;
 
 /**
+ * Tests the parser against the upstream cucumber/gherkin test data
+ *
  * @group cucumber-compatibility
  */
 class CompatibilityTest extends TestCase
 {
     const TESTDATA_PATH = __DIR__ . '/../../../../vendor/cucumber/cucumber/gherkin/testdata';
 
-    const NOT_PARSABLE = [
-        'complex_background.feature',
-        'descriptions.feature',
-        'docstrings.feature',
-        'incomplete.feature',
-        'incomplete_scenario_outline.feature',
-        'padded_example.feature',
-        'rule.feature',
-        'scenario_outline.feature',
-        'spaces_in_language.feature',
-        'empty.feature',
-        'incomplete_feature_3.feature'
+    const NOT_COMPATIBLE = [
+        'complex_background.feature' => 'Rule keyword not supported',
+        'rule.feature' => 'Rule keyword not supported',
+        'descriptions.feature' => 'Examples table descriptions not supported',
+        'docstrings.feature' => 'Docstrings with ``` separators not supported',
+        'incomplete_scenario_outline.feature' => 'Scenario and Scenario outline not yet synonyms',
+        'padded_example.feature' => 'Scenario and Scenario outline not yet synonyms',
+        'scenario_outline.feature' => 'Scenario and Scenario outline not yet synonyms',
+        'spaces_in_language.feature' => 'Whitespace not supported around language selector',
+        'incomplete_feature_3.feature' => 'file with no feature keyword not handled correctly',
+        'rule_without_name_and_description.feature' => 'Rule is wrongly parsed as Description',
+        'escaped_pipes.feature' => 'Feature description has wrong whitespace captured',
+        'incomplete_scenario.feature' => 'Wrong background parsing when there are no steps',
+        'incomplete_background_2.feature' => 'Wrong background parsing when there are no steps',
+        'tags.feature' => 'Tags followed by comments not parsed correctly'
     ];
 
     /**
@@ -37,33 +46,84 @@ class CompatibilityTest extends TestCase
      */
     private $parser;
 
+    /**
+     * @var LoaderInterface
+     */
+    private $loader;
+
     public function setUp()
     {
         $arrKeywords = include __DIR__ . '/../../../../i18n.php';
         $lexer  = new Lexer(new Keywords\ArrayKeywords($arrKeywords));
         $this->parser = new Parser($lexer);
+        $this->loader = new CucumberNDJsonAstLoader();
     }
 
     /**
-     * @dataProvider goodFeatures
+     * @dataProvider cucumberFeatures
      */
-    public function testGoodFeaturesCanParse($gherkinFile)
+    public function testFeaturesParseTheSameAsCucumber(\SplFileInfo $file)
     {
-        $actual = $this->parser->parse(file_get_contents($gherkinFile), $gherkinFile);
+        if (isset((self::NOT_COMPATIBLE)[$file->getFilename()])){
+            $this->markTestIncomplete((self::NOT_COMPATIBLE)[$file->getFilename()]);
+        }
 
-        $this->assertInstanceOf(FeatureNode::class, $actual);
+        $gherkinFile = $file->getPathname();
+
+        $actual = $this->normaliseFeature($this->parser->parse(file_get_contents($gherkinFile), $gherkinFile));
+        $expected = $this->normaliseFeature($this->loader->load($gherkinFile . '.ast.ndjson')[0]);
+
+        $this->assertEquals($expected, $actual);
     }
 
-    public static function goodFeatures()
+    public static function cucumberFeatures()
     {
         foreach (new \FilesystemIterator(self::TESTDATA_PATH . '/good') as $file) {
-            if (in_array($file->getFilename(), self::NOT_PARSABLE)) {
-                continue;
-            }
-
-            if ($file->isFile() && $file->getExtension() === 'feature') {
-                yield $file->getFilename() => [ $file->getPathname(), $file->getPathname() . '.ast.ndjson' ];
+           if ($file->isFile() && $file->getExtension() === 'feature') {
+                yield $file->getFilename() => [$file];
             }
         }
     }
+
+    /**
+     * Renove features that aren't present in the cucumber source
+     */
+    private function normaliseFeature($featureNode)
+    {
+
+        if (is_null($featureNode)) {
+            return null;
+        }
+
+        $scenarios = array_map(
+            function(ScenarioInterface $scenarioNode) {
+                $steps = array_map(
+                    function(StepNode $step) {
+                        $this->setPrivateProperty($step, 'keywordType', '');
+                        $this->setPrivateProperty($step, 'arguments', array());
+
+                        return $step;
+                    },
+                    $scenarioNode->getSteps()
+                );
+
+                $this->setPrivateProperty($scenarioNode, 'steps', $steps);
+
+                return $scenarioNode;
+            },
+            $featureNode->getScenarios()
+        );
+
+
+        return $featureNode;
+    }
+
+    private function setPrivateProperty($object, $propertyName, $value)
+    {
+        $reflectionClass = new \ReflectionClass($object);
+        $property = $reflectionClass->getProperty($propertyName);
+        $property->setAccessible(true);
+        $property->setValue($object, $value);
+    }
+
 }

--- a/tests/Behat/Gherkin/Cucumber/CompatibilityTest.php
+++ b/tests/Behat/Gherkin/Cucumber/CompatibilityTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Behat\Gherkin\Cucumber;
+
+use Behat\Gherkin\Gherkin;
+use Behat\Gherkin\Keywords;
+use Behat\Gherkin\Lexer;
+use Behat\Gherkin\Loader\ArrayLoader;
+use Behat\Gherkin\Loader\CucumberNDJsonAstLoader;
+use Behat\Gherkin\Node\FeatureNode;
+use Behat\Gherkin\Parser;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group cucumber-compatibility
+ */
+class CompatibilityTest extends TestCase
+{
+    const TESTDATA_PATH = __DIR__ . '/../../../../vendor/cucumber/cucumber/gherkin/testdata';
+
+    const NOT_PARSABLE = [
+        'complex_background.feature',
+        'descriptions.feature',
+        'docstrings.feature',
+        'incomplete.feature',
+        'incomplete_scenario_outline.feature',
+        'padded_example.feature',
+        'rule.feature',
+        'scenario_outline.feature',
+        'spaces_in_language.feature',
+        'empty.feature',
+        'incomplete_feature_3.feature'
+    ];
+
+    /**
+     * @var Parser
+     */
+    private $parser;
+
+    public function setUp()
+    {
+        $arrKeywords = include __DIR__ . '/../../../../i18n.php';
+        $lexer  = new Lexer(new Keywords\ArrayKeywords($arrKeywords));
+        $this->parser = new Parser($lexer);
+    }
+
+    /**
+     * @dataProvider goodFeatures
+     */
+    public function testGoodFeaturesCanParse($gherkinFile)
+    {
+        $actual = $this->parser->parse(file_get_contents($gherkinFile), $gherkinFile);
+
+        $this->assertInstanceOf(FeatureNode::class, $actual);
+    }
+
+    public static function goodFeatures()
+    {
+        foreach (new \FilesystemIterator(self::TESTDATA_PATH . '/good') as $file) {
+            if (in_array($file->getFilename(), self::NOT_PARSABLE)) {
+                continue;
+            }
+
+            if ($file->isFile() && $file->getExtension() === 'feature') {
+                yield $file->getFilename() => [ $file->getPathname(), $file->getPathname() . '.ast.ndjson' ];
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is a replacement for #152 that checks we are parsing gherkin files the same way that Cucumber does. 

Tests that parse differently are marked as Not Implemented, with an indication of the issue. Hopefully we can work through them one by one.

The tests are pulled from Cucumber's test suite. We can of course add more (and maybe cucumber would appreciate edge cases upstream)