### PR TITLE
Use hardcoded path to i18n file if not provided

### DIFF
--- a/src/Behat/Gherkin/Keywords/CachedArrayKeywords.php
+++ b/src/Behat/Gherkin/Keywords/CachedArrayKeywords.php
@@ -19,13 +19,15 @@ namespace Behat\Gherkin\Keywords;
  */
 class CachedArrayKeywords extends ArrayKeywords
 {
+    private const I18N_FILE_LOCATION = __DIR__ . '/../../../../i18n.php';
+
     /**
      * Initializes holder with file.
      *
      * @param string $file Cached array path
      */
-    public function __construct($file)
+    public function __construct($file = null)
     {
-        parent::__construct(include $file);
+        parent::__construct(require $file ?? self::I18N_FILE_LOCATION);
     }
 }

--- a/src/Behat/Gherkin/Keywords/CachedArrayKeywords.php
+++ b/src/Behat/Gherkin/Keywords/CachedArrayKeywords.php
@@ -19,15 +19,18 @@ namespace Behat\Gherkin\Keywords;
  */
 class CachedArrayKeywords extends ArrayKeywords
 {
-    private const I18N_FILE_LOCATION = __DIR__ . '/../../../../i18n.php';
+    public static function withDefaultKeywords(): self
+    {
+        return new self(__DIR__ . '/../../../../i18n.php');
+    }
 
     /**
      * Initializes holder with file.
      *
      * @param string $file Cached array path
      */
-    public function __construct($file = null)
+    public function __construct($file)
     {
-        parent::__construct(require $file ?? self::I18N_FILE_LOCATION);
+        parent::__construct(require $file);
     }
 }

--- a/tests/Behat/Gherkin/Keywords/CachedArrayKeywordsTest.php
+++ b/tests/Behat/Gherkin/Keywords/CachedArrayKeywordsTest.php
@@ -17,12 +17,13 @@ class CachedArrayKeywordsTest extends KeywordsTestCase
 {
     protected function getKeywords()
     {
-        return new CachedArrayKeywords(__DIR__ . '/../../../../i18n.php');
+        // Test with the default i18n file provided in this repository
+        return new CachedArrayKeywords();
     }
 
     protected function getKeywordsArray()
     {
-        return include __DIR__ . '/../../../../i18n.php';
+        return require __DIR__ . '/../../../../i18n.php';
     }
 
     protected function getSteps($keywords, $text, &$line, $keywordType)

--- a/tests/Behat/Gherkin/Keywords/CachedArrayKeywordsTest.php
+++ b/tests/Behat/Gherkin/Keywords/CachedArrayKeywordsTest.php
@@ -18,7 +18,7 @@ class CachedArrayKeywordsTest extends KeywordsTestCase
     protected function getKeywords()
     {
         // Test with the default i18n file provided in this repository
-        return new CachedArrayKeywords();
+        return CachedArrayKeywords::withDefaultKeywords();
     }
 
     protected function getKeywordsArray()


### PR DESCRIPTION
Alternate solution to the problem described in https://github.com/Behat/Behat/pull/1602 and https://github.com/Behat/Behat/pull/1603. Since the file that `CachedArrayKeywords` needs to load is in the same package, it does not need to be told its location by another package. We keep the option of passing a file name in case someone is using this class to load an i18n file from some other location. After this is merged in this package we should update Behat so that it does not attempt to provide the path to the file