### PR TITLE
GH Actions: don't run cron job on forks

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -6,6 +6,9 @@ on:
 
 jobs:
   cucumber-update:
+    # Don't run the cron job on forks.
+    if: ${{ github.event_name != 'schedule' || github.repository == 'Behat/Gherkin' }}
+
     runs-on: ubuntu-latest
     name: Upstream cucumber update
     steps:


### PR DESCRIPTION
Noticed a PR had been automatically opened on my fork. Typically cron-jobs which should not run on forks.