### PR TITLE
Make nullable type explicit

### DIFF
--- a/src/Behat/Gherkin/Loader/GherkinFileLoader.php
+++ b/src/Behat/Gherkin/Loader/GherkinFileLoader.php
@@ -30,7 +30,7 @@ class GherkinFileLoader extends AbstractFileLoader
      * @param Parser         $parser Parser
      * @param CacheInterface $cache  Cache layer
      */
-    public function __construct(Parser $parser, CacheInterface $cache = null)
+    public function __construct(Parser $parser, ?CacheInterface $cache = null)
     {
         $this->parser = $parser;
         $this->cache = $cache;


### PR DESCRIPTION
This makes the nullable CacheInterface explicitly nullable. Previously the default value of `null` made the parameter implicitly nullable. That behaviour has been deprecated in PHP8.4 which caused a deprecation message for this package.

Making this explicit now removes the deprecation message