### PR TITLE
PHP 8.4 | FeatureNode: fix implicitly nullable parameter

### DIFF
--- a/src/Behat/Gherkin/Node/FeatureNode.php
+++ b/src/Behat/Gherkin/Node/FeatureNode.php
@@ -71,7 +71,7 @@ class FeatureNode implements KeywordNodeInterface, TaggedNodeInterface
         $title,
         $description,
         array $tags,
-        BackgroundNode $background = null,
+        ?BackgroundNode $background,
         array $scenarios,
         $keyword,
         $language,


### PR DESCRIPTION
Follow up to #258

PHP 8.4 deprecates implicitly nullable parameters, i.e. typed parameters with a `null` default value, which are not explicitly declared as nullable.

This commit fixes the last instance of that in the codebase.

Also note that this was effectively an "optional parameter before a required one", so the default value of `null` needs to be removed as well.

Ref: https://wiki.php.net/rfc/deprecate-implicitly-nullable-types

@heiglandreas Would you like to look over ? (seeing that you pulled the prior PR)