### PR TITLE
Cast table node exceptions into ParserExceptions when throwing

### DIFF
--- a/src/Behat/Gherkin/Parser.php
+++ b/src/Behat/Gherkin/Parser.php
@@ -566,11 +566,13 @@ class Parser
      */
     protected function parseTable()
     {
+        $table = $this->parseTableRows();
+
         try {
-            return new TableNode($this->parseTableRows());
+            return new TableNode($table);
         } catch(NodeException $e) {
             throw new ParserException(
-                $e->getMessage() . $this->file ? ' in file '.$this->file : '',
+                $e->getMessage() . ($this->file ? ' in file '.$this->file : ''),
                 0,
                 $e
             );

--- a/src/Behat/Gherkin/Parser.php
+++ b/src/Behat/Gherkin/Parser.php
@@ -550,13 +550,15 @@ class Parser
      */
     protected function parseExamples()
     {
-        $token = $this->expectTokenType('Examples');
-
-        $keyword = $token['keyword'];
-
+        $keyword = ($this->expectTokenType('Examples'))['keyword'];
         $tags = empty($this->tags) ? array() : $this->popTags();
+        $table = $this->parseTableRows();
 
-        return new ExampleTableNode($this->parseTableRows(), $keyword, $tags);
+        try {
+            return new ExampleTableNode($table, $keyword, $tags);
+        } catch(NodeException $e) {
+            $this->rethrowNodeException($e);
+        }
     }
 
     /**
@@ -571,11 +573,7 @@ class Parser
         try {
             return new TableNode($table);
         } catch(NodeException $e) {
-            throw new ParserException(
-                $e->getMessage() . ($this->file ? ' in file '.$this->file : ''),
-                0,
-                $e
-            );
+            $this->rethrowNodeException($e);
         }
     }
 
@@ -743,5 +741,14 @@ class Parser
             );
         }
         return $node;
+    }
+
+    private function rethrowNodeException(NodeException $e): void
+    {
+        throw new ParserException(
+            $e->getMessage() . ($this->file ? ' in file ' . $this->file : ''),
+            0,
+            $e
+        );
     }
 }

--- a/src/Behat/Gherkin/Parser.php
+++ b/src/Behat/Gherkin/Parser.php
@@ -11,6 +11,7 @@
 namespace Behat\Gherkin;
 
 use Behat\Gherkin\Exception\LexerException;
+use Behat\Gherkin\Exception\NodeException;
 use Behat\Gherkin\Exception\ParserException;
 use Behat\Gherkin\Node\BackgroundNode;
 use Behat\Gherkin\Node\ExampleTableNode;
@@ -565,7 +566,16 @@ class Parser
      */
     protected function parseTable()
     {
-        return new TableNode($this->parseTableRows());
+        try {
+            return new TableNode($this->parseTableRows());
+        }
+        catch(NodeException $e) {
+            throw new ParserException(
+                $e->getMessage() . $this->file ? ' in file '.$this->file : '',
+                0,
+                $e
+            );
+        }
     }
 
     /**

--- a/src/Behat/Gherkin/Parser.php
+++ b/src/Behat/Gherkin/Parser.php
@@ -568,8 +568,7 @@ class Parser
     {
         try {
             return new TableNode($this->parseTableRows());
-        }
-        catch(NodeException $e) {
+        } catch(NodeException $e) {
             throw new ParserException(
                 $e->getMessage() . $this->file ? ' in file '.$this->file : '',
                 0,

--- a/tests/Behat/Gherkin/Cucumber/CompatibilityTest.php
+++ b/tests/Behat/Gherkin/Cucumber/CompatibilityTest.php
@@ -43,7 +43,6 @@ class CompatibilityTest extends TestCase
     ];
 
     private $parsedButShouldNotBe = [
-        'inconsistent_cell_count.feature' => 'Inconsistent cells count throws low level exception not ParserException',
         'invalid_language.feature' => 'Invalid language is silently ignored',
         'whitespace_in_tags.feature' => 'Whitespace in tags is tolerated',
     ];


### PR DESCRIPTION
Rather than leaking this, we should make a ParserException

Closes #212 