### PR TITLE
ci: Fix git permissions for pushing cucumber updates

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -73,6 +73,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ steps.check-existing-pr.outputs.checkout_branch }}
+          persist-credentials: 'false'
 
       - run: bin/update_cucumber
         id: cucumber


### PR DESCRIPTION
There is a bug / unexpected behaviour in gh CLI when used following an actions/checkout execution with default arguments.

actions/checkout modifies the local git config to force the authorization header to use the token that was used for the original checkout. This takes precedence over the credential helper configured by `gh auth setup-git`. As a result that command has no effect and the `git push` is attempted with the default `GITHUB_TOKEN` (and fails due to insufficient permissions).

To fix this, actions/checkout needs to be configured with the `persist-credentials: 'false'` to have it remove the custom header config as soon as the checkout completes.

Refs https://github.com/cli/cli/issues/10905