### PR TITLE
Improve title handling, especially for example scenarios 

### DIFF
--- a/src/Behat/Gherkin/Node/ExampleNode.php
+++ b/src/Behat/Gherkin/Node/ExampleNode.php
@@ -97,12 +97,11 @@ class ExampleNode implements ScenarioInterface
      *
      * @return string
      *
-     * @deprecated You should normally not depend on the original row text, but if you really do, just switch to {@see self::getExampleText()}.
+     * @deprecated You should normally not depend on the original row text, but if you really do, please switch
+     *             to {@see self::getExampleText()} as this method will be removed in the next major version.
      */
     public function getTitle()
     {
-        @trigger_error('`ExampleNode::getTitle()` calls should be migrated to `ExampleNode::getScenarioTitle()` or `ExampleNode::getExampleText()`.', E_USER_DEPRECATED);
-
         return $this->text;
     }
 
@@ -189,11 +188,11 @@ class ExampleNode implements ScenarioInterface
     }
 
     /**
-     * Returns title for this scenario outline example.
+     * Returns the name of the scenario example.
      *
      * @return string
      */
-    public function getScenarioTitle()
+    public function getName()
     {
         return "{$this->replaceTextTokens($this->outlineTitle)} #{$this->index}";
     }

--- a/src/Behat/Gherkin/Node/ExampleNode.php
+++ b/src/Behat/Gherkin/Node/ExampleNode.php
@@ -197,11 +197,9 @@ class ExampleNode implements ScenarioInterface, NamedScenarioInterface
      *
      * You should normally not need this, since it is an implementation detail.
      * If you need the individual example values, use {@see self::getTokens()}.
-     * To get the fully-normalised/expanded title, use {@see self::getScenarioTitle()}.
-     *
-     * @return string
+     * To get the fully-normalised/expanded title, use {@see self::getName()}.
      */
-    public function getExampleText()
+    public function getExampleText(): string
     {
         return $this->text;
     }

