### PR TITLE
Remove symfony phpunit bridge

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,6 @@
 
     "require-dev": {
         "symfony/yaml": "~3|~4|~5",
-        "symfony/phpunit-bridge": "~3|~4|~5",
         "phpunit/phpunit": "~8|~9",
         "cucumber/cucumber": "dev-gherkin-16.0.0"
     },


### PR DESCRIPTION
This was added to catch deprecations, which modern PHPUnit does. It also interferes with expectDeprecation's functionality