### PR TITLE
Refactor the parsing of comments to avoid recursion

### DIFF
--- a/src/Behat/Gherkin/Parser.php
+++ b/src/Behat/Gherkin/Parser.php
@@ -183,7 +183,15 @@ class Parser
      */
     protected function parseExpression()
     {
-        switch ($type = $this->predictTokenType()) {
+        $type = $this->predictTokenType();
+
+        while ($type === 'Comment') {
+            $this->expectTokenType('Comment');
+
+            $type = $this->predictTokenType();
+        }
+
+        switch ($type) {
             case 'Feature':
                 return $this->parseFeature();
             case 'Background':
@@ -206,8 +214,6 @@ class Parser
                 return $this->parseNewline();
             case 'Tag':
                 return $this->parseTags();
-            case 'Comment':
-                return $this->parseComment();
             case 'Language':
                 return $this->parseLanguage();
             case 'EOS':
@@ -651,18 +657,6 @@ class Parser
         $this->expectTokenType('Newline');
 
         return "\n";
-    }
-
-    /**
-     * Parses next comment token & returns it's string content.
-     *
-     * @return BackgroundNode|FeatureNode|OutlineNode|ScenarioNode|StepNode|TableNode|string
-     */
-    protected function parseComment()
-    {
-        $this->expectTokenType('Comment');
-
-        return $this->parseExpression();
     }
 
     /**

--- a/tests/Behat/Gherkin/ParserTest.php
+++ b/tests/Behat/Gherkin/ParserTest.php
@@ -162,4 +162,16 @@ FEATURE
             $feature->getLine()
         );
     }
+
+    public function testParsingManyCommentsShouldPass()
+    {
+        if (! extension_loaded('xdebug')) {
+            $this->markTestSkipped('xdebug extension must be enabled.');
+        }
+        $defaultPHPSetting = 256;
+        $this->iniSet('xdebug.max_nesting_level', $defaultPHPSetting);
+
+        $lineCount = 150; // 119 is the real threshold, higher just in case
+        $this->assertNull($this->getGherkinParser()->parse(str_repeat("# \n", $lineCount)));
+    }
 }


### PR DESCRIPTION
Closes https://github.com/Behat/Gherkin/pull/138 (the first commit adding a test is the one from this PR)