--- a/src/Behat/Gherkin/Node/ExampleNode.php
+++ b/src/Behat/Gherkin/Node/ExampleNode.php
@@ -15,7 +15,7 @@ namespace Behat\Gherkin\Node;
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-class ExampleNode implements ScenarioInterface
+class ExampleNode implements ScenarioInterface, NamedScenarioInterface
 {
     /**
      * @var string
@@ -187,12 +187,7 @@ class ExampleNode implements ScenarioInterface
         return $this->outlineTitle;
     }
 
-    /**
-     * Returns the name of the scenario example.
-     *
-     * @return string
-     */
-    public function getName()
+    public function getName(): ?string
     {
         return "{$this->replaceTextTokens($this->outlineTitle)} #{$this->index}";
     }

--- a/src/Behat/Gherkin/Node/ExampleNode.php
+++ b/src/Behat/Gherkin/Node/ExampleNode.php
@@ -59,7 +59,7 @@ class ExampleNode implements ScenarioInterface, NamedScenarioInterface
      * @param string[]    $tokens
      * @param integer     $line         Line number within the feature file.
      * @param string|null $outlineTitle Original title of the scenario outline.
-     * @param null|int    $index        The 0-based index of the row/example within the scenario outline.
+     * @param null|int    $index        The 1-based index of the row/example within the scenario outline.
      */
     public function __construct($text, array $tags, $outlineSteps, array $tokens, $line, $outlineTitle = null, $index = null)
     {

--- a/src/Behat/Gherkin/Node/ExampleNode.php
+++ b/src/Behat/Gherkin/Node/ExampleNode.php
@@ -20,7 +20,7 @@ class ExampleNode implements ScenarioInterface
     /**
      * @var string
      */
-    private $title;
+    private $text;
     /**
      * @var string[]
      */
@@ -45,25 +45,31 @@ class ExampleNode implements ScenarioInterface
      * @var string
      */
     private $outlineTitle;
+    /**
+     * @var null|int
+     */
+    private $index;
 
     /**
      * Initializes outline.
      *
-     * @param string      $title
+     * @param string      $text         The entire row as a string, e.g. "| 1 | 2 | 3 |"
      * @param string[]    $tags
      * @param StepNode[]  $outlineSteps
      * @param string[]    $tokens
-     * @param integer     $line
-     * @param string|null $outlineTitle
+     * @param integer     $line         Line number within the feature file.
+     * @param string|null $outlineTitle Original title of the scenario outline.
+     * @param null|int    $index        The 0-based index of the row/example within the scenario outline.
      */
-    public function __construct($title, array $tags, $outlineSteps, array $tokens, $line, $outlineTitle = null)
+    public function __construct($text, array $tags, $outlineSteps, array $tokens, $line, $outlineTitle = null, $index = null)
     {
-        $this->title = $title;
+        $this->text = $text;
         $this->tags = $tags;
         $this->outlineSteps = $outlineSteps;
         $this->tokens = $tokens;
         $this->line = $line;
         $this->outlineTitle = $outlineTitle;
+        $this->index = $index;
     }
 
     /**
@@ -87,13 +93,17 @@ class ExampleNode implements ScenarioInterface
     }
 
     /**
-     * Returns example title.
+     * Returns the example row as a single string.
      *
      * @return string
+     *
+     * @deprecated You should normally not depend on the original row text, but if you really do, just switch to {@see self::getExampleText()}.
      */
     public function getTitle()
     {
-        return $this->title;
+        @trigger_error('`ExampleNode::getTitle()` calls should be migrated to `ExampleNode::getScenarioTitle()` or `ExampleNode::getExampleText()`.', E_USER_DEPRECATED);
+
+        return $this->text;
     }
 
     /**
@@ -176,6 +186,30 @@ class ExampleNode implements ScenarioInterface
     public function getOutlineTitle()
     {
         return $this->outlineTitle;
+    }
+
+    /**
+     * Returns title for this scenario outline example.
+     *
+     * @return string
+     */
+    public function getScenarioTitle()
+    {
+        return "{$this->replaceTextTokens($this->outlineTitle)} #{$this->index}";
+    }
+
+    /**
+     * Returns the example row as a single string.
+     *
+     * You should normally not need this, since it is an implementation detail.
+     * If you need the individual example values, use {@see self::getTokens()}.
+     * To get the fully-normalised/expanded title, use {@see self::getScenarioTitle()}.
+     *
+     * @return string
+     */
+    public function getExampleText()
+    {
+        return $this->text;
     }
 
     /**

--- a/src/Behat/Gherkin/Node/NamedScenarioInterface.php
+++ b/src/Behat/Gherkin/Node/NamedScenarioInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Behat\Gherkin\Node;
+
+interface NamedScenarioInterface
+{
+    /**
+     * Returns the human-readable name of the scenario.
+     */
+    public function getName(): ?string;
+}

--- a/src/Behat/Gherkin/Node/OutlineNode.php
+++ b/src/Behat/Gherkin/Node/OutlineNode.php
@@ -236,7 +236,8 @@ class OutlineNode implements ScenarioInterface
                     $this->getSteps(),
                     $row,
                     $exampleTable->getRowLine($rowNum + 1),
-                    $this->getTitle()
+                    $this->getTitle(),
+                    $rowNum + 1
                 );
             }
         }

