### PR TITLE
fix: Ensure assertions in the update_cucumber script are executed

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           php-version: 8.4
           coverage: none
+          ini-file: "development"
 
       - name: Check whether to update or create PR
         id: check-existing-pr

--- a/bin/update_cucumber
+++ b/bin/update_cucumber
@@ -12,6 +12,12 @@
 ini_set('error_reporting', E_ALL);
 set_error_handler(static fn ($code, $msg, $file, $line) => throw new ErrorException($msg, $code, $code, $file, $line));
 
+if (ini_get('zend.assertions') !== '1') {
+    // Ensure our assertions are actually processed. Otherwise any code inside the assert() call is compiled out
+    echo "This script must be run with zend.assertions set to 1\n";
+    exit;
+}
+
 $updater = new
 /**
  * @phpstan-type CurrentVersionArray array{tag_name: string, hash: string, composer_version: string}
@@ -264,6 +270,6 @@ try {
     );
     exit(0);
 } catch (Throwable $e) {
-    echo 'ERROR: ' . $e->getMessage() . "\n";
+    echo sprintf("ERROR [%s:%d]: %s\n", $e->getFile(), $e->getLine(), $e->getMessage());
     exit(1);
 }


### PR DESCRIPTION
By default shivammathur/setup-php configures PHP with a production ini file, which disables zend assertions.

This means that calls like `assert(preg_match(...,..., $matches))` are compiled out, leaving $matches undefined. The logic in the update_cucumber script requires the assertions to run, so we use the development ini file and have the script fail if they're not enabled.