### PR TITLE
Improve tag handling; update test

### DIFF
--- a/src/Node/ExampleNode.php
+++ b/src/Node/ExampleNode.php
@@ -17,6 +17,8 @@ namespace Behat\Gherkin\Node;
  */
 class ExampleNode implements ScenarioInterface, NamedScenarioInterface
 {
+    use TaggedNodeTrait;
+
     /**
      * @var string
      */
@@ -105,33 +107,6 @@ class ExampleNode implements ScenarioInterface, NamedScenarioInterface
         return $this->text;
     }
 
-    /**
-     * Checks if outline is tagged with tag.
-     *
-     * @param string $tag
-     *
-     * @return bool
-     */
-    public function hasTag($tag)
-    {
-        return in_array($tag, $this->getTags());
-    }
-
-    /**
-     * Checks if outline has tags (both inherited from feature and own).
-     *
-     * @return bool
-     */
-    public function hasTags()
-    {
-        return count($this->getTags()) > 0;
-    }
-
-    /**
-     * Returns outline tags (including inherited from feature).
-     *
-     * @return string[]
-     */
     public function getTags()
     {
         return $this->tags;

--- a/src/Node/ExampleTableNode.php
+++ b/src/Node/ExampleTableNode.php
@@ -15,8 +15,10 @@ namespace Behat\Gherkin\Node;
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
-class ExampleTableNode extends TableNode
+class ExampleTableNode extends TableNode implements TaggedNodeInterface
 {
+    use TaggedNodeTrait;
+
     /**
      * @var string[]
      */
@@ -52,11 +54,6 @@ class ExampleTableNode extends TableNode
         return 'ExampleTable';
     }
 
-    /**
-     * Returns attached tags.
-     *
-     * @return string[]
-     */
     public function getTags()
     {
         return $this->tags;

--- a/src/Node/FeatureNode.php
+++ b/src/Node/FeatureNode.php
@@ -21,6 +21,8 @@ use function strlen;
  */
 class FeatureNode implements KeywordNodeInterface, TaggedNodeInterface
 {
+    use TaggedNodeTrait;
+
     /**
      * @var string|null
      */
@@ -136,33 +138,6 @@ class FeatureNode implements KeywordNodeInterface, TaggedNodeInterface
         return $this->description;
     }
 
-    /**
-     * Checks if feature is tagged with tag.
-     *
-     * @param string $tag
-     *
-     * @return bool
-     */
-    public function hasTag($tag)
-    {
-        return in_array($tag, $this->tags);
-    }
-
-    /**
-     * Checks if feature has tags.
-     *
-     * @return bool
-     */
-    public function hasTags()
-    {
-        return count($this->tags) > 0;
-    }
-
-    /**
-     * Returns feature tags.
-     *
-     * @return string[]
-     */
     public function getTags()
     {
         return $this->tags;

--- a/src/Node/OutlineNode.php
+++ b/src/Node/OutlineNode.php
@@ -17,6 +17,8 @@ namespace Behat\Gherkin\Node;
  */
 class OutlineNode implements ScenarioInterface
 {
+    use TaggedNodeTrait;
+
     /**
      * @var string
      */
@@ -92,33 +94,6 @@ class OutlineNode implements ScenarioInterface
         return $this->title;
     }
 
-    /**
-     * Checks if outline is tagged with tag.
-     *
-     * @param string $tag
-     *
-     * @return bool
-     */
-    public function hasTag($tag)
-    {
-        return in_array($tag, $this->getTags());
-    }
-
-    /**
-     * Checks if outline has tags (both inherited from feature and own).
-     *
-     * @return bool
-     */
-    public function hasTags()
-    {
-        return count($this->getTags()) > 0;
-    }
-
-    /**
-     * Returns outline tags (including inherited from feature).
-     *
-     * @return string[]
-     */
     public function getTags()
     {
         return $this->tags;

--- a/src/Node/ScenarioNode.php
+++ b/src/Node/ScenarioNode.php
@@ -17,6 +17,8 @@ namespace Behat\Gherkin\Node;
  */
 class ScenarioNode implements ScenarioInterface, NamedScenarioInterface
 {
+    use TaggedNodeTrait;
+
     /**
      * @var string
      */
@@ -83,33 +85,6 @@ class ScenarioNode implements ScenarioInterface, NamedScenarioInterface
         return $this->title;
     }
 
-    /**
-     * Checks if scenario is tagged with tag.
-     *
-     * @param string $tag
-     *
-     * @return bool
-     */
-    public function hasTag($tag)
-    {
-        return in_array($tag, $this->getTags());
-    }
-
-    /**
-     * Checks if scenario has tags (both inherited from feature and own).
-     *
-     * @return bool
-     */
-    public function hasTags()
-    {
-        return count($this->getTags()) > 0;
-    }
-
-    /**
-     * Returns scenario tags (including inherited from feature).
-     *
-     * @return array
-     */
     public function getTags()
     {
         return $this->tags;

--- a/src/Node/TaggedNodeInterface.php
+++ b/src/Node/TaggedNodeInterface.php
@@ -27,14 +27,14 @@ interface TaggedNodeInterface extends NodeInterface
     public function hasTag($tag);
 
     /**
-     * Checks if node has tags (both inherited from feature and own).
+     * Checks if node has tags (including any inherited tags e.g. from feature).
      *
      * @return bool
      */
     public function hasTags();
 
     /**
-     * Returns node tags (including inherited from feature).
+     * Returns node tags (including any inherited tags e.g. from feature).
      *
      * @return list<string>
      */

--- a/src/Node/TaggedNodeTrait.php
+++ b/src/Node/TaggedNodeTrait.php
@@ -12,6 +12,8 @@ namespace Behat\Gherkin\Node;
 
 /**
  * This trait partially implements {@see TaggedNodeInterface}.
+ *
+ * @internal
  */
 trait TaggedNodeTrait
 {

--- a/src/Node/TaggedNodeTrait.php
+++ b/src/Node/TaggedNodeTrait.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Behat Gherkin Parser.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Gherkin\Node;
+
+/**
+ * This trait partially implements {@see TaggedNodeInterface}.
+ */
+trait TaggedNodeTrait
+{
+    /**
+     * @return list<string>
+     */
+    abstract public function getTags();
+
+    /**
+     * @param string $tag
+     *
+     * @return bool
+     */
+    public function hasTag($tag)
+    {
+        return in_array($tag, $this->getTags(), true);
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasTags()
+    {
+        return $this->getTags() !== [];
+    }
+}

--- a/tests/Loader/ArrayLoaderTest.php
+++ b/tests/Loader/ArrayLoaderTest.php
@@ -60,19 +60,19 @@ class ArrayLoaderTest extends TestCase
 
         $this->assertCount(2, $features);
 
-        $this->assertEquals(3, $features[0]->getLine());
-        $this->assertEquals('First feature', $features[0]->getTitle());
+        $this->assertSame(3, $features[0]->getLine());
+        $this->assertSame('First feature', $features[0]->getTitle());
         $this->assertNull($features[0]->getDescription());
         $this->assertNull($features[0]->getFile());
-        $this->assertEquals('en', $features[0]->getLanguage());
-        $this->assertFalse($features[0]->hasTags());
+        $this->assertSame('en', $features[0]->getLanguage());
+        $this->assertSame([], $features[0]->getTags());
 
-        $this->assertEquals(1, $features[1]->getLine());
+        $this->assertSame(1, $features[1]->getLine());
         $this->assertNull($features[1]->getTitle());
-        $this->assertEquals('Second feature description', $features[1]->getDescription());
+        $this->assertSame('Second feature description', $features[1]->getDescription());
         $this->assertNull($features[1]->getFile());
-        $this->assertEquals('ru', $features[1]->getLanguage());
-        $this->assertEquals(['some', 'tags'], $features[1]->getTags());
+        $this->assertSame('ru', $features[1]->getLanguage());
+        $this->assertSame(['some', 'tags'], $features[1]->getTags());
     }
 
     public function testLoadScenarios(): void
@@ -105,19 +105,19 @@ class ArrayLoaderTest extends TestCase
         $this->assertCount(3, $scenarios);
 
         $this->assertInstanceOf(ScenarioNode::class, $scenarios[0]);
-        $this->assertEquals('First scenario', $scenarios[0]->getTitle());
-        $this->assertFalse($scenarios[0]->hasTags());
-        $this->assertEquals(2, $scenarios[0]->getLine());
+        $this->assertSame('First scenario', $scenarios[0]->getTitle());
+        $this->assertSame([], $scenarios[0]->getTags());
+        $this->assertSame(2, $scenarios[0]->getLine());
 
         $this->assertInstanceOf(ScenarioNode::class, $scenarios[1]);
         $this->assertNull($scenarios[1]->getTitle());
-        $this->assertEquals(['second', 'scenario', 'tags'], $scenarios[1]->getTags());
-        $this->assertEquals(1, $scenarios[1]->getLine());
+        $this->assertSame(['second', 'scenario', 'tags'], $scenarios[1]->getTags());
+        $this->assertSame(1, $scenarios[1]->getLine());
 
         $this->assertInstanceOf(ScenarioNode::class, $scenarios[2]);
         $this->assertNull($scenarios[2]->getTitle());
-        $this->assertEquals(['third', 'scenario'], $scenarios[2]->getTags());
-        $this->assertEquals(3, $scenarios[2]->getLine());
+        $this->assertSame(['third', 'scenario'], $scenarios[2]->getTags());
+        $this->assertSame(3, $scenarios[2]->getLine());
     }
 
     public function testLoadOutline(): void
@@ -148,14 +148,14 @@ class ArrayLoaderTest extends TestCase
         $this->assertCount(2, $outlines);
 
         $this->assertInstanceOf(OutlineNode::class, $outlines[0]);
-        $this->assertEquals('First outline', $outlines[0]->getTitle());
-        $this->assertFalse($outlines[0]->hasTags());
-        $this->assertEquals(2, $outlines[0]->getLine());
+        $this->assertSame('First outline', $outlines[0]->getTitle());
+        $this->assertSame([], $outlines[0]->getTags());
+        $this->assertSame(2, $outlines[0]->getLine());
 
         $this->assertInstanceOf(OutlineNode::class, $outlines[1]);
         $this->assertNull($outlines[1]->getTitle());
-        $this->assertEquals(['second', 'outline', 'tags'], $outlines[1]->getTags());
-        $this->assertEquals(1, $outlines[1]->getLine());
+        $this->assertSame(['second', 'outline', 'tags'], $outlines[1]->getTags());
+        $this->assertSame(1, $outlines[1]->getLine());
     }
 
     public function testOutlineExamples(): void

--- a/tests/Node/OutlineNodeTest.php
+++ b/tests/Node/OutlineNodeTest.php
@@ -65,27 +65,38 @@ class OutlineNodeTest extends TestCase
 
         $outline = new OutlineNode(null, ['otag1', 'otag2'], $steps, [$table, $table2], '', 1);
 
-        $this->assertCount(4, $examples = $outline->getExamples());
-        $this->assertEquals(22, $examples[0]->getLine());
-        $this->assertEquals(23, $examples[1]->getLine());
-        $this->assertEquals(32, $examples[2]->getLine());
-        $this->assertEquals(33, $examples[3]->getLine());
-        $this->assertEquals(['name' => 'everzet', 'email' => 'ever.zet@gmail.com'], $examples[0]->getTokens());
-        $this->assertEquals(['name' => 'example', 'email' => 'example@example.com'], $examples[1]->getTokens());
-        $this->assertEquals(['name' => 'everzet2', 'email' => 'ever.zet2@gmail.com'], $examples[2]->getTokens());
-        $this->assertEquals(['name' => 'example2', 'email' => 'example2@example.com'], $examples[3]->getTokens());
-
-        for ($i = 0; $i < 2; ++$i) {
-            foreach (['otag1', 'otag2'] as $tag) {
-                $this->assertTrue($examples[$i]->hasTag($tag), 'there is no tag ' . $tag . ' in example #' . $i);
-            }
-        }
-
-        for ($i = 2; $i < 4; ++$i) {
-            foreach (['otag1', 'otag2', 'etag1', 'etag2'] as $tag) {
-                $this->assertTrue($examples[$i]->hasTag($tag), 'there is no tag ' . $tag . ' in example #' . $i);
-            }
-        }
+        $this->assertSame(
+            [
+                [
+                    'line' => 22,
+                    'tokens' => ['name' => 'everzet', 'email' => 'ever.zet@gmail.com'],
+                    'tags' => ['otag1', 'otag2'],
+                ],
+                [
+                    'line' => 23,
+                    'tokens' => ['name' => 'example', 'email' => 'example@example.com'],
+                    'tags' => ['otag1', 'otag2'],
+                ],
+                [
+                    'line' => 32,
+                    'tokens' => ['name' => 'everzet2', 'email' => 'ever.zet2@gmail.com'],
+                    'tags' => ['otag1', 'otag2', 'etag1', 'etag2'],
+                ],
+                [
+                    'line' => 33,
+                    'tokens' => ['name' => 'example2', 'email' => 'example2@example.com'],
+                    'tags' => ['otag1', 'otag2', 'etag1', 'etag2'],
+                ],
+            ],
+            array_map(
+                static fn (ExampleNode $example) => [
+                    'line' => $example->getLine(),
+                    'tokens' => $example->getTokens(),
+                    'tags' => $example->getTags(),
+                ],
+                $outline->getExamples(),
+            ),
+        );
     }
 
     public function testCreatesEmptyExamplesForEmptyExampleTable(): void

--- a/tests/Node/OutlineNodeTest.php
+++ b/tests/Node/OutlineNodeTest.php
@@ -128,11 +128,15 @@ class OutlineNodeTest extends TestCase
             new StepNode('', 'I am <name>', [], 1, 'Given'),
         ];
 
-        $table = new ExampleTableNode([
-            10 => ['name', 'email'],
-            11 => ['Ciaran', 'ciaran@example.com'],
-            12 => ['John', 'john@example.com'],
-        ], 'Examples');
+        $table = new ExampleTableNode(
+            [
+                10 => ['name', 'email'],
+                11 => ['Ciaran', 'ciaran@example.com'],
+                12 => ['John', 'john@example.com'],
+            ],
+            'Examples',
+            ['tagA', 'tagB'],
+        );
 
         $outline = new OutlineNode('An outline title for <name>', [], $steps, $table, '', 1);
 
@@ -143,12 +147,14 @@ class OutlineNodeTest extends TestCase
                     'getTitle' => '| Ciaran | ciaran@example.com |',
                     'getOutlineTitle' => 'An outline title for <name>',
                     'getExampleText' => '| Ciaran | ciaran@example.com |',
+                    'getTags' => ['tagA', 'tagB'],
                 ],
                 [
                     'getName' => 'An outline title for John #2',
                     'getTitle' => '| John   | john@example.com   |',
                     'getOutlineTitle' => 'An outline title for <name>',
                     'getExampleText' => '| John   | john@example.com   |',
+                    'getTags' => ['tagA', 'tagB'],
                 ],
             ],
             array_map(
@@ -158,6 +164,7 @@ class OutlineNodeTest extends TestCase
                         'getTitle' => $node->getTitle(),
                         'getOutlineTitle' => $node->getOutlineTitle(),
                         'getExampleText' => $node->getExampleText(),
+                        'getTags' => $node->getTags(),
                     ];
                 },
                 $outline->getExamples()

