### PR TITLE
.gitattributes: clean up

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,8 @@
+/.github/ export-ignore
 /bin/ export-ignore
 /tests export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore
-/.travis.yml export-ignore
 /package.xml.tpl export-ignore
 /phpdoc.ini.dist export-ignore
 /phpunit.xml.dist export-ignore


### PR DESCRIPTION
The `.travis.yml` has been long removed and sort of replaced by the `.github` directory, but the `.github` directory was not being export-ignored, so is currently shipped with releases, while it shouldn't be.