### PR TITLE
Compatibility layer for `cucumber/gherkin`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,8 @@ jobs:
               symfony-version: '5.*'
           -   php: 8.0
               symfony-version: '5.*'
+          -   php: 8.1
+              cucumber: true
 
     steps:
       -   uses: actions/checkout@v2
@@ -40,8 +42,16 @@ jobs:
           if: matrix.symfony-version != ''
           run: composer require --no-update "symfony/symfony:${{ matrix.symfony-version }}"
 
+      -   name: Require cucumber
+          if: matrix.cucumber == true
+          run: composer require --no-update "cucumber/gherkin"
+
       -   name: Install dependencies
           run: composer update ${{ matrix.composer-flags }}
 
       -   name: Run tests (phpunit)
           run: ./vendor/bin/phpunit
+
+      -   name: Run cucumber tests (phpunit)
+          if: matrix.cucumber == true
+          run: ./vendor/bin/phpunit --group=cucumber

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,10 @@
         "cucumber/cucumber": "dev-gherkin-24.0.0"
     },
 
+    "conflict": {
+        "cucumber/messages": "<19.0.0"
+    },
+
     "suggest": {
         "symfony/yaml": "If you want to parse features, represented in YAML files"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,6 +11,12 @@
          stopOnFailure="false"
          bootstrap="vendor/autoload.php"
 >
+    <groups>
+        <exclude>
+            <group>cucumber</group>
+        </exclude>
+    </groups>
+
     <testsuites>
         <testsuite name="Behat Gherkin test suite">
             <directory>./tests/Behat/Gherkin/</directory>

--- a/src/Behat/Gherkin/Cucumber/BackgroundNodeMapper.php
+++ b/src/Behat/Gherkin/Cucumber/BackgroundNodeMapper.php
@@ -3,6 +3,7 @@
 namespace Behat\Gherkin\Cucumber;
 
 use Behat\Gherkin\Node\BackgroundNode;
+use Cucumber\Messages\Background;
 use Cucumber\Messages\FeatureChild;
 
 final class BackgroundNodeMapper
@@ -26,8 +27,17 @@ final class BackgroundNodeMapper
     {
         foreach($children as $child) {
             if ($child->background) {
+
+                $title = $child->background->name;
+                if ($child->background->description) {
+                    $title .= "\n" . $child->background->description;
+                }
+
                 return new BackgroundNode(
-                    $child->background->name,
+                    MultilineStringFormatter::format(
+                        $title,
+                        $child->background->location
+                    ),
                     $this->stepNodeMapper->map($child->background->steps),
                     $child->background->keyword,
                     $child->background->location->line

--- a/src/Behat/Gherkin/Cucumber/BackgroundNodeMapper.php
+++ b/src/Behat/Gherkin/Cucumber/BackgroundNodeMapper.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Behat\Gherkin\Cucumber;
+
+use Behat\Gherkin\Node\BackgroundNode;
+use Cucumber\Messages\FeatureChild;
+
+final class BackgroundNodeMapper
+{
+    /**
+     * @var StepNodeMapper
+     */
+    private $stepNodeMapper;
+
+    public function __construct(StepNodeMapper $stepNodeMapper)
+    {
+        $this->stepNodeMapper = $stepNodeMapper;
+    }
+
+    /**
+     * @param FeatureChild[] $children
+     *
+     * @return BackgroundNode|null
+     */
+    public function map(array $children) : ?BackgroundNode
+    {
+        foreach($children as $child) {
+            if ($child->background) {
+                return new BackgroundNode(
+                    $child->background->name,
+                    $this->stepNodeMapper->map($child->background->steps),
+                    $child->background->keyword,
+                    $child->background->location->line
+                );
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Behat/Gherkin/Cucumber/ExampleTableNodeMapper.php
+++ b/src/Behat/Gherkin/Cucumber/ExampleTableNodeMapper.php
@@ -5,10 +5,19 @@ namespace Behat\Gherkin\Cucumber;
 use Behat\Gherkin\Node\ExampleTableNode;
 use Cucumber\Messages\Examples;
 use Cucumber\Messages\TableCell;
-use Cucumber\Messages\TableRow;
 
 final class ExampleTableNodeMapper
 {
+    /**
+     * @var TagMapper
+     */
+    private $tagMapper;
+
+    public function __construct(TagMapper $tagMapper)
+    {
+        $this->tagMapper = $tagMapper;
+    }
+
     /**
      * @param Examples[] $exampleTables
      *
@@ -22,7 +31,7 @@ final class ExampleTableNodeMapper
             $exampleTableNodes[] = new ExampleTableNode(
                 $this->getTableArray($exampleTable),
                 $exampleTable->keyword,
-                []
+                $this->tagMapper->map($exampleTable->tags)
             );
         }
 

--- a/src/Behat/Gherkin/Cucumber/ExampleTableNodeMapper.php
+++ b/src/Behat/Gherkin/Cucumber/ExampleTableNodeMapper.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Behat\Gherkin\Cucumber;
+
+use Behat\Gherkin\Node\ExampleTableNode;
+use Cucumber\Messages\Examples;
+use Cucumber\Messages\TableCell;
+use Cucumber\Messages\TableRow;
+
+final class ExampleTableNodeMapper
+{
+    /**
+     * @param Examples[] $exampleTables
+     *
+     * @return ExampleTableNode[]
+     */
+    public function map(array $exampleTables) : array
+    {
+        $exampleTableNodes = [];
+
+        foreach ($exampleTables as $exampleTable) {
+            $exampleTableNodes[] = new ExampleTableNode(
+                $this->getTableArray($exampleTable),
+                $exampleTable->keyword,
+                []
+            );
+        }
+
+        return $exampleTableNodes;
+    }
+
+    private function getTableArray(Examples $exampleTable) : array
+    {
+        $array = [];
+
+        if ($exampleTable->tableHeader) {
+            $array[$exampleTable->tableHeader->location->line] = array_map(
+                function (TableCell $cell) {
+                    return $cell->value;
+                },
+                $exampleTable->tableHeader->cells
+            );
+        }
+
+        foreach ($exampleTable->tableBody as $row) {
+            $array[$row->location->line] = array_map(
+                function (TableCell $cell) {
+                    return $cell->value;
+                },
+                $row->cells
+            );
+        }
+
+        return $array;
+    }
+}

--- a/src/Behat/Gherkin/Cucumber/FeatureNodeMapper.php
+++ b/src/Behat/Gherkin/Cucumber/FeatureNodeMapper.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Behat\Gherkin\Cucumber;
+
+use Behat\Gherkin\Node\FeatureNode;
+use Cucumber\Messages\GherkinDocument;
+
+final class FeatureNodeMapper
+{
+    /**
+     * @var TagMapper
+     */
+    private $tagMapper;
+
+    /**
+     * @var BackgroundNodeMapper
+     */
+    private $backgroundMapper;
+
+    /**
+     * @var ScenarioNodeMapper
+     */
+    private $scenarioMapper;
+
+    public function __construct(
+        TagMapper $tagMapper,
+        BackgroundNodeMapper $backgroundMapper,
+        ScenarioNodeMapper $scenarioMapper
+    )
+    {
+        $this->tagMapper = $tagMapper;
+        $this->backgroundMapper = $backgroundMapper;
+        $this->scenarioMapper = $scenarioMapper;
+    }
+
+    function map(GherkinDocument $gherkinDocument) : ?FeatureNode
+    {
+        if (!$gherkinDocument->feature) {
+            return null;
+        }
+
+        return new FeatureNode(
+            $gherkinDocument->feature->name,
+            $gherkinDocument->feature->description,
+            $this->tagMapper->map($gherkinDocument->feature->tags),
+            $this->backgroundMapper->map($gherkinDocument->feature->children),
+            $this->scenarioMapper->map($gherkinDocument->feature->children),
+            $gherkinDocument->feature->keyword,
+            $gherkinDocument->feature->language,
+            $gherkinDocument->uri,
+            $gherkinDocument->feature->location->line
+        );
+    }
+}

--- a/src/Behat/Gherkin/Cucumber/FeatureNodeMapper.php
+++ b/src/Behat/Gherkin/Cucumber/FeatureNodeMapper.php
@@ -3,6 +3,7 @@
 namespace Behat\Gherkin\Cucumber;
 
 use Behat\Gherkin\Node\FeatureNode;
+use Cucumber\Messages\Feature;
 use Cucumber\Messages\GherkinDocument;
 
 final class FeatureNodeMapper
@@ -41,7 +42,10 @@ final class FeatureNodeMapper
 
         return new FeatureNode(
             $gherkinDocument->feature->name,
-            $gherkinDocument->feature->description,
+            MultilineStringFormatter::format(
+                $gherkinDocument->feature->description,
+                $gherkinDocument->feature->location
+            ) ?: null, // background has empty = null
             $this->tagMapper->map($gherkinDocument->feature->tags),
             $this->backgroundMapper->map($gherkinDocument->feature->children),
             $this->scenarioMapper->map($gherkinDocument->feature->children),
@@ -51,4 +55,5 @@ final class FeatureNodeMapper
             $gherkinDocument->feature->location->line
         );
     }
+
 }

--- a/src/Behat/Gherkin/Cucumber/KeywordTypeMapper.php
+++ b/src/Behat/Gherkin/Cucumber/KeywordTypeMapper.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Behat\Gherkin\Cucumber;
+
+use Cucumber\Messages\Step\KeywordType;
+
+final class KeywordTypeMapper
+{
+    public function map(?KeywordType $type, ?string $prevType) : string
+    {
+        if ($type == KeywordType::CONTEXT) {
+            return 'Given';
+        }
+
+        if ($type == KeywordType::ACTION) {
+            return 'When';
+        }
+
+        if ($type == KeywordType::OUTCOME) {
+            return 'Then';
+        }
+
+        if ($type == KeywordType::CONJUNCTION && $prevType != null) {
+            return $prevType;
+        }
+
+        return 'Given';
+    }
+
+}

--- a/src/Behat/Gherkin/Cucumber/MultilineStringFormatter.php
+++ b/src/Behat/Gherkin/Cucumber/MultilineStringFormatter.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace Behat\Gherkin\Cucumber;
+
+use Cucumber\Messages\Location;
+
+final class MultilineStringFormatter
+{
+    public static function format(string $string, Location $keywordLocation = null): string
+    {
+        if (!$keywordLocation) {
+            $keywordLocation = new Location(0,1);
+        }
+
+        $maxIndent = ($keywordLocation->column-1 ?: 0) + 2;
+
+        return preg_replace(
+            ["/^[^\n\S]{0,$maxIndent}/um", '/[^\n\S]+$/um'],
+            ['', ''],
+            $string
+        );
+    }
+}

--- a/src/Behat/Gherkin/Cucumber/PyStringNodeMapper.php
+++ b/src/Behat/Gherkin/Cucumber/PyStringNodeMapper.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Behat\Gherkin\Cucumber;
+
+use Behat\Gherkin\Node\PyStringNode;
+use Cucumber\Messages\DocString;
+
+final class PyStringNodeMapper
+{
+    /**
+     * @param DocString $docString
+     * @return PyStringNode[]
+     */
+    public function map(?DocString $docString) : array
+    {
+        if (!$docString) {
+            return [];
+        }
+
+        return [
+            new PyStringNode(
+                $this->split($docString->content),
+                $docString->location->line
+            )
+        ];
+    }
+
+    private function split(string $content) {
+        $content = strtr($content, array("\r\n" => "\n", "\r" => "\n"));
+
+        return explode("\n", $content);
+    }
+}

--- a/src/Behat/Gherkin/Cucumber/ScenarioNodeMapper.php
+++ b/src/Behat/Gherkin/Cucumber/ScenarioNodeMapper.php
@@ -6,6 +6,7 @@ use Behat\Gherkin\Node\OutlineNode;
 use Behat\Gherkin\Node\ScenarioInterface;
 use Behat\Gherkin\Node\ScenarioNode;
 use Cucumber\Messages\FeatureChild;
+use Cucumber\Messages\Scenario;
 
 final class ScenarioNodeMapper
 {
@@ -25,8 +26,8 @@ final class ScenarioNodeMapper
     private $exampleTableNodeMapper;
 
     public function __construct(
-        TagMapper $tagMapper,
-        StepNodeMapper $stepNodeMapper,
+        TagMapper              $tagMapper,
+        StepNodeMapper         $stepNodeMapper,
         ExampleTableNodeMapper $exampleTableNodeMapper
     )
     {
@@ -40,7 +41,7 @@ final class ScenarioNodeMapper
      *
      * @return ScenarioInterface[]
      */
-    public function map(array $children) : array
+    public function map(array $children): array
     {
         $scenarios = [];
 
@@ -53,7 +54,10 @@ final class ScenarioNodeMapper
                 }
 
                 $scenario = new ScenarioNode (
-                    $title,
+                    MultilineStringFormatter::format(
+                        $title,
+                        $child->scenario->location
+                    ),
                     $this->tagMapper->map($child->scenario->tags),
                     $this->stepNodeMapper->map($child->scenario->steps),
                     $child->scenario->keyword,

--- a/src/Behat/Gherkin/Cucumber/ScenarioNodeMapper.php
+++ b/src/Behat/Gherkin/Cucumber/ScenarioNodeMapper.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Behat\Gherkin\Cucumber;
+
+use Behat\Gherkin\Node\OutlineNode;
+use Behat\Gherkin\Node\ScenarioInterface;
+use Behat\Gherkin\Node\ScenarioNode;
+use Cucumber\Messages\FeatureChild;
+
+final class ScenarioNodeMapper
+{
+    /**
+     * @var TagMapper
+     */
+    private $tagMapper;
+
+    /**
+     * @var StepNodeMapper
+     */
+    private $stepNodeMapper;
+
+    /**
+     * @var ExampleTableNodeMapper
+     */
+    private $exampleTableNodeMapper;
+
+    public function __construct(
+        TagMapper $tagMapper,
+        StepNodeMapper $stepNodeMapper,
+        ExampleTableNodeMapper $exampleTableNodeMapper
+    )
+    {
+        $this->tagMapper = $tagMapper;
+        $this->stepNodeMapper = $stepNodeMapper;
+        $this->exampleTableNodeMapper = $exampleTableNodeMapper;
+    }
+
+    /**
+     * @param FeatureChild[] $children
+     *
+     * @return ScenarioInterface[]
+     */
+    public function map(array $children) : array
+    {
+        $scenarios = [];
+
+        foreach ($children as $child) {
+            if ($child->scenario) {
+
+                $title = $child->scenario->name;
+                if ($child->scenario->description) {
+                    $title .= "\n" . $child->scenario->description;
+                }
+
+                $scenario = new ScenarioNode (
+                    $title,
+                    $this->tagMapper->map($child->scenario->tags),
+                    $this->stepNodeMapper->map($child->scenario->steps),
+                    $child->scenario->keyword,
+                    $child->scenario->location->line
+                );
+
+                if ($child->scenario->examples) {
+                    $scenario = new OutlineNode(
+                        $scenario->getTitle(),
+                        $scenario->getTags(),
+                        $scenario->getSteps(),
+                        $this->exampleTableNodeMapper->map($child->scenario->examples),
+                        $scenario->getKeyword(),
+                        $scenario->getLine()
+                    );
+                }
+
+                $scenarios[] = $scenario;
+            }
+
+        }
+
+        return $scenarios;
+    }
+}

--- a/src/Behat/Gherkin/Cucumber/StepNodeMapper.php
+++ b/src/Behat/Gherkin/Cucumber/StepNodeMapper.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Behat\Gherkin\Cucumber;
+
+use Behat\Gherkin\Node\StepNode;
+use Cucumber\Messages\Step;
+
+final class StepNodeMapper
+{
+    /**
+     * @var KeywordTypeMapper
+     */
+    private $keywordTypeMapper;
+
+    /**
+     * @var PyStringNodeMapper
+     */
+    private $pyStringNodeMapper;
+
+    /**
+     * @var TableNodeMapper
+     */
+    private $tableNodeMapper;
+
+    public function __construct(
+        KeywordTypeMapper $keywordTypeMapper,
+        PyStringNodeMapper $pyStringNodeMapper,
+        TableNodeMapper $tableNodeMapper
+    )
+    {
+        $this->keywordTypeMapper = $keywordTypeMapper;
+        $this->pyStringNodeMapper = $pyStringNodeMapper;
+        $this->tableNodeMapper = $tableNodeMapper;
+    }
+
+    /**
+     * @param Step[] $steps
+     * @return StepNode[]
+     */
+    public function map(array $steps)
+    {
+        $stepNodes = [];
+        $prevType = null;
+
+        foreach ($steps as $step) {
+            $stepNodes[] = new StepNode(
+                // behat does not include space at end of keyword
+                rtrim($step->keyword),
+                $step->text,
+                array_merge(
+                    $this->pyStringNodeMapper->map($step->docString),
+                    $this->tableNodeMapper->map($step->dataTable),
+                ),
+                $step->location->line,
+                $prevType = $this->keywordTypeMapper->map($step->keywordType, $prevType)
+            );
+        }
+
+        return $stepNodes;
+    }
+
+}

--- a/src/Behat/Gherkin/Cucumber/TableNodeMapper.php
+++ b/src/Behat/Gherkin/Cucumber/TableNodeMapper.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Behat\Gherkin\Cucumber;
+
+use Behat\Gherkin\Node\TableNode;
+use Cucumber\Messages\DataTable;
+use Cucumber\Messages\TableCell;
+use Cucumber\Messages\TableRow;
+
+final class TableNodeMapper
+{
+    /**
+     * @return TableNode[]
+     */
+    public function map(?DataTable $table) : array
+    {
+        if (!$table) {
+            return [];
+        }
+
+        $rows = [];
+
+        foreach($table->rows as $row) {
+            $rows[$row->location->line] = array_map(
+                function(TableCell $cell) {
+                    return $cell->value;
+                },
+                $row->cells
+            );
+        }
+
+        return [
+            new TableNode($rows)
+        ];
+    }
+}

--- a/src/Behat/Gherkin/Cucumber/TagMapper.php
+++ b/src/Behat/Gherkin/Cucumber/TagMapper.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Behat\Gherkin\Cucumber;
+
+use Cucumber\Messages\Tag;
+
+final class TagMapper
+{
+    /**
+     * @param Tag[] $tags
+     * @return string[]
+     */
+    public function map(array $tags) : array {
+        return array_map(
+            function(Tag $t) {
+                return ltrim($t->name, '@');
+            },
+            $tags
+        );
+    }
+}

--- a/src/Behat/Gherkin/Lexer.php
+++ b/src/Behat/Gherkin/Lexer.php
@@ -627,6 +627,7 @@ class Lexer
      */
     private function getStepKeywordType($native)
     {
+
         // Consider "*" as a AND keyword so that it is normalized to the previous step type
         if ('*' === $native) {
             return 'And';
@@ -644,6 +645,7 @@ class Lexer
 
         foreach ($this->stepKeywordTypesCache as $type => $keywords) {
             if (in_array($native, $keywords) || in_array($native . '<', $keywords)) {
+
                 return $type;
             }
         }

--- a/src/Behat/Gherkin/Loader/CucumberGherkinLoader.php
+++ b/src/Behat/Gherkin/Loader/CucumberGherkinLoader.php
@@ -1,0 +1,90 @@
+<?php declare(strict_types=1);
+
+namespace Behat\Gherkin\Loader;
+
+use Behat\Gherkin\Cucumber\BackgroundNodeMapper;
+use Behat\Gherkin\Cucumber\ExampleTableNodeMapper;
+use Behat\Gherkin\Cucumber\FeatureNodeMapper;
+use Behat\Gherkin\Cucumber\KeywordTypeMapper;
+use Behat\Gherkin\Cucumber\PyStringNodeMapper;
+use Behat\Gherkin\Cucumber\ScenarioNodeMapper;
+use Behat\Gherkin\Cucumber\StepNodeMapper;
+use Behat\Gherkin\Cucumber\TableNodeMapper;
+use Behat\Gherkin\Cucumber\TagMapper;
+use Behat\Gherkin\Node\FeatureNode;
+use Cucumber\Gherkin\GherkinParser;
+use Cucumber\Messages\GherkinDocument;
+
+final class CucumberGherkinLoader extends AbstractFileLoader
+{
+    /**
+     * @var FeatureNodeMapper
+     */
+    private $mapper;
+
+    /**
+     * @var GherkinParser
+     */
+    private $parser;
+
+    public function __construct()
+    {
+        $tagMapper = new TagMapper();
+        $stepNodeMapper = new StepNodeMapper(
+            new KeywordTypeMapper(),
+            new PyStringNodeMapper(),
+            new TableNodeMapper()
+        );
+        $this->mapper = new FeatureNodeMapper(
+            $tagMapper,
+            new BackgroundNodeMapper(
+                $stepNodeMapper
+            ),
+            new ScenarioNodeMapper(
+                $tagMapper,
+                $stepNodeMapper,
+                new ExampleTableNodeMapper()
+            )
+        );
+        
+        $this->parser = new GherkinParser(false, false, true, false);
+    }
+
+    /**
+     * Checks if current loader supports provided resource.
+     *
+     * @param mixed $path Resource to load
+     *
+     * @return bool
+     */
+    public function supports($path)
+    {
+        return is_string($path)
+            && is_file($absolute = $this->findAbsolutePath($path))
+            && 'feature' === pathinfo($absolute, PATHINFO_EXTENSION);
+    }
+
+    /**
+     * Loads features from provided resource.
+     *
+     * @param string $path Resource to load
+     *
+     * @return FeatureNode[]
+     */
+    public function load($resource)
+    {
+        $features = [];
+
+        $envelopes = $this->parser->parseString($this->findAbsolutePath($resource), file_get_contents($resource));
+        foreach ($envelopes as $envelope) {
+            if ($envelope->gherkinDocument) {
+                if ($feature = $this->mapper->map($envelope->gherkinDocument)) {
+                    $features[] = $feature;
+                }
+            }
+        }
+
+        return $features;
+    }
+
+}

--- a/src/Behat/Gherkin/Loader/CucumberGherkinLoader.php
+++ b/src/Behat/Gherkin/Loader/CucumberGherkinLoader.php
@@ -67,6 +67,14 @@ final class CucumberGherkinLoader extends AbstractFileLoader
     }
 
     /**
+     * Whether this Loader is available for use
+     */
+    public static function isAvailable() : bool
+    {
+        return class_exists(GherkinParser::class);
+    }
+
+    /**
      * Loads features from provided resource.
      *
      * @param string $path Resource to load

--- a/src/Behat/Gherkin/Loader/CucumberGherkinLoader.php
+++ b/src/Behat/Gherkin/Loader/CucumberGherkinLoader.php
@@ -43,7 +43,9 @@ final class CucumberGherkinLoader extends AbstractFileLoader
             new ScenarioNodeMapper(
                 $tagMapper,
                 $stepNodeMapper,
-                new ExampleTableNodeMapper()
+                new ExampleTableNodeMapper(
+                    $tagMapper
+                )
             )
         );
         

--- a/test.feature
+++ b/test.feature
@@ -1,0 +1,7 @@
+Feature:
+
+  this is a description with some important points
+
+  this is another paragraph in the same description
+
+  Scenario:

--- a/tests/Behat/Gherkin/Acceptance/CompatibilityTestTrait.php
+++ b/tests/Behat/Gherkin/Acceptance/CompatibilityTestTrait.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Tests\Behat\Gherkin\Acceptance;
+
+use Behat\Gherkin\Loader\YamlFileLoader;
+use Behat\Gherkin\Node\FeatureNode;
+
+trait CompatibilityTestTrait
+{
+    private $yaml;
+
+    abstract protected function parseFeature($featureFile) : FeatureNode;
+
+    /**
+     * @dataProvider etalonsProvider
+     */
+    public function testItParsesTheBehatEtalons($yamlFile, $featureFile)
+    {
+        $fixture = $this->getYamlParser()->load($yamlFile)[0];
+        $feature = $this->parseFeature($featureFile);
+
+        $this->compare($fixture, $feature);
+    }
+
+    public function etalonsProvider()
+    {
+        foreach (glob(__DIR__ . '/../Fixtures/etalons/*.yml') as $file) {
+            $testname = basename($file, '.yml');
+
+            if (!in_array($testname, $this->etalons_skip)) {
+                yield $testname => [$file, __DIR__ . '/../Fixtures/features/'.$testname.'.feature'];
+            }
+
+        }
+    }
+
+    protected function getYamlParser()
+    {
+        if (null === $this->yaml) {
+            $this->yaml = new YamlFileLoader();
+        }
+
+        return $this->yaml;
+    }
+
+    private function compare(FeatureNode $fixture, ?FeatureNode $feature): void
+    {
+        $rc = new \ReflectionClass(FeatureNode::class);
+        $rp = $rc->getProperty('file');
+        $rp->setAccessible(true);
+        $rp->setValue($fixture, null);
+        $rp->setValue($feature, null);
+
+        $this->assertEquals($fixture, $feature);
+    }
+
+}

--- a/tests/Behat/Gherkin/Acceptance/CucumberParserTest.php
+++ b/tests/Behat/Gherkin/Acceptance/CucumberParserTest.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Behat\Gherkin\Acceptance;
+
+use Behat\Gherkin\Loader\CucumberGherkinLoader;
+use Behat\Gherkin\Node\FeatureNode;
+use PHPUnit\Framework\TestCase;
+
+/** @group cucumber */
+final class CucumberParserTest extends TestCase
+{
+    protected $etalons_skip = [
+        'comments', # see https://github.com/cucumber/common/issues/1413
+        'multiline_name_with_newlines', # cucumber does not preserve leading newlines in description blocks
+    ];
+
+    public function setUp() : void
+    {
+        $this->loader = new CucumberGherkinLoader();
+    }
+
+    use CompatibilityTestTrait;
+
+    protected function parseFeature($featureFile): FeatureNode
+    {
+        return $this->loader->load($featureFile)[0];
+    }
+}

--- a/tests/Behat/Gherkin/Acceptance/LegacyParserTest.php
+++ b/tests/Behat/Gherkin/Acceptance/LegacyParserTest.php
@@ -11,7 +11,9 @@ use PHPUnit\Framework\TestCase;
 final class LegacyParserTest extends TestCase
 {
     private $gherkin;
-    protected $etalons_skip = [];
+    protected $etalons_skip = [
+        'rules', # rules are not supported
+    ];
 
     use CompatibilityTestTrait;
 

--- a/tests/Behat/Gherkin/Acceptance/LegacyParserTest.php
+++ b/tests/Behat/Gherkin/Acceptance/LegacyParserTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\Behat\Gherkin\Acceptance;
+
+use Behat\Gherkin\Keywords\ArrayKeywords;
+use Behat\Gherkin\Lexer;
+use Behat\Gherkin\Node\FeatureNode;
+use Behat\Gherkin\Parser;
+use PHPUnit\Framework\TestCase;
+
+final class LegacyParserTest extends TestCase
+{
+    private $gherkin;
+    protected $etalons_skip = [];
+
+    use CompatibilityTestTrait;
+
+    protected function parseFeature($featureFile) : FeatureNode
+    {
+        return $this->getGherkinParser()->parse(file_get_contents($featureFile), $featureFile);
+    }
+
+    protected function getGherkinParser()
+    {
+        if (null === $this->gherkin) {
+            $keywords       = new ArrayKeywords(array(
+                'en' => array(
+                    'feature'          => 'Feature',
+                    'background'       => 'Background',
+                    'scenario'         => 'Scenario',
+                    'scenario_outline' => 'Scenario Outline',
+                    'examples'         => 'Examples',
+                    'given'            => 'Given',
+                    'when'             => 'When',
+                    'then'             => 'Then',
+                    'and'              => 'And',
+                    'but'              => 'But'
+                ),
+                'ru' => array(
+                    'feature'          => 'Функционал',
+                    'background'       => 'Предыстория',
+                    'scenario'         => 'Сценарий',
+                    'scenario_outline' => 'Структура сценария',
+                    'examples'         => 'Примеры',
+                    'given'            => 'Допустим',
+                    'when'             => 'Если',
+                    'then'             => 'То',
+                    'and'              => 'И',
+                    'but'              => 'Но'
+                ),
+                'ja' => array (
+                    'feature'           => 'フィーチャ',
+                    'background'        => '背景',
+                    'scenario'          => 'シナリオ',
+                    'scenario_outline'  => 'シナリオアウトライン',
+                    'examples'          => '例|サンプル',
+                    'given'             => '前提<',
+                    'when'              => 'もし<',
+                    'then'              => 'ならば<',
+                    'and'               => 'かつ<',
+                    'but'               => 'しかし<'
+                )
+            ));
+            $this->gherkin  = new Parser(new Lexer($keywords));
+        }
+
+        return $this->gherkin;
+    }
+}

--- a/tests/Behat/Gherkin/Cucumber/BackgroundNodeMapperTest.php
+++ b/tests/Behat/Gherkin/Cucumber/BackgroundNodeMapperTest.php
@@ -1,7 +1,12 @@
 <?php
 
-namespace Behat\Gherkin\Cucumber;
+namespace Tests\Behat\Gherkin\Cucumber;
 
+use Behat\Gherkin\Cucumber\BackgroundNodeMapper;
+use Behat\Gherkin\Cucumber\KeywordTypeMapper;
+use Behat\Gherkin\Cucumber\PyStringNodeMapper;
+use Behat\Gherkin\Cucumber\StepNodeMapper;
+use Behat\Gherkin\Cucumber\TableNodeMapper;
 use Behat\Gherkin\Node\BackgroundNode;
 use Behat\Gherkin\Node\StepNode;
 use Cucumber\Messages\Background;
@@ -54,6 +59,15 @@ final class BackgroundNodeMapperTest extends TestCase
         )]);
 
         self::assertSame('Background title', $result->getTitle());
+    }
+
+    public function testItPopulatesTitleFromDescriptionWhenMultiline()
+    {
+        $result = $this->mapper->map([new FeatureChild(null,
+            new Background(new Location(), '', 'title', "across\nmany\nlines")
+        )]);
+
+        self::assertSame("title\nacross\nmany\nlines", $result->getTitle());
     }
 
     public function testItPopulatesKeyword()

--- a/tests/Behat/Gherkin/Cucumber/BackgroundNodeMapperTest.php
+++ b/tests/Behat/Gherkin/Cucumber/BackgroundNodeMapperTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Behat\Gherkin\Cucumber;
+
+use Behat\Gherkin\Node\BackgroundNode;
+use Behat\Gherkin\Node\StepNode;
+use Cucumber\Messages\Background;
+use Cucumber\Messages\FeatureChild;
+use Cucumber\Messages\Location;
+use Cucumber\Messages\Step;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group cucumber
+ */
+final class BackgroundNodeMapperTest extends TestCase
+{
+    /**
+     * @var BackgroundNodeMapper
+     */
+    private $mapper;
+
+    public function setUp() : void
+    {
+        $this->mapper = new BackgroundNodeMapper(
+            new StepNodeMapper(
+                new KeywordTypeMapper(),
+                new PyStringNodeMapper(),
+                new TableNodeMapper()
+            )
+        );
+    }
+
+    public function testItReturnsNullIfNoChildrenAreBackgrounds()
+    {
+        $result = $this->mapper->map([]);
+
+        self::assertNull($result);
+    }
+
+    public function testItReturnsABackgroundNodeIfOneIsPresent()
+    {
+        $result = $this->mapper->map([
+            new FeatureChild(null, new Background())
+        ]);
+
+        self::assertInstanceOf(BackgroundNode::class, $result);
+    }
+
+    public function testItPopulatesTitle()
+    {
+        $result = $this->mapper->map([new FeatureChild(null,
+            new Background(new Location(),'','Background title','')
+        )]);
+
+        self::assertSame('Background title', $result->getTitle());
+    }
+
+    public function testItPopulatesKeyword()
+    {
+        $result = $this->mapper->map([new FeatureChild(null,
+            new Background(new Location(),'Background','','')
+        )]);
+
+        self::assertSame('Background', $result->getKeyword());
+    }
+
+    public function testItPopulatesLine()
+    {
+        $result = $this->mapper->map([new FeatureChild(null,
+            new Background(new Location(100, 0))
+        )]);
+
+        self::assertSame(100, $result->getLine());
+    }
+
+    public function testItPopulatesSteps()
+    {
+        $result = $this->mapper->map([new FeatureChild(null,
+            new Background(new Location(), '', '', '', [
+                new Step()
+            ])
+        )]);
+
+        self::assertCount(1, $result->getSteps());
+        self::assertInstanceOf(StepNode::class, $result->getSteps()[0]);
+    }
+}

--- a/tests/Behat/Gherkin/Cucumber/CompatibilityTest.php
+++ b/tests/Behat/Gherkin/Cucumber/CompatibilityTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Behat\Gherkin\Cucumber;
+namespace Tests\Behat\Gherkin\Cucumber;
 
 use Behat\Gherkin\Exception\ParserException;
 use Behat\Gherkin\Gherkin;

--- a/tests/Behat/Gherkin/Cucumber/ExampleTableNodeMapperTest.php
+++ b/tests/Behat/Gherkin/Cucumber/ExampleTableNodeMapperTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Behat\Gherkin\Cucumber;
+
+use Cucumber\Messages\DataTable;
+use Cucumber\Messages\Examples;
+use Cucumber\Messages\Location;
+use Cucumber\Messages\TableCell;
+use Cucumber\Messages\TableRow;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group cucumber
+ */
+final class ExampleTableNodeMapperTest extends TestCase
+{
+    /**
+     * @var ExampleTableNodeMapper
+     */
+    private $mapper;
+
+    public function setUp() : void
+    {
+        $this->mapper = new ExampleTableNodeMapper();
+    }
+
+    public function testItMapsEmptyArrayToEmpty()
+    {
+        $result = $this->mapper->map([]);
+
+        self::assertSame([], $result);
+    }
+
+    public function testItMapsKeyword()
+    {
+        $tables = $this->mapper->map([
+            new Examples(new Location(), [], 'Examples')
+        ]);
+
+        self::assertCount(1, $tables);
+        self::assertSame('Examples', $tables[0]->getKeyword());
+    }
+
+    public function testItMapsHeaderAndRowsIntoOneTable()
+    {
+        {
+            $tables = $this->mapper->map([
+                new Examples(new Location(), [], '','','',
+                    new TableRow(new Location(100, 0), [
+                        new TableCell(new Location(), 'header-1'),
+                        new TableCell(new Location(), 'header-2'),
+                    ]),
+                    [
+                        new TableRow(new Location(101, 0), [
+                            new TableCell(new Location(), 'value-3'),
+                            new TableCell(new Location(), 'value-4'),
+                        ]),
+                        new TableRow(new Location(102, 0), [
+                            new TableCell(new Location(), 'value-5'),
+                            new TableCell(new Location(), 'value-6'),
+                        ])
+                    ]
+                )
+            ]);
+
+            $expectedHash = [
+                [
+                    'header-1'=>'value-3',
+                    'header-2'=>'value-4'
+                ],
+                [
+                    'header-1'=>'value-5',
+                    'header-2'=>'value-6'
+                ]
+            ];
+
+            self::assertCount(1, $tables);
+            self::assertSame($expectedHash, $tables[0]->getHash());
+        }
+    }
+
+    public function testItMapsLineFromHeaderRow()
+    {
+        $tables = $this->mapper->map([
+            new Examples(new Location(), [], '','','',
+                new TableRow(new Location(100, 0), [])
+            )
+        ]);
+
+        self::assertCount(1, $tables);
+        self::assertSame(100, $tables[0]->getLine());
+    }
+
+}

--- a/tests/Behat/Gherkin/Cucumber/ExampleTableNodeMapperTest.php
+++ b/tests/Behat/Gherkin/Cucumber/ExampleTableNodeMapperTest.php
@@ -1,12 +1,14 @@
 <?php
 
-namespace Behat\Gherkin\Cucumber;
+namespace Tests\Behat\Gherkin\Cucumber;
 
-use Cucumber\Messages\DataTable;
+use Behat\Gherkin\Cucumber\ExampleTableNodeMapper;
+use Behat\Gherkin\Cucumber\TagMapper;
 use Cucumber\Messages\Examples;
 use Cucumber\Messages\Location;
 use Cucumber\Messages\TableCell;
 use Cucumber\Messages\TableRow;
+use Cucumber\Messages\Tag;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -21,7 +23,7 @@ final class ExampleTableNodeMapperTest extends TestCase
 
     public function setUp() : void
     {
-        $this->mapper = new ExampleTableNodeMapper();
+        $this->mapper = new ExampleTableNodeMapper(new TagMapper());
     }
 
     public function testItMapsEmptyArrayToEmpty()
@@ -91,4 +93,17 @@ final class ExampleTableNodeMapperTest extends TestCase
         self::assertSame(100, $tables[0]->getLine());
     }
 
+    public function testItMapsTags()
+    {
+
+        $tables = $this->mapper->map([
+            new Examples(new Location(), [
+                new Tag(new Location(), '@foo'),
+                new Tag(new Location(), '@bar')
+            ])
+        ]);
+
+        self::assertCount(1, $tables);
+        self::assertSame(['foo', 'bar'], $tables[0]->getTags());
+    }
 }

--- a/tests/Behat/Gherkin/Cucumber/FeatureNodeMapperTest.php
+++ b/tests/Behat/Gherkin/Cucumber/FeatureNodeMapperTest.php
@@ -1,10 +1,18 @@
 <?php
 
-namespace Behat\Gherkin\Cucumber;
+namespace Tests\Behat\Gherkin\Cucumber;
 
+use Behat\Gherkin\Cucumber\BackgroundNodeMapper;
+use Behat\Gherkin\Cucumber\ExampleTableNodeMapper;
+use Behat\Gherkin\Cucumber\FeatureNodeMapper;
+use Behat\Gherkin\Cucumber\KeywordTypeMapper;
+use Behat\Gherkin\Cucumber\PyStringNodeMapper;
+use Behat\Gherkin\Cucumber\ScenarioNodeMapper;
+use Behat\Gherkin\Cucumber\StepNodeMapper;
+use Behat\Gherkin\Cucumber\TableNodeMapper;
+use Behat\Gherkin\Cucumber\TagMapper;
 use Behat\Gherkin\Node\BackgroundNode;
 use Behat\Gherkin\Node\FeatureNode;
-use Behat\Gherkin\Node\ScenarioNode;
 use Cucumber\Messages\Background;
 use Cucumber\Messages\Feature;
 use Cucumber\Messages\FeatureChild;
@@ -35,7 +43,9 @@ final class FeatureNodeMapperTest extends TestCase
             new ScenarioNodeMapper(
                 $tagMapper,
                 $stepNodeMapper,
-                new ExampleTableNodeMapper()
+                new ExampleTableNodeMapper(
+                    $tagMapper
+                )
             )
         );
     }
@@ -56,7 +66,7 @@ final class FeatureNodeMapperTest extends TestCase
         self::assertInstanceOf(FeatureNode::class, $feature);
     }
 
-    public function testItPopulatesTheTitle()
+    public function testItMapsTheTitle()
     {
         $feature = $this->mapper->map(new GherkinDocument(
             '', new Feature(new Location(), [], '', '', 'This is the feature title')
@@ -65,7 +75,7 @@ final class FeatureNodeMapperTest extends TestCase
         self::assertSame('This is the feature title', $feature->getTitle());
     }
 
-    public function testItPopulatesTheDescription()
+    public function testItMapsTheDescription()
     {
         $feature = $this->mapper->map(new GherkinDocument(
             '', new Feature(new Location(), [], '', '', '', 'This is the feature description')
@@ -74,7 +84,16 @@ final class FeatureNodeMapperTest extends TestCase
         self::assertSame('This is the feature description', $feature->getDescription());
     }
 
-    public function testItPopulatesTheKeyword()
+    public function testItTrimsTheDescription()
+    {
+        $feature = $this->mapper->map(new GherkinDocument(
+            '', new Feature(new Location(0,1), [], '', '', '', '  This is the feature description')
+        ));
+
+        self::assertSame('This is the feature description', $feature->getDescription());
+    }
+
+    public function testItMapsTheKeyword()
     {
         $feature = $this->mapper->map(new GherkinDocument(
             '', new Feature(new Location(), [], '', 'Given')
@@ -83,7 +102,7 @@ final class FeatureNodeMapperTest extends TestCase
         self::assertSame('Given', $feature->getKeyword());
     }
 
-    public function testItPopulatesTheLanguage()
+    public function testItMapsTheLanguage()
     {
         $feature = $this->mapper->map(new GherkinDocument(
             '', new Feature(new Location(), [], 'zh')
@@ -92,7 +111,7 @@ final class FeatureNodeMapperTest extends TestCase
         self::assertSame('zh', $feature->getLanguage());
     }
 
-    public function testItPopulatesTheFile()
+    public function testItMapsTheFile()
     {
         $feature = $this->mapper->map(new GherkinDocument(
             '/foo/bar.feature', new Feature()
@@ -101,7 +120,7 @@ final class FeatureNodeMapperTest extends TestCase
         self::assertSame('/foo/bar.feature', $feature->getFile());
     }
 
-    public function testItPopulatesTheLine()
+    public function testItMapsTheLine()
     {
         $feature = $this->mapper->map(new GherkinDocument(
             '', new Feature(new Location(100,0))
@@ -110,7 +129,7 @@ final class FeatureNodeMapperTest extends TestCase
         self::assertSame(100, $feature->getLine());
     }
 
-    public function testItPopulatesTheTags()
+    public function testItMapsTheTags()
     {
         $feature = $this->mapper->map(new GherkinDocument(
             '', new Feature(new Location(),[
@@ -122,7 +141,7 @@ final class FeatureNodeMapperTest extends TestCase
         self::assertSame(['foo', 'bar'], $feature->getTags());
     }
 
-    public function testItPopulatesTheBackground()
+    public function testItMapsTheBackground()
     {
         $feature = $this->mapper->map(new GherkinDocument(
             '', new Feature(new Location(), [], '', '', '', '',
@@ -133,7 +152,7 @@ final class FeatureNodeMapperTest extends TestCase
         self::assertInstanceOf(BackgroundNode::class, $feature->getBackground());
     }
 
-    public function testItPopulatesScenarios()
+    public function testItMapsScenarios()
     {
         $feature = $this->mapper->map(new GherkinDocument(
             '', new Feature(new Location(), [], '', '', '', '',

--- a/tests/Behat/Gherkin/Cucumber/FeatureNodeMapperTest.php
+++ b/tests/Behat/Gherkin/Cucumber/FeatureNodeMapperTest.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace Behat\Gherkin\Cucumber;
+
+use Behat\Gherkin\Node\BackgroundNode;
+use Behat\Gherkin\Node\FeatureNode;
+use Behat\Gherkin\Node\ScenarioNode;
+use Cucumber\Messages\Background;
+use Cucumber\Messages\Feature;
+use Cucumber\Messages\FeatureChild;
+use Cucumber\Messages\GherkinDocument;
+use Cucumber\Messages\Location;
+use Cucumber\Messages\Scenario;
+use Cucumber\Messages\Tag;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group cucumber
+ */
+final class FeatureNodeMapperTest extends TestCase
+{
+    public function setUp() : void
+    {
+        $tagMapper = new TagMapper();
+        $stepNodeMapper = new StepNodeMapper(
+            new KeywordTypeMapper(),
+            new PyStringNodeMapper(),
+            new TableNodeMapper()
+        );
+        $this->mapper = new FeatureNodeMapper(
+            $tagMapper,
+            new BackgroundNodeMapper(
+                $stepNodeMapper
+            ),
+            new ScenarioNodeMapper(
+                $tagMapper,
+                $stepNodeMapper,
+                new ExampleTableNodeMapper()
+            )
+        );
+    }
+
+    public function testItReturnsNullIfThereIsNoFeature()
+    {
+        $result = $this->mapper->map(new GherkinDocument());
+
+        self::assertSame(null, $result);
+    }
+
+    public function testItReturnsAFeatureIfThereIsOne()
+    {
+        $feature = $this->mapper->map(new GherkinDocument(
+            '', new Feature()
+        ));
+
+        self::assertInstanceOf(FeatureNode::class, $feature);
+    }
+
+    public function testItPopulatesTheTitle()
+    {
+        $feature = $this->mapper->map(new GherkinDocument(
+            '', new Feature(new Location(), [], '', '', 'This is the feature title')
+        ));
+
+        self::assertSame('This is the feature title', $feature->getTitle());
+    }
+
+    public function testItPopulatesTheDescription()
+    {
+        $feature = $this->mapper->map(new GherkinDocument(
+            '', new Feature(new Location(), [], '', '', '', 'This is the feature description')
+        ));
+
+        self::assertSame('This is the feature description', $feature->getDescription());
+    }
+
+    public function testItPopulatesTheKeyword()
+    {
+        $feature = $this->mapper->map(new GherkinDocument(
+            '', new Feature(new Location(), [], '', 'Given')
+        ));
+
+        self::assertSame('Given', $feature->getKeyword());
+    }
+
+    public function testItPopulatesTheLanguage()
+    {
+        $feature = $this->mapper->map(new GherkinDocument(
+            '', new Feature(new Location(), [], 'zh')
+        ));
+
+        self::assertSame('zh', $feature->getLanguage());
+    }
+
+    public function testItPopulatesTheFile()
+    {
+        $feature = $this->mapper->map(new GherkinDocument(
+            '/foo/bar.feature', new Feature()
+        ));
+
+        self::assertSame('/foo/bar.feature', $feature->getFile());
+    }
+
+    public function testItPopulatesTheLine()
+    {
+        $feature = $this->mapper->map(new GherkinDocument(
+            '', new Feature(new Location(100,0))
+        ));
+
+        self::assertSame(100, $feature->getLine());
+    }
+
+    public function testItPopulatesTheTags()
+    {
+        $feature = $this->mapper->map(new GherkinDocument(
+            '', new Feature(new Location(),[
+                new Tag(new Location(), '@foo'),
+                new Tag(new Location(), '@bar')
+            ])
+        ));
+
+        self::assertSame(['foo', 'bar'], $feature->getTags());
+    }
+
+    public function testItPopulatesTheBackground()
+    {
+        $feature = $this->mapper->map(new GherkinDocument(
+            '', new Feature(new Location(), [], '', '', '', '',
+            [new FeatureChild(null, new Background())]
+            )
+        ));
+
+        self::assertInstanceOf(BackgroundNode::class, $feature->getBackground());
+    }
+
+    public function testItPopulatesScenarios()
+    {
+        $feature = $this->mapper->map(new GherkinDocument(
+            '', new Feature(new Location(), [], '', '', '', '',
+                [new FeatureChild(null, null, new Scenario())]
+            )
+        ));
+
+        self::assertCount(1, $feature->getScenarios());
+    }
+}

--- a/tests/Behat/Gherkin/Cucumber/KeywordTypeMapperTest.php
+++ b/tests/Behat/Gherkin/Cucumber/KeywordTypeMapperTest.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace Behat\Gherkin\Cucumber;
+namespace Tests\Behat\Gherkin\Cucumber;
 
+use Behat\Gherkin\Cucumber\KeywordTypeMapper;
 use Cucumber\Messages\Step\KeywordType;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Behat/Gherkin/Cucumber/KeywordTypeMapperTest.php
+++ b/tests/Behat/Gherkin/Cucumber/KeywordTypeMapperTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Behat\Gherkin\Cucumber;
+
+use Cucumber\Messages\Step\KeywordType;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group cucumber
+ */
+final class KeywordTypeMapperTest extends TestCase
+{
+    public function setUp() : void
+    {
+        $this->mapper = new KeywordTypeMapper();
+    }
+
+    /**
+     * @dataProvider regularKeywords
+     */
+    public function testItMapsRegularKeywordsCorrectly($expected, KeywordType $input)
+    {
+        self::assertSame($expected, $this->mapper->map($input, null));
+    }
+
+    public function regularKeywords()
+    {
+        yield ['Given', KeywordType::CONTEXT];
+        yield ['When', KeywordType::ACTION];
+        yield ['Then', KeywordType::OUTCOME];
+    }
+
+    public function testItMapsToGivenIfNullIsPassed()
+    {
+        self::assertSame('Given', $this->mapper->map(null, null));
+    }
+
+    public function testItMapsToGivenIfUnknownIsPassed()
+    {
+        self::assertSame('Given', $this->mapper->map(KeywordType::UNKNOWN, null));
+    }
+
+    public function testItMapsToGivenIfConjunctionIsFirstStep()
+    {
+        self::assertSame('Given', $this->mapper->map(KeywordType::CONJUNCTION, null));
+    }
+
+    public function testItMapsConjunctionToPreviousType()
+    {
+        self::assertSame('When', $this->mapper->map(KeywordType::CONJUNCTION, 'When'));
+    }
+}

--- a/tests/Behat/Gherkin/Cucumber/MultilineStringFormatterTest.php
+++ b/tests/Behat/Gherkin/Cucumber/MultilineStringFormatterTest.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+
+namespace Behat\Gherkin\Cucumber;
+
+use Cucumber\Messages\Location;
+use PHPUnit\Framework\TestCase;
+
+/** @group cucumber */
+final class MultilineStringFormatterTest extends TestCase
+{
+    public function testItLeftTrimsAString()
+    {
+        $input = <<<EOF
+  foo
+  bar
+EOF;
+        $expected = <<<EOF
+foo
+bar
+EOF;
+
+        self::assertSame($expected, MultilineStringFormatter::format($input));
+    }
+
+    public function testItRightTrimsAString()
+    {
+        $input = "foo   \nbar   ";
+        $expected = "foo\nbar";
+
+        self::assertSame($expected, MultilineStringFormatter::format($input));
+    }
+
+    public function testItDoesNotLeftTrimAStringMoreThanTwoLinesPastIndent()
+    {
+        $input = <<<EOF
+      foo
+      bar
+EOF;
+        $expected = <<<EOF
+  foo
+  bar
+EOF;
+
+        self::assertSame($expected, MultilineStringFormatter::format($input, new Location(0,3)));
+    }
+}

--- a/tests/Behat/Gherkin/Cucumber/PyStringNodeMapperTest.php
+++ b/tests/Behat/Gherkin/Cucumber/PyStringNodeMapperTest.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace Behat\Gherkin\Cucumber;
+namespace Tests\Behat\Gherkin\Cucumber;
 
+use Behat\Gherkin\Cucumber\PyStringNodeMapper;
 use Cucumber\Messages\DocString;
 use Cucumber\Messages\Location;
 use PHPUnit\Framework\TestCase;

--- a/tests/Behat/Gherkin/Cucumber/PyStringNodeMapperTest.php
+++ b/tests/Behat/Gherkin/Cucumber/PyStringNodeMapperTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Behat\Gherkin\Cucumber;
+
+use Cucumber\Messages\DocString;
+use Cucumber\Messages\Location;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group cucumber
+ */
+final class PyStringNodeMapperTest extends TestCase
+{
+    /**
+     * @var PyStringNodeMapper
+     */
+    private $mapper;
+
+    public function setUp() : void
+    {
+        $this->mapper = new PyStringNodeMapper();
+    }
+
+    public function testItMapsNullToEmpty()
+    {
+        $result = $this->mapper->map(null);
+
+        self::assertSame([], $result);
+    }
+
+    public function testItMapsLine()
+    {
+        $stringNodes = $this->mapper->map(new DocString(new Location(100, 0)));
+
+        self::assertCount(1, $stringNodes);
+        self::assertSame(100, $stringNodes[0]->getLine());
+    }
+
+    public function testItMapsStringSplitByNewline()
+    {
+        $stringNodes = $this->mapper->map(new DocString(new Location(), '', "foo\nbar\r\nbaz"));
+
+        self::assertCount(1, $stringNodes);
+        self::assertSame(['foo','bar','baz'], $stringNodes[0]->getStrings());
+    }
+}

--- a/tests/Behat/Gherkin/Cucumber/ScenarioNodeMapperTest.php
+++ b/tests/Behat/Gherkin/Cucumber/ScenarioNodeMapperTest.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace Behat\Gherkin\Cucumber;
+
+use Behat\Gherkin\Node\OutlineNode;
+use Behat\Gherkin\Node\ScenarioNode;
+use Cucumber\Messages\Examples;
+use Cucumber\Messages\FeatureChild;
+use Cucumber\Messages\Location;
+use Cucumber\Messages\Scenario;
+use Cucumber\Messages\Step;
+use Cucumber\Messages\Tag;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group cucumber
+ */
+final class ScenarioNodeMapperTest extends TestCase
+{
+    /**
+     * @var ScenarioNodeMapper
+     */
+    private $mapper;
+
+    public function setUp() : void
+    {
+        $this->mapper = new ScenarioNodeMapper(
+            new TagMapper(),
+            new StepNodeMapper(
+                new KeywordTypeMapper(),
+                new PyStringNodeMapper(),
+                new TableNodeMapper()
+            ),
+            new ExampleTableNodeMapper()
+        );
+    }
+
+    public function testItMapsEmptyArrayToEmpty()
+    {
+        $result = $this->mapper->map([]);
+
+        self::assertSame([], $result);
+    }
+
+    public function testItMapsAScenario()
+    {
+        $scenarios = $this->mapper->map([new FeatureChild(null, null,
+            new Scenario(new Location())
+        )]);
+
+        self::assertCount(1, $scenarios);
+        self::assertInstanceOf(ScenarioNode::class, $scenarios[0]);
+    }
+
+    public function testItMapsScenarioTitle()
+    {
+        $scenarios = $this->mapper->map([new FeatureChild(null, null,
+            new Scenario(new Location(), [], '', 'Scenario title')
+        )]);
+
+        self::assertCount(1, $scenarios);
+        self::assertSame('Scenario title', $scenarios[0]->getTitle());
+    }
+
+    public function testItMapsDescriptionAsMultiLineScenarioTitle()
+    {
+        $scenarios = $this->mapper->map([new FeatureChild(null, null,
+            new Scenario(new Location(), [], '', 'title', "across\nmany\nlines")
+        )]);
+
+        self::assertCount(1, $scenarios);
+        self::assertSame("title\nacross\nmany\nlines", $scenarios[0]->getTitle());
+    }
+
+    public function testItMapsScenarioKeyword()
+    {
+        $scenarios = $this->mapper->map([new FeatureChild(null, null,
+            new Scenario(new Location(), [], 'Scenario', '')
+        )]);
+
+        self::assertCount(1, $scenarios);
+        self::assertSame('Scenario', $scenarios[0]->getKeyword());
+    }
+
+    public function testItMapsScenarioLine()
+    {
+        $scenarios = $this->mapper->map([new FeatureChild(null, null,
+            new Scenario(new Location(100, 0))
+        )]);
+
+        self::assertCount(1, $scenarios);
+        self::assertSame(100, $scenarios[0]->getLine());
+    }
+
+    public function testItMapsScenarioTags()
+    {
+        $scenarios = $this->mapper->map([new FeatureChild(null, null,
+            new Scenario(new Location(), [new Tag(new Location(), 'foo')])
+        )]);
+
+        self::assertCount(1, $scenarios);
+        self::assertSame(['foo'], $scenarios[0]->getTags());
+    }
+
+    public function testItMapsScenarioSteps()
+    {
+        $scenarios = $this->mapper->map([new FeatureChild(null, null,
+            new Scenario(new Location(), [], '', '', '',
+                [new Step() ]
+            )
+        )]);
+
+        self::assertCount(1, $scenarios);
+        self::assertCount(1, $scenarios[0]->getSteps());
+    }
+
+    public function testItMapsScenarioWithExamplesAsScenarioOutline()
+    {
+        $scenarios = $this->mapper->map([new FeatureChild(null, null,
+            new Scenario(new Location(), [], '', '', '', [],
+                [new Examples()]
+            )
+        )]);
+
+        self::assertCount(1, $scenarios);
+        self::assertInstanceOf(OutlineNode::class, $scenarios[0]);
+    }
+
+    public function testItMapsExamples()
+    {
+        $scenarios = $this->mapper->map([new FeatureChild(null, null,
+            new Scenario(new Location(), [], '', '', '', [],
+                [new Examples()]
+            )
+        )]);
+
+        self::assertCount(1, $scenarios);
+        self::assertCount(1, $scenarios[0]->getExampleTables());
+    }
+}

--- a/tests/Behat/Gherkin/Cucumber/ScenarioNodeMapperTest.php
+++ b/tests/Behat/Gherkin/Cucumber/ScenarioNodeMapperTest.php
@@ -1,7 +1,14 @@
 <?php
 
-namespace Behat\Gherkin\Cucumber;
+namespace Tests\Behat\Gherkin\Cucumber;
 
+use Behat\Gherkin\Cucumber\ExampleTableNodeMapper;
+use Behat\Gherkin\Cucumber\KeywordTypeMapper;
+use Behat\Gherkin\Cucumber\PyStringNodeMapper;
+use Behat\Gherkin\Cucumber\ScenarioNodeMapper;
+use Behat\Gherkin\Cucumber\StepNodeMapper;
+use Behat\Gherkin\Cucumber\TableNodeMapper;
+use Behat\Gherkin\Cucumber\TagMapper;
 use Behat\Gherkin\Node\OutlineNode;
 use Behat\Gherkin\Node\ScenarioNode;
 use Cucumber\Messages\Examples;
@@ -24,14 +31,17 @@ final class ScenarioNodeMapperTest extends TestCase
 
     public function setUp() : void
     {
+        $tagMapper = new TagMapper();
         $this->mapper = new ScenarioNodeMapper(
-            new TagMapper(),
+            $tagMapper,
             new StepNodeMapper(
                 new KeywordTypeMapper(),
                 new PyStringNodeMapper(),
                 new TableNodeMapper()
             ),
-            new ExampleTableNodeMapper()
+            new ExampleTableNodeMapper(
+                $tagMapper
+            )
         );
     }
 
@@ -70,6 +80,16 @@ final class ScenarioNodeMapperTest extends TestCase
 
         self::assertCount(1, $scenarios);
         self::assertSame("title\nacross\nmany\nlines", $scenarios[0]->getTitle());
+    }
+
+    public function testItTrimsScenarioTitle()
+    {
+        $scenarios = $this->mapper->map([new FeatureChild(null, null,
+            new Scenario(new Location(0,1), [], '', '  title')
+        )]);
+
+        self::assertCount(1, $scenarios);
+        self::assertSame("title", $scenarios[0]->getTitle());
     }
 
     public function testItMapsScenarioKeyword()

--- a/tests/Behat/Gherkin/Cucumber/StepNodeMapperTest.php
+++ b/tests/Behat/Gherkin/Cucumber/StepNodeMapperTest.php
@@ -1,7 +1,11 @@
 <?php
 
-namespace Behat\Gherkin\Cucumber;
+namespace Tests\Behat\Gherkin\Cucumber;
 
+use Behat\Gherkin\Cucumber\KeywordTypeMapper;
+use Behat\Gherkin\Cucumber\PyStringNodeMapper;
+use Behat\Gherkin\Cucumber\StepNodeMapper;
+use Behat\Gherkin\Cucumber\TableNodeMapper;
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\StepNode;
 use Behat\Gherkin\Node\TableNode;

--- a/tests/Behat/Gherkin/Cucumber/StepNodeMapperTest.php
+++ b/tests/Behat/Gherkin/Cucumber/StepNodeMapperTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Behat\Gherkin\Cucumber;
+
+use Behat\Gherkin\Node\PyStringNode;
+use Behat\Gherkin\Node\StepNode;
+use Behat\Gherkin\Node\TableNode;
+use Cucumber\Messages\DataTable;
+use Cucumber\Messages\DocString;
+use Cucumber\Messages\Location;
+use Cucumber\Messages\Step;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group cucumber
+ */
+final class StepNodeMapperTest extends TestCase
+{
+    /**
+     * @var StepNodeMapper
+     */
+    private $mapper;
+
+    public function setUp() : void
+    {
+        $this->mapper = new StepNodeMapper(
+            new KeywordTypeMapper(),
+            new PyStringNodeMapper(),
+            new TableNodeMapper()
+        );
+    }
+
+    public function testItMapsEmptyArray()
+    {
+        $steps = $this->mapper->map([]);
+
+        self::assertSame([], $steps);
+    }
+
+    public function testItMapsSteps()
+    {
+        $steps = $this->mapper->map([new Step()]);
+
+        self::assertCount(1, $steps);
+        self::assertInstanceOf(StepNode::class, $steps[0]);
+    }
+
+    public function testItMapsKeyword()
+    {
+        $steps = $this->mapper->map([new Step(
+            new Location(), 'Given '
+        )]);
+        $step = $steps[0];
+
+        self::assertSame('Given', $step->getKeyword());
+    }
+
+    public function testItMapsText()
+    {
+        $steps = $this->mapper->map([new Step(
+            new Location(), '', null, 'I have five carrots'
+        )]);
+        $step = $steps[0];
+
+        self::assertSame('I have five carrots', $step->getText());
+    }
+
+    public function testItMapsLine()
+    {
+        $steps = $this->mapper->map([new Step(
+            new Location(100, 0)
+        )]);
+        $step = $steps[0];
+
+        self::assertSame(100, $step->getLine());
+    }
+
+    public function testItMapsKeywordType()
+    {
+        $steps = $this->mapper->map([new Step(
+            new Location(), '', Step\KeywordType::CONTEXT
+        )]);
+        $step = $steps[0];
+
+        self::assertSame('Given', $step->getKeywordType());
+    }
+
+    public function testItMapsDocstringsToArguments()
+    {
+        $steps = $this->mapper->map([new Step(
+            new Location(), '', null,'', new DocString()
+        )]);
+        $step = $steps[0];
+
+        self::assertCount(1, $step->getArguments());
+        self::assertInstanceOf(PyStringNode::class, $step->getArguments()[0]);
+    }
+
+    public function testItMapsTablesToArguments()
+    {
+        $steps = $this->mapper->map([new Step(
+            new Location(), '', null,'', null, new DataTable()
+        )]);
+        $step = $steps[0];
+
+        self::assertCount(1, $step->getArguments());
+        self::assertInstanceOf(TableNode::class, $step->getArguments()[0]);
+    }
+}

--- a/tests/Behat/Gherkin/Cucumber/TableNodeMapperTest.php
+++ b/tests/Behat/Gherkin/Cucumber/TableNodeMapperTest.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace Behat\Gherkin\Cucumber;
+namespace Tests\Behat\Gherkin\Cucumber;
 
+use Behat\Gherkin\Cucumber\TableNodeMapper;
 use Cucumber\Messages\DataTable;
 use Cucumber\Messages\Location;
 use Cucumber\Messages\TableCell;

--- a/tests/Behat/Gherkin/Cucumber/TableNodeMapperTest.php
+++ b/tests/Behat/Gherkin/Cucumber/TableNodeMapperTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Behat\Gherkin\Cucumber;
+
+use Cucumber\Messages\DataTable;
+use Cucumber\Messages\Location;
+use Cucumber\Messages\TableCell;
+use Cucumber\Messages\TableRow;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group cucumber
+ */
+final class TableNodeMapperTest extends TestCase
+{
+    /**
+     * @var TableNodeMapper
+     */
+    private $mapper;
+
+    public function setUp() : void
+    {
+        $this->mapper = new TableNodeMapper();
+    }
+
+    public function testItMapsNullToEmptyArray()
+    {
+        $result = $this->mapper->map(null);
+
+        self::assertSame([], $result);
+    }
+
+    public function testItMapsCells()
+    {
+        $tables = $this->mapper->map(
+            new DataTable(new Location(), [
+                new TableRow(new Location(), [
+                    new TableCell(new Location(100, 10), 'foo'),
+                    new TableCell(new Location(100, 20), 'bar')
+                ]),
+                new TableRow(new Location(101, 0), [
+                    new TableCell(new Location(101, 10), 'baz'),
+                    new TableCell(new Location(101, 20), 'boz')
+                ])
+            ])
+        );
+
+        self::assertCount(1, $tables);
+        self::assertSame(['foo', 'bar'], $tables[0]->getRow(0));
+        self::assertSame(['baz', 'boz'], $tables[0]->getRow(1));
+    }
+
+    public function testItMapsLineFromFirstTableRow()
+    {
+        $tables = $this->mapper->map(
+            new DataTable(new Location(), [
+                new TableRow(new Location(100, 10), [
+                    new TableCell(new Location(), 'foo')
+                ])
+            ])
+        );
+
+        self::assertCount(1, $tables);
+        self::assertSame(100, $tables[0]->getLine());
+    }
+}

--- a/tests/Behat/Gherkin/Fixtures/etalons/ru_addition.yml
+++ b/tests/Behat/Gherkin/Fixtures/etalons/ru_addition.yml
@@ -17,5 +17,5 @@ feature:
       steps:
         - { keyword_type: 'Given', type: 'Допустим', text: 'я ввожу число 50',                   line: 8 }
         - { keyword_type: 'Given', type: 'И',        text: 'затем ввожу число 70',               line: 9 }
-        - { keyword_type: 'Then',  type: 'Если',     text: 'я нажимаю "+"',                      line: 10 }
-        - { keyword_type: 'When',  type: 'То',       text: 'результатом должно быть число 120',  line: 11 }
+        - { keyword_type: 'When',  type: 'Если',     text: 'я нажимаю "+"',                      line: 10 }
+        - { keyword_type: 'Then',  type: 'То',       text: 'результатом должно быть число 120',  line: 11 }

--- a/tests/Behat/Gherkin/Fixtures/etalons/ru_consecutive_calculations.yml
+++ b/tests/Behat/Gherkin/Fixtures/etalons/ru_consecutive_calculations.yml
@@ -20,15 +20,15 @@ feature:
       title:    сложение с результатом последней операций
       line:     9
       steps:
-        - { keyword_type: Then, type: Если, text: 'я ввожу число 4',                  line: 10 }
-        - { keyword_type: Then, type: И,    text: 'нажимаю "+"',                      line: 11 }
-        - { keyword_type: When, type: То,   text: 'результатом должно быть число 12', line: 12 }
+        - { keyword_type: When, type: Если, text: 'я ввожу число 4',                  line: 10 }
+        - { keyword_type: When, type: И,    text: 'нажимаю "+"',                      line: 11 }
+        - { keyword_type: Then, type: То,   text: 'результатом должно быть число 12', line: 12 }
     -
       type:     scenario
       keyword:  Сценарий
       title:    деление результата последней операции
       line:     14
       steps:
-        - { keyword_type: Then, type: Если, text: 'я ввожу число 2',                  line: 15 }
-        - { keyword_type: Then, type: И,    text: 'нажимаю "/"',                      line: 16 }
-        - { keyword_type: When, type: То,   text: 'результатом должно быть число 4',  line: 17 }
+        - { keyword_type: When, type: Если, text: 'я ввожу число 2',                  line: 15 }
+        - { keyword_type: When, type: И,    text: 'нажимаю "/"',                      line: 16 }
+        - { keyword_type: Then, type: То,   text: 'результатом должно быть число 4',  line: 17 }

--- a/tests/Behat/Gherkin/Fixtures/etalons/ru_division.yml
+++ b/tests/Behat/Gherkin/Fixtures/etalons/ru_division.yml
@@ -16,8 +16,8 @@ feature:
       steps:
         - { keyword_type: Given, type: 'Допустим', text: 'я ввожу число <делимое>',                  line: 7 }
         - { keyword_type: Given, type: 'И',        text: 'затем ввожу число <делитель>',             line: 8 }
-        - { keyword_type: Then,  type: 'Если',     text: 'я нажимаю "/"',                            line: 9 }
-        - { keyword_type: When,  type: 'То',       text: 'результатом должно быть число <частное>',  line: 10 }
+        - { keyword_type: When,  type: 'Если',     text: 'я нажимаю "/"',                            line: 9 }
+        - { keyword_type: Then,  type: 'То',       text: 'результатом должно быть число <частное>',  line: 10 }
 
       examples:
         keyword: Примеры

--- a/tests/Behat/Gherkin/Fixtures/etalons/rules.yml
+++ b/tests/Behat/Gherkin/Fixtures/etalons/rules.yml
@@ -1,0 +1,14 @@
+feature:
+  title:        ''
+  language:     en
+  line:         1
+  description:  ~
+
+  scenarios:
+    -
+      type:     scenario
+      title:    ''
+      tags:     [rule-tag, scenario-tag]
+      line:     7
+      steps:
+        - { keyword_type: Given, type: Given, text: A, line: 8 }

--- a/tests/Behat/Gherkin/Fixtures/features/rules.feature
+++ b/tests/Behat/Gherkin/Fixtures/features/rules.feature
@@ -1,0 +1,8 @@
+Feature:
+
+  @rule-tag
+  Rule:
+
+    @scenario-tag
+    Scenario:
+      Given A

--- a/tests/Behat/Gherkin/ParserTest.php
+++ b/tests/Behat/Gherkin/ParserTest.php
@@ -15,36 +15,6 @@ class ParserTest extends TestCase
     private $gherkin;
     private $yaml;
 
-    public function parserTestDataProvider()
-    {
-        $data = array();
-
-        foreach (glob(__DIR__ . '/Fixtures/etalons/*.yml') as $file) {
-            $testname = basename($file, '.yml');
-
-            $data[$testname] = array($testname);
-        }
-
-        return $data;
-    }
-
-    /**
-     * @dataProvider parserTestDataProvider
-     *
-     * @param string $fixtureName name of the fixture
-     */
-    public function testParser($fixtureName)
-    {
-        $etalon = $this->parseEtalon($fixtureName . '.yml');
-        $features = $this->parseFixture($fixtureName . '.feature');
-
-        $this->assertIsArray($features);
-        $this->assertEquals(1, count($features));
-        $fixture = $features[0];
-
-        $this->assertEquals($etalon, $fixture);
-    }
-
     public function testParserResetsTagsBetweenFeatures()
     {
         $parser = $this->getGherkinParser();
@@ -97,70 +67,12 @@ FEATURE
                     'then'             => 'Then',
                     'and'              => 'And',
                     'but'              => 'But'
-                ),
-                'ru' => array(
-                    'feature'          => 'Функционал',
-                    'background'       => 'Предыстория',
-                    'scenario'         => 'Сценарий',
-                    'scenario_outline' => 'Структура сценария',
-                    'examples'         => 'Примеры',
-                    'given'            => 'Допустим',
-                    'when'             => 'То',
-                    'then'             => 'Если',
-                    'and'              => 'И',
-                    'but'              => 'Но'
-                ),
-                'ja' => array (
-                    'feature'           => 'フィーチャ',
-                    'background'        => '背景',
-                    'scenario'          => 'シナリオ',
-                    'scenario_outline'  => 'シナリオアウトライン',
-                    'examples'          => '例|サンプル',
-                    'given'             => '前提<',
-                    'when'              => 'もし<',
-                    'then'              => 'ならば<',
-                    'and'               => 'かつ<',
-                    'but'               => 'しかし<'
                 )
             ));
             $this->gherkin  = new Parser(new Lexer($keywords));
         }
 
         return $this->gherkin;
-    }
-
-    protected function getYamlParser()
-    {
-        if (null === $this->yaml) {
-            $this->yaml = new YamlFileLoader();
-        }
-
-        return $this->yaml;
-    }
-
-    protected function parseFixture($fixture)
-    {
-        $file = __DIR__ . '/Fixtures/features/' . $fixture;
-
-        return array($this->getGherkinParser()->parse(file_get_contents($file), $file));
-    }
-
-    protected function parseEtalon($etalon)
-    {
-        $features = $this->getYamlParser()->load(__DIR__ . '/Fixtures/etalons/' . $etalon);
-        $feature  = $features[0];
-
-        return new FeatureNode(
-            $feature->getTitle(),
-            $feature->getDescription(),
-            $feature->getTags(),
-            $feature->getBackground(),
-            $feature->getScenarios(),
-            $feature->getKeyword(),
-            $feature->getLanguage(),
-            __DIR__ . '/Fixtures/features/' . basename($etalon, '.yml') . '.feature',
-            $feature->getLine()
-        );
     }
 
     public function testParsingManyCommentsShouldPass()


### PR DESCRIPTION
This adds a compatibility layer that can be used when `cucumber/gherkin` is also installed, that uses that parser instead and then maps the result back to our 'regular' AST for Behat (and maybe Codeception?) to consume.

This means that when parsing edge cases we will conform much more closely with the cucumber core implementations. It also means newer syntax items will be ignored / handled more cleanly rather than triggering odd parsing errors

To avoid bumping the minimum PHP version we support, this does not depend directly on `cucumber/gherkin`; instead there is a static `CucumberGherkinLoader::isAvailable()` method that can be called to see if the CucumberGherkinLoader can be used instead of the regular one, e.g. 

```php
if (
  class_exists(CucumberGherkinLoader::class) // if supporting older behat/gherkin
  && CucumberGherkinLoader::isAvailable()
) {
   $parser = new CucumberGherkinLoader(...)
} 
else {
   $parser = new GherkinFileLoader(...)
}
```

An alternative option to this would be to merge this into cucumber/gherkin 5.0.0 and let that require cucumber/gherkin (and PHP 8.1), then the version detection can move to Behat - I'm not sure that's warranted yet

## Motivation

Moving to the cucumber parser entirely will reduce the maintenance effort on Behat, and unlock newer features we didn't support yet. 

That's a big refactor though, and this goes someway towards it by enabling Behat to introduce the cucumber parser partially as an experimental feature (behind a config flag) to detect feature files in the wild that are unparsable, or parsed in unexpected ways.

## Compatibility

 - Passes the behat/gherkin etalon tests (tests in PR) with one exception (see Known incompatibilities)
 - Passes the entire behat/behat test suite (manually tested by me)

## Mapping notes

The majority of the mapping is simple from one tree to another, aside from a few places where the Behat AST doesn't support a feature:

### Multi-line scenario/background/outline names

```Gherkin
Scenario: Something awesome
   Something amazing
```

Cucumber sees this as Scenario with `name: 'Something awesome'` and `description: 'Something amazing'`. For compatibility we map this as a multi-line scenario name (which cucumber does not support but Behat does) so `title: "Something awesome\nSomething amazing"`

### Descriptions trimming

Cucumber preserves whitespaces in descriptions, Behat right and left-trims them based on how indented the previous keyword is. This logic is retained to be as like Behat as possible.

### Rule support

Cucumber supports scenarios inside tagged Rules:

```Gherkin
Feature:

    @foo
    Scenario:

    @bar
    Rule:

        @baz
        Scenario:
```

Because the Behat AST doesn't support Rule, this will be flattened into the same AST as this feature:

```Gherkin
Feature:

    @foo
    Scenario:


   

        @bar @baz
        Scenario:
```

This will enable implementations to parse files with Rule, and to use tags from Rule keywords when filtering examples

##  Known incompatibilities

There will doubtless be incompatibilities in the wild, but most will be around 'odd' Gherkin. The following are known:

### Comments at the end of Feature description no longer work

[Cucumber has a bug about this](https://github.com/cucumber/common/issues/1413) so one of the test files has had to be excluded.

### Backgrounds inside Rules do not work

There's no sensible way to map Background up into the Feature level and only have it apply to some scenarios, therefore we throw a parser error if it happens.

This syntax is discouraged by Cucumber anyhow