### PR TITLE
GH Actions/tests: use "develop" ini file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,7 @@ jobs:
           uses: shivammathur/setup-php@v2
           with:
             php-version: "${{ matrix.php }}"
+            ini-file: "development"
             coverage: none
 
       -   name: Update Symfony version


### PR DESCRIPTION
By default setupPHP uses the `production` ini file, which silences some errors. Changing this to the `development` ini file should surface all errors when running the tests.