### PR TITLE
Improve error message for checking tags for whitespaces

### DIFF
--- a/src/Behat/Gherkin/Parser.php
+++ b/src/Behat/Gherkin/Parser.php
@@ -656,7 +656,7 @@ class Parser
     {
         foreach ($tags as $tag) {
             if (preg_match('/\s/', $tag)) {
-                trigger_error('Whitespace in tags is deprecated, found "$tag"', E_USER_DEPRECATED);
+                trigger_error(sprintf('Whitespace in tags is deprecated, found "%s"', $tag), E_USER_DEPRECATED);
             }
         }
     }


### PR DESCRIPTION
I guess the error message was supposed to contain the actual erroneous tag.