--- a/tests/Node/TaggedNodeTraitTest.php
+++ b/tests/Node/TaggedNodeTraitTest.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Behat Gherkin Parser.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Behat\Gherkin\Node;
+
+use Behat\Gherkin\Node\TaggedNodeInterface;
+use Behat\Gherkin\Node\TaggedNodeTrait;
+use PHPUnit\Framework\TestCase;
+
+class TaggedNodeTraitTest extends TestCase
+{
+    public function testHasTags(): void
+    {
+        $node = $this->createTaggedNode([]);
+        $this->assertFalse($node->hasTags());
+
+        $node = $this->createTaggedNode(['a']);
+        $this->assertTrue($node->hasTags());
+    }
+
+    public function testHasTag(): void
+    {
+        $node = $this->createTaggedNode([]);
+        $this->assertFalse($node->hasTag('a'));
+
+        $node = $this->createTaggedNode(['a']);
+        $this->assertTrue($node->hasTag('a'));
+
+        $node = $this->createTaggedNode(['a']);
+        $this->assertFalse($node->hasTag('b'));
+    }
+
+    private function createTaggedNode(array $tags): TaggedNodeInterface
+    {
+        return new class($tags) implements TaggedNodeInterface {
+            use TaggedNodeTrait;
+
+            public function __construct(private readonly array $tags)
+            {
+            }
+
+            public function getTags()
+            {
+                return $this->tags;
+            }
+
+            public function getNodeType()
+            {
+                return 'Fake';
+            }
+
+            public function getLine()
+            {
+                return 0;
+            }
+        };
+    }
+}

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -47,30 +47,33 @@ class ParserTest extends TestCase
     {
         $parser = $this->getGherkinParser();
 
-        $parser->parse(<<<'FEATURE'
-        Feature:
-        Scenario:
-        Given step
-        @skipped
-        FEATURE
+        $parser->parse(
+            <<<'FEATURE'
+            Feature:
+            Scenario:
+            Given step
+            @skipped
+            FEATURE
         );
-        $feature2 = $parser->parse(<<<'FEATURE'
-        Feature:
-        Scenario:
-        Given step
-        FEATURE
+        $feature2 = $parser->parse(
+            <<<'FEATURE'
+            Feature:
+            Scenario:
+            Given step
+            FEATURE
         );
 
-        $this->assertFalse($feature2->hasTags());
+        $this->assertSame([], $feature2->getTags());
     }
 
     public function testSingleCharacterStepSupport(): void
     {
-        $feature = $this->getGherkinParser()->parse(<<<'FEATURE'
-        Feature:
-        Scenario:
-        When x
-        FEATURE
+        $feature = $this->getGherkinParser()->parse(
+            <<<'FEATURE'
+            Feature:
+            Scenario:
+            When x
+            FEATURE
         );
 
         $scenarios = $feature->getScenarios();


### PR DESCRIPTION
This isn't a new feature, but rather a small improvement on tag handling.

Here's what changed:
1. `hasTag`/`hasTags` code is always the same, so I moved it into a trait (that depends on abstract method `getTags`).
2. I removed the somewhat redundant PHPDoc comments, in favour of the one provided by the interface
3. `ExampleTableNode` now implements `TaggedNodeInterface` and the new trait - I couldn't see why it wouldn't have that in the first place
4. I've updated a test to cover point 3.

It would have been nice to move `getTags` to the trait too, but at this PHP level we can't define abstract properties or property requirements, so I think this is the safest and cleanest approach at the moment.