--- a/src/Behat/Gherkin/Node/ScenarioNode.php
+++ b/src/Behat/Gherkin/Node/ScenarioNode.php
@@ -15,7 +15,7 @@ namespace Behat\Gherkin\Node;
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-class ScenarioNode implements ScenarioInterface
+class ScenarioNode implements ScenarioInterface, NamedScenarioInterface
 {
     /**
      * @var string
@@ -84,7 +84,7 @@ class ScenarioNode implements ScenarioInterface
      *
      * @return null|string
      */
-    public function getName()
+    public function getName(): ?string
     {
         return $this->title;
     }

--- a/src/Behat/Gherkin/Node/ScenarioNode.php
+++ b/src/Behat/Gherkin/Node/ScenarioNode.php
@@ -71,21 +71,20 @@ class ScenarioNode implements ScenarioInterface
      *
      * @return null|string
      *
-     * @deprecated You should use {@see self::getScenarioTitle()} instead.
+     * @deprecated You should use {@see self::getScenarioTitle()} instead as this method will be removed in the next
+     *             major version.
      */
     public function getTitle()
     {
-        @trigger_error('`ScenarioNode::getTitle()` calls should be migrated to `ScenarioNode::getScenarioTitle()`.', E_USER_DEPRECATED);
-
         return $this->title;
     }
 
     /**
-     * Returns scenario title.
+     * Returns the name of the scenario.
      *
      * @return null|string
      */
-    public function getScenarioTitle()
+    public function getName()
     {
         return $this->title;
     }

--- a/src/Behat/Gherkin/Node/ScenarioNode.php
+++ b/src/Behat/Gherkin/Node/ScenarioNode.php
@@ -70,8 +70,22 @@ class ScenarioNode implements ScenarioInterface
      * Returns scenario title.
      *
      * @return null|string
+     *
+     * @deprecated You should use {@see self::getScenarioTitle()} instead.
      */
     public function getTitle()
+    {
+        @trigger_error('`ScenarioNode::getTitle()` calls should be migrated to `ScenarioNode::getScenarioTitle()`.', E_USER_DEPRECATED);
+
+        return $this->title;
+    }
+
+    /**
+     * Returns scenario title.
+     *
+     * @return null|string
+     */
+    public function getScenarioTitle()
     {
         return $this->title;
     }

--- a/src/Behat/Gherkin/Node/ScenarioNode.php
+++ b/src/Behat/Gherkin/Node/ScenarioNode.php
@@ -71,7 +71,7 @@ class ScenarioNode implements ScenarioInterface, NamedScenarioInterface
      *
      * @return null|string
      *
-     * @deprecated You should use {@see self::getScenarioTitle()} instead as this method will be removed in the next
+     * @deprecated You should use {@see self::getName()} instead as this method will be removed in the next
      *             major version.
      */
     public function getTitle()

--- a/src/Behat/Gherkin/Node/ScenarioNode.php
+++ b/src/Behat/Gherkin/Node/ScenarioNode.php
@@ -79,11 +79,6 @@ class ScenarioNode implements ScenarioInterface, NamedScenarioInterface
         return $this->title;
     }
 
