### PR TITLE
Check for empty Tag filter string

### DIFF
--- a/src/Behat/Gherkin/Filter/TagFilter.php
+++ b/src/Behat/Gherkin/Filter/TagFilter.php
@@ -13,6 +13,7 @@ namespace Behat\Gherkin\Filter;
 use Behat\Gherkin\Node\FeatureNode;
 use Behat\Gherkin\Node\OutlineNode;
 use Behat\Gherkin\Node\ScenarioInterface;
+use function mb_strlen;
 
 /**
  * Filters scenarios by feature/scenario tag.
@@ -136,6 +137,10 @@ class TagFilter extends ComplexFilter
     protected function isTagsMatchCondition($tags)
     {
         $satisfies = true;
+
+        if (mb_strlen($this->filterString) === 0) {
+            return $satisfies;
+        }
 
         foreach (explode('&&', $this->filterString) as $andTags) {
             $satisfiesComma = false;

--- a/src/Behat/Gherkin/Filter/TagFilter.php
+++ b/src/Behat/Gherkin/Filter/TagFilter.php
@@ -13,7 +13,6 @@ namespace Behat\Gherkin\Filter;
 use Behat\Gherkin\Node\FeatureNode;
 use Behat\Gherkin\Node\OutlineNode;
 use Behat\Gherkin\Node\ScenarioInterface;
-use function mb_strlen;
 
 /**
  * Filters scenarios by feature/scenario tag.
@@ -138,7 +137,7 @@ class TagFilter extends ComplexFilter
     {
         $satisfies = true;
 
-        if (mb_strlen($this->filterString) === 0) {
+        if (\strlen($this->filterString) === 0) {
             return $satisfies;
         }
 

--- a/tests/Behat/Gherkin/Filter/TagFilterTest.php
+++ b/tests/Behat/Gherkin/Filter/TagFilterTest.php
@@ -280,4 +280,13 @@ class TagFilterTest extends TestCase
 
         $this->assertEquals([$scenario], $scenarios);
     }
+
+    public function testTagFilterThatIsAllWhitespaceIsIgnored()
+    {
+        $feature = new FeatureNode(null, null, [], null, [], null, null, null, 1);
+        $tagFilter = new TagFilter('');
+        $result = $tagFilter->isFeatureMatch($feature);
+
+        $this->assertTrue($result);
+    }
 }


### PR DESCRIPTION
If the `filterString` in `TagFilter` is an empty string, an exception
was being thrown because the code was expecting a non-empty string.
This checks if the string is non-empty and returns early if it is.

Issue: #250