### PR TITLE
Cucumber changelog in PRs and using correct hash

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -32,6 +32,11 @@ jobs:
         run: bin/update_i18n
         if: steps.cucumber.outputs.cucumber_version
 
+      - name: Find changelog
+        id: changelog
+        run: bin/cucumber_changelog ${{ steps.cucumber.outputs.cucumber_version }}
+        if: steps.cucumber.outputs.cucumber_version
+
       - name: Open a PR
         uses: peter-evans/create-pull-request@v3
         if: steps.cucumber.outputs.cucumber_version
@@ -40,4 +45,5 @@ jobs:
           branch: cucumber-update-${{ steps.cucumber.outputs.cucumber_version }}
           delete-branch: true
           title: Cucumber update ${{ steps.cucumber.outputs.cucumber_version }}
+          body: ${{ steps.changelog.outputs.changelog }}
           base: 'master'

--- a/bin/cucumber_changelog
+++ b/bin/cucumber_changelog
@@ -27,5 +27,7 @@ if (!preg_match('/(?<changes>##\s+\['.preg_quote($version).'\].*?)^##\s/ms', $ch
 
 echo "Found changelog:\n$changes";
 
-$changes = strtr($changes, ["%" => "%25", "\r" => '%0D', "\n" => '%0A', ':' => '%3A', ',' => '%2C']);
-echo "::set-output name=changelog::$changes\n";
+if (getenv('GITHUB_ACTIONS')) {
+    $changes = strtr($changes, ["%" => "%25", "\r" => '%0D', "\n" => '%0A', ':' => '%3A', ',' => '%2C']);
+    echo "::set-output name=changelog::$changes\n";
+}

--- a/bin/cucumber_changelog
+++ b/bin/cucumber_changelog
@@ -1,0 +1,31 @@
+#!/usr/bin/env php
+<?php
+
+if ($argc != 2) {
+    echo "Usage: {$argv[0]} <version>\n";
+    exit(1);
+}
+
+$version = $argv[1];
+
+if (!preg_match('/[0-9]+.[0-9]+.[0-9]+/', $version)) {
+    echo "Error: Version format not recognised\n";
+    exit(1);
+}
+
+if (!$changelog = file_get_contents(__DIR__ . '/../vendor/cucumber/cucumber/gherkin/CHANGELOG.md')) {
+    echo "Error: Could not read changelog\n";
+    exit(1);
+}
+
+if (!preg_match('/(?<changes>##\s+\['.preg_quote($version).'\].*?)^##\s/ms', $changelog, $matches)) {
+    echo "Error: Could not find version $version in changelog\n";
+    exit(1);
+}
+
+['changes' => $changes] = $matches;
+
+echo "Found changelog:\n$changes";
+
+$changes = strtr($changes, ["%" => "%25", "\r" => '%0D', "\n" => '%0A', ':' => '%3A', ',' => '%2C']);
+echo "::set-output name=changelog::$changes\n";

--- a/bin/update_cucumber
+++ b/bin/update_cucumber
@@ -54,4 +54,8 @@ $newJson = str_replace(
 file_put_contents($composerFile, $newJson);
 
 echo "Updated composer config:\n$newJson";
-echo "::set-output name=cucumber_version::$newTag\n";
+
+
+if (getenv('GITHUB_ACTIONS')) {
+    echo "::set-output name=cucumber_version::$newTag\n";
+}

--- a/bin/update_cucumber
+++ b/bin/update_cucumber
@@ -30,7 +30,7 @@ echo "Latest local hash is {$oldHash} (tagged {$oldTag})\n";
 
 if(!preg_match(
     '/^(?<hash>[0-9a-z]+)\s+\S+\\/v(?<tag>[0-9.]+)/',
-    shell_exec('git ls-remote --tags https://github.com/cucumber/cucumber.git | grep cucumber-gherkin | sort --version-sort -k2 | tail -n 1'),
+    shell_exec('git ls-remote --tags https://github.com/cucumber/cucumber.git | grep refs/tags/gherkin | sort --version-sort -k2 | tail -n 1'),
     $matches
 )) {
     echo "ERROR: Could not parse the repository tags\n";

--- a/composer.json
+++ b/composer.json
@@ -54,13 +54,12 @@
                 "source": {
                     "type": "git",
                     "url": "https://github.com/cucumber/cucumber.git",
-                    "reference": "99706895df020c8d005bc6d32afe2fec691b8493"
+                    "reference": "8b574b631d215e6d11bd00c91d496664b4f2e7aa"
                 },
                 "dist": {
                     "type": "zip",
-                    "url": "https://api.github.com/repos/cucumber/cucumber/zipball/99706895df020c8d005bc6d32afe2fec691b8493",
-                    "reference": "99706895df020c8d005bc6d32afe2fec691b8493",
-                    "shasum": ""
+                    "url": "https://api.github.com/repos/cucumber/cucumber/zipball/8b574b631d215e6d11bd00c91d496664b4f2e7aa",
+                    "reference": "8b574b631d215e6d11bd00c91d496664b4f2e7aa"
                 }
             }
         }


### PR DESCRIPTION
Changes how we find the cucumber release hash to fix #223 

Also finds and includes the changeling section for the relevant release in the body of the PR (see https://github.com/ciaranmcnulty/Gherkin-1/pull/12 for how this looks)