-    /**
-     * Returns the name of the scenario.
-     *
-     * @return null|string
-     */
     public function getName(): ?string
     {
         return $this->title;

--- a/tests/Behat/Gherkin/Cache/FileCacheTest.php
+++ b/tests/Behat/Gherkin/Cache/FileCacheTest.php
@@ -3,9 +3,10 @@
 namespace Tests\Behat\Gherkin\Cache;
 
 use Behat\Gherkin\Cache\FileCache;
+use Behat\Gherkin\Exception\CacheException;
+use Behat\Gherkin\Gherkin;
 use Behat\Gherkin\Node\FeatureNode;
 use Behat\Gherkin\Node\ScenarioNode;
-use Behat\Gherkin\Gherkin;
 use PHPUnit\Framework\TestCase;
 
 class FileCacheTest extends TestCase
@@ -13,12 +14,12 @@ class FileCacheTest extends TestCase
     private $path;
     private $cache;
 
-    public function testIsFreshWhenThereIsNoFile()
+    public function testIsFreshWhenThereIsNoFile(): void
     {
         $this->assertFalse($this->cache->isFresh('unexisting', time() + 100));
     }
 
-    public function testIsFreshOnFreshFile()
+    public function testIsFreshOnFreshFile(): void
     {
         $feature = new FeatureNode(null, null, array(), null, array(), null, null, null, null);
 
@@ -27,7 +28,7 @@ class FileCacheTest extends TestCase
         $this->assertFalse($this->cache->isFresh('some_path', time() + 100));
     }
 
-    public function testIsFreshOnOutdated()
+    public function testIsFreshOnOutdated(): void
     {
         $feature = new FeatureNode(null, null, array(), null, array(), null, null, null, null);
 
@@ -36,7 +37,7 @@ class FileCacheTest extends TestCase
         $this->assertTrue($this->cache->isFresh('some_path', time() - 100));
     }
 
-    public function testCacheAndRead()
+    public function testCacheAndRead(): void
     {
         $scenarios = array(new ScenarioNode('Some scenario', array(), array(), null, null));
         $feature = new FeatureNode('Some feature', 'some description', array(), null, $scenarios, null, null, null, null);
@@ -47,22 +48,23 @@ class FileCacheTest extends TestCase
         $this->assertEquals($feature, $featureRead);
     }
 
-    public function testBrokenCacheRead()
+    public function testBrokenCacheRead(): void
     {
-        $this->expectException('Behat\Gherkin\Exception\CacheException');
+        $this->expectException(CacheException::class);
 
         touch($this->path . '/v' . Gherkin::VERSION . '/' . md5('broken_feature') . '.feature.cache');
         $this->cache->read('broken_feature');
     }
 
-    /**
-     * @requires OSFAMILY != Windows
-     */
-    public function testUnwriteableCacheDir()
+    public function testUnwriteableCacheDir(): void
     {
-        $this->expectException('Behat\Gherkin\Exception\CacheException');
+        $this->expectException(CacheException::class);
 
-        new FileCache('/dev/null/gherkin-test');
+        if (PHP_OS_FAMILY === 'Windows') {
+            new FileCache('C:\\Windows\\System32\\drivers\\etc');
+        } else {
+            new FileCache('/dev/null/gherkin-test');
+        }
     }
 
     protected function setUp(): void

--- a/tests/Behat/Gherkin/Cache/FileCacheTest.php
+++ b/tests/Behat/Gherkin/Cache/FileCacheTest.php
@@ -55,6 +55,9 @@ class FileCacheTest extends TestCase
         $this->cache->read('broken_feature');
     }
 
+    /**
+     * @requires OSFAMILY != Windows
+     */
     public function testUnwriteableCacheDir()
     {
         $this->expectException('Behat\Gherkin\Exception\CacheException');

--- a/tests/Behat/Gherkin/Node/OutlineNodeTest.php
+++ b/tests/Behat/Gherkin/Node/OutlineNodeTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Behat\Gherkin\Node;
 
+use Behat\Gherkin\Node\ExampleNode;
 use Behat\Gherkin\Node\ExampleTableNode;
 use Behat\Gherkin\Node\OutlineNode;
 use Behat\Gherkin\Node\StepNode;
@@ -122,11 +123,37 @@ class OutlineNodeTest extends TestCase
         $table = new ExampleTableNode(array(
             10 => array('name', 'email'),
             11 => array('Ciaran', 'ciaran@example.com'),
+            12 => array('John', 'john@example.com'),
         ), 'Examples');
 
-        $outline = new OutlineNode('An outline title', array(), $steps, $table, null, null);
+        $outline = new OutlineNode('An outline title for <name>', array(), $steps, $table, null, null);
 
-        $this->assertCount(1, $examples = $outline->getExamples());
-        $this->assertEquals('An outline title', current($examples)->getOutlineTitle());
+        $this->assertEquals(
+            [
+                [
+                    'getName' => 'An outline title for Ciaran #1',
+                    'getTitle' => '| Ciaran | ciaran@example.com |',
+                    'getOutlineTitle' => 'An outline title for <name>',
+                    'getExampleText' => '| Ciaran | ciaran@example.com |',
+                ],
+                [
+                    'getName' => 'An outline title for John #2',
+                    'getTitle' => '| John   | john@example.com   |',
+                    'getOutlineTitle' => 'An outline title for <name>',
+                    'getExampleText' => '| John   | john@example.com   |',
+                ],
+            ],
+            array_map(
+                static function (ExampleNode $node) {
+                    return [
+                        'getName' => $node->getName(),
+                        'getTitle' => $node->getTitle(),
+                        'getOutlineTitle' => $node->getOutlineTitle(),
+                        'getExampleText' => $node->getExampleText(),
+                    ];
+                },
+                $outline->getExamples()
+            )
+        );
     }
 }

