### PR TITLE
Ignore the bin folder in archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
+/bin/ export-ignore
 /tests export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore


### PR DESCRIPTION
This folder contains maintenance scripts, not files meant to be part of the package.