--- a/tests/Behat/Gherkin/Node/OutlineNodeTest.php
+++ b/tests/Behat/Gherkin/Node/OutlineNodeTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 
 class OutlineNodeTest extends TestCase
 {
-    public function testCreatesExamplesForExampleTable()
+    public function testCreatesExamplesForExampleTable(): void
     {
         $steps = array(
             new StepNode('Gangway!', 'I am <name>', array(), null, 'Given'),
@@ -34,7 +34,7 @@ class OutlineNodeTest extends TestCase
         $this->assertEquals(array('name' => 'example', 'email' => 'example@example.com'), $examples[1]->getTokens());
     }
 
-    public function testCreatesExamplesForExampleTableWithSeveralExamplesAndTags()
+    public function testCreatesExamplesForExampleTableWithSeveralExamplesAndTags(): void
     {
         $steps = array(
             new StepNode('Gangway!', 'I am <name>', array(), null, 'Given'),
@@ -80,7 +80,7 @@ class OutlineNodeTest extends TestCase
         }
     }
 
-    public function testCreatesEmptyExamplesForEmptyExampleTable()
+    public function testCreatesEmptyExamplesForEmptyExampleTable(): void
     {
         $steps = array(
             new StepNode('Gangway!', 'I am <name>', array(), null, 'Given'),
@@ -95,10 +95,10 @@ class OutlineNodeTest extends TestCase
 
         $outline = new OutlineNode(null, array(), $steps, $table, null, null);
 
-        $this->assertCount(0, $examples = $outline->getExamples());
+        $this->assertCount(0, $outline->getExamples());
     }
 
-    public function testCreatesEmptyExamplesForNoExampleTable()
+    public function testCreatesEmptyExamplesForNoExampleTable(): void
     {
         $steps = array(
             new StepNode('Gangway!', 'I am <name>', array(), null, 'Given'),
@@ -111,10 +111,10 @@ class OutlineNodeTest extends TestCase
 
         $outline = new OutlineNode(null, array(), $steps, array($table), null, null);
 
-        $this->assertCount(0, $examples = $outline->getExamples());
+        $this->assertCount(0, $outline->getExamples());
     }
 
-    public function testPopulatesExampleWithOutlineTitle()
+    public function testPopulatesExampleWithOutlineTitle(): void
     {
         $steps = array(
             new StepNode('', 'I am <name>', array(), null, 'Given'),
@@ -128,7 +128,7 @@ class OutlineNodeTest extends TestCase
 
         $outline = new OutlineNode('An outline title for <name>', array(), $steps, $table, null, null);
 
-        $this->assertEquals(
+        $this->assertSame(
             [
                 [
                     'getName' => 'An outline title for Ciaran #1',


### PR DESCRIPTION
Fixes #270

----

Remaining points
- [x] Cover changes with tests
- [x] What about interfaces? Changing them constitutes a BC break. (`getTitle` is defined in `KeywordNodeInterface` - there's also `ScenarioLikeInterface` and `ScenarioInterface`).
      We could add a new interface on top, though - no BC break there.
- [x] Still a bit uncomfortable requiring a migration from `getTitle()` to ~~`getScenarioTitle()`~~ `getName()`.
- [ ] Could it make sense to make `\Behat\Gherkin\Node\ExampleNode::replaceTextTokens` public? It feels less important to do so with this PR, plus it's a BC break (since `ExampleNode` is not final)