### PR TITLE
refactor: Simplify tag filtering implementation

### DIFF
--- a/src/Filter/ComplexFilter.php
+++ b/src/Filter/ComplexFilter.php
@@ -27,11 +27,12 @@ abstract class ComplexFilter implements ComplexFilterInterface
      */
     public function filterFeature(FeatureNode $feature)
     {
-        return $feature->withScenarios(
-            array_filter(
-                $feature->getScenarios(),
-                fn (ScenarioInterface $scenario) => $this->isScenarioMatch($feature, $scenario)
-            )
+        $scenarios = $feature->getScenarios();
+        $filteredScenarios = array_filter(
+            $scenarios,
+            fn (ScenarioInterface $scenario) => $this->isScenarioMatch($feature, $scenario)
         );
+
+        return $scenarios === $filteredScenarios ? $feature : $feature->withScenarios($filteredScenarios);
     }
 }

--- a/src/Filter/ComplexFilter.php
+++ b/src/Filter/ComplexFilter.php
@@ -11,6 +11,7 @@
 namespace Behat\Gherkin\Filter;
 
 use Behat\Gherkin\Node\FeatureNode;
+use Behat\Gherkin\Node\ScenarioInterface;
 
 /**
  * Abstract filter class.
@@ -26,25 +27,11 @@ abstract class ComplexFilter implements ComplexFilterInterface
      */
     public function filterFeature(FeatureNode $feature)
     {
-        $scenarios = [];
-        foreach ($feature->getScenarios() as $scenario) {
-            if (!$this->isScenarioMatch($feature, $scenario)) {
-                continue;
-            }
-
-            $scenarios[] = $scenario;
-        }
-
-        return new FeatureNode(
-            $feature->getTitle(),
-            $feature->getDescription(),
-            $feature->getTags(),
-            $feature->getBackground(),
-            $scenarios,
-            $feature->getKeyword(),
-            $feature->getLanguage(),
-            $feature->getFile(),
-            $feature->getLine()
+        return $feature->withScenarios(
+            array_filter(
+                $feature->getScenarios(),
+                fn (ScenarioInterface $scenario) => $this->isScenarioMatch($feature, $scenario)
+            )
         );
     }
 }

--- a/src/Filter/LineFilter.php
+++ b/src/Filter/LineFilter.php
@@ -95,13 +95,8 @@ class LineFilter implements FilterInterface
                             $filteredTable[$this->filterLine] = $table[$this->filterLine];
                         }
 
-                        $scenario = new OutlineNode(
-                            $scenario->getTitle(),
-                            $scenario->getTags(),
-                            $scenario->getSteps(),
+                        $scenario = $scenario->withTables(
                             [new ExampleTableNode($filteredTable, $exampleTable->getKeyword(), $exampleTable->getTags())],
-                            $scenario->getKeyword(),
-                            $scenario->getLine()
                         );
                     }
                 }
@@ -110,16 +105,6 @@ class LineFilter implements FilterInterface
             $scenarios[] = $scenario;
         }
 
-        return new FeatureNode(
-            $feature->getTitle(),
-            $feature->getDescription(),
-            $feature->getTags(),
-            $feature->getBackground(),
-            $scenarios,
-            $feature->getKeyword(),
-            $feature->getLanguage(),
-            $feature->getFile(),
-            $feature->getLine()
-        );
+        return $feature->withScenarios($scenarios);
     }
 }

--- a/src/Filter/LineRangeFilter.php
+++ b/src/Filter/LineRangeFilter.php
@@ -40,11 +40,7 @@ class LineRangeFilter implements FilterInterface
     public function __construct($filterMinLine, $filterMaxLine)
     {
         $this->filterMinLine = (int) $filterMinLine;
-        if ($filterMaxLine === '*') {
-            $this->filterMaxLine = PHP_INT_MAX;
-        } else {
-            $this->filterMaxLine = (int) $filterMaxLine;
-        }
+        $this->filterMaxLine = $filterMaxLine === '*' ? PHP_INT_MAX : (int) $filterMaxLine;
     }
 
     /**
@@ -119,29 +115,12 @@ class LineRangeFilter implements FilterInterface
                     }
                 }
 
-                $scenario = new OutlineNode(
-                    $scenario->getTitle(),
-                    $scenario->getTags(),
-                    $scenario->getSteps(),
-                    $exampleTableNodes,
-                    $scenario->getKeyword(),
-                    $scenario->getLine()
-                );
+                $scenario = $scenario->withTables($exampleTableNodes);
             }
 
             $scenarios[] = $scenario;
         }
 
-        return new FeatureNode(
-            $feature->getTitle(),
-            $feature->getDescription(),
-            $feature->getTags(),
-            $feature->getBackground(),
-            $scenarios,
-            $feature->getKeyword(),
-            $feature->getLanguage(),
-            $feature->getFile(),
-            $feature->getLine()
-        );
+        return $feature->withScenarios($scenarios);
     }
 }

--- a/src/Filter/SimpleFilter.php
+++ b/src/Filter/SimpleFilter.php
@@ -30,25 +30,11 @@ abstract class SimpleFilter implements FilterInterface
             return $feature;
         }
 
-        $scenarios = [];
-        foreach ($feature->getScenarios() as $scenario) {
-            if (!$this->isScenarioMatch($scenario)) {
-                continue;
-            }
-
-            $scenarios[] = $scenario;
-        }
-
-        return new FeatureNode(
-            $feature->getTitle(),
-            $feature->getDescription(),
-            $feature->getTags(),
-            $feature->getBackground(),
-            $scenarios,
-            $feature->getKeyword(),
-            $feature->getLanguage(),
-            $feature->getFile(),
-            $feature->getLine()
+        return $feature->withScenarios(
+            array_filter(
+                $feature->getScenarios(),
+                $this->isScenarioMatch(...)
+            )
         );
     }
 }

--- a/src/Filter/TagFilter.php
+++ b/src/Filter/TagFilter.php
@@ -14,8 +14,6 @@ use Behat\Gherkin\Node\FeatureNode;
 use Behat\Gherkin\Node\OutlineNode;
 use Behat\Gherkin\Node\ScenarioInterface;
 
-use function strlen;
-
 /**
  * Filters scenarios by feature/scenario tag.
  *
@@ -64,30 +62,13 @@ class TagFilter extends ComplexFilter
                     }
                 }
 
-                $scenario = new OutlineNode(
-                    $scenario->getTitle(),
-                    $scenario->getTags(),
-                    $scenario->getSteps(),
-                    $exampleTables,
-                    $scenario->getKeyword(),
-                    $scenario->getLine()
-                );
+                $scenario = $scenario->withTables($exampleTables);
             }
 
             $scenarios[] = $scenario;
         }
 
-        return new FeatureNode(
-            $feature->getTitle(),
-            $feature->getDescription(),
-            $feature->getTags(),
-            $feature->getBackground(),
-            $scenarios,
-            $feature->getKeyword(),
-            $feature->getLanguage(),
-            $feature->getFile(),
-            $feature->getLine()
-        );
+        return $feature->withScenarios($scenarios);
     }
 
     /**
@@ -134,10 +115,8 @@ class TagFilter extends ComplexFilter
      */
     protected function isTagsMatchCondition($tags)
     {
-        $satisfies = true;
-
-        if (strlen($this->filterString) === 0) {
-            return $satisfies;
+        if ($this->filterString === '') {
+            return true;
         }
 
         foreach (explode('&&', $this->filterString) as $andTags) {
@@ -148,15 +127,17 @@ class TagFilter extends ComplexFilter
 
                 if ($tag[0] === '~') {
                     $tag = mb_substr($tag, 1, mb_strlen($tag, 'utf8') - 1, 'utf8');
-                    $satisfiesComma = !in_array($tag, $tags) || $satisfiesComma;
+                    $satisfiesComma = !in_array($tag, $tags, true) || $satisfiesComma;
                 } else {
-                    $satisfiesComma = in_array($tag, $tags) || $satisfiesComma;
+                    $satisfiesComma = in_array($tag, $tags, true) || $satisfiesComma;
                 }
             }
 
-            $satisfies = $satisfiesComma && $satisfies;
+            if (!$satisfiesComma) {
+                return false;
+            }
         }
 
-        return $satisfies;
+        return true;
     }
 }

--- a/src/Node/FeatureNode.php
+++ b/src/Node/FeatureNode.php
@@ -224,22 +224,22 @@ class FeatureNode implements KeywordNodeInterface, TaggedNodeInterface
     }
 
     /**
-     * Returns a copy of this features but with a different set of scenarios.
+     * Returns a copy of this feature but with a different set of scenarios.
      *
      * @param array<array-key, ScenarioInterface> $scenarios
      */
     public function withScenarios(array $scenarios): self
     {
         return new self(
-            $this->getTitle(),
-            $this->getDescription(),
-            $this->getTags(),
-            $this->getBackground(),
+            $this->title,
+            $this->description,
+            $this->tags,
+            $this->background,
             array_values($scenarios),
-            $this->getKeyword(),
-            $this->getLanguage(),
-            $this->getFile(),
-            $this->getLine()
+            $this->keyword,
+            $this->language,
+            $this->file,
+            $this->line,
         );
     }
 

--- a/src/Node/FeatureNode.php
+++ b/src/Node/FeatureNode.php
@@ -224,6 +224,26 @@ class FeatureNode implements KeywordNodeInterface, TaggedNodeInterface
     }
 
     /**
+     * Returns a copy of this features but with a different set of scenarios.
+     *
+     * @param array<array-key, ScenarioInterface> $scenarios
+     */
+    public function withScenarios(array $scenarios): self
+    {
+        return new self(
+            $this->getTitle(),
+            $this->getDescription(),
+            $this->getTags(),
+            $this->getBackground(),
+            array_values($scenarios),
+            $this->getKeyword(),
+            $this->getLanguage(),
+            $this->getFile(),
+            $this->getLine()
+        );
+    }
+
+    /**
      * Returns whether the file path is an absolute path.
      *
      * @param string|null $file A file path
@@ -243,7 +263,6 @@ class FeatureNode implements KeywordNodeInterface, TaggedNodeInterface
                 && $file[1] === ':'
                 && strspn($file, '/\\', 2, 1)
             )
-            || parse_url($file, PHP_URL_SCHEME) !== null
-        ;
+            || parse_url($file, PHP_URL_SCHEME) !== null;
     }
 }

--- a/src/Node/OutlineNode.php
+++ b/src/Node/OutlineNode.php
@@ -201,12 +201,12 @@ class OutlineNode implements ScenarioInterface
     public function withTables(array $exampleTables): self
     {
         return new OutlineNode(
-            $this->getTitle(),
-            $this->getTags(),
-            $this->getSteps(),
+            $this->title,
+            $this->tags,
+            $this->steps,
             $exampleTables,
-            $this->getKeyword(),
-            $this->getLine()
+            $this->keyword,
+            $this->line,
         );
     }
 

--- a/src/Node/OutlineNode.php
+++ b/src/Node/OutlineNode.php
@@ -134,9 +134,9 @@ class OutlineNode implements ScenarioInterface
      *
      * WARNING: it returns a merged table with tags lost.
      *
-     * @deprecated use getExampleTables instead
-     *
      * @return ExampleTableNode
+     *
+     * @deprecated use getExampleTables instead
      */
     public function getExampleTable()
     {
@@ -193,6 +193,21 @@ class OutlineNode implements ScenarioInterface
     public function getLine()
     {
         return $this->line;
+    }
+
+    /**
+     * @param array<array-key, ExampleTableNode> $exampleTables
+     */
+    public function withTables(array $exampleTables): self
+    {
+        return new OutlineNode(
+            $this->getTitle(),
+            $this->getTags(),
+            $this->getSteps(),
+            $exampleTables,
+            $this->getKeyword(),
+            $this->getLine()
+        );
     }
 
     /**

--- a/tests/Filter/ComplexFilterTest.php
+++ b/tests/Filter/ComplexFilterTest.php
@@ -21,42 +21,21 @@ class ComplexFilterTest extends FilterTestCase
     {
         $scenarios = [new ScenarioNode('Scenario#1', [], [], '', 1)];
         $feature = new FeatureNode('Feature#1', null, [], null, $scenarios, '', '', null, 1);
+        $nonFilteringFilter = new class extends ComplexFilter {
+            public function isScenarioMatch(FeatureNode $feature, ScenarioInterface $scenario): bool
+            {
+                return true;
+            }
 
-        $filter = $this->createComplexFilter([$feature], $scenarios);
+            public function isFeatureMatch(FeatureNode $feature): bool
+            {
+                return true;
+            }
+        };
 
-        $filtered = $filter->filterFeature($feature);
+        $filtered = $nonFilteringFilter->filterFeature($feature);
 
         $this->assertCount(1, $scenarios = $filtered->getScenarios());
         $this->assertSame('Scenario#1', $scenarios[0]->getTitle());
-    }
-
-    /**
-     * @param list<FeatureNode> $matchingFeatures
-     * @param list<ScenarioInterface> $matchingScenarios
-     */
-    private function createComplexFilter(array $matchingFeatures, array $matchingScenarios): ComplexFilter
-    {
-        return new class($matchingFeatures, $matchingScenarios) extends ComplexFilter {
-            /**
-             * @param list<FeatureNode> $matchingFeatures
-             * @param list<ScenarioInterface> $matchingScenarios
-             */
-            public function __construct(
-                private readonly array $matchingFeatures,
-                private readonly array $matchingScenarios,
-            ) {
-            }
-
-            public function isScenarioMatch(FeatureNode $feature, ScenarioInterface $scenario)
-            {
-                return in_array($feature, $this->matchingFeatures, true)
-                    && in_array($scenario, $this->matchingScenarios, true);
-            }
-
-            public function isFeatureMatch(FeatureNode $feature)
-            {
-                return in_array($feature, $this->matchingFeatures, true);
-            }
-        };
     }
 }

--- a/tests/Filter/ComplexFilterTest.php
+++ b/tests/Filter/ComplexFilterTest.php
@@ -14,28 +14,73 @@ use Behat\Gherkin\Filter\ComplexFilter;
 use Behat\Gherkin\Node\FeatureNode;
 use Behat\Gherkin\Node\ScenarioInterface;
 use Behat\Gherkin\Node\ScenarioNode;
+use Closure;
+use RuntimeException;
 
 class ComplexFilterTest extends FilterTestCase
 {
-    public function testFilterFeature(): void
+    public function testFilterFeatureShouldReturnSameInstanceWhenNotFiltering(): void
     {
-        $scenarios = [new ScenarioNode('Scenario#1', [], [], '', 1)];
-        $feature = new FeatureNode('Feature#1', null, [], null, $scenarios, '', '', null, 1);
-        $nonFilteringFilter = new class extends ComplexFilter {
-            public function isScenarioMatch(FeatureNode $feature, ScenarioInterface $scenario): bool
-            {
-                return true;
+        $scenarios = [new ScenarioNode('A scenario', [], [], '', 1)];
+        $originalFeature = new FeatureNode('A feature', null, [], null, $scenarios, '', '', null, 1);
+        $nonFilteringFilter = $this->createComplexFilter(static fn () => true);
+
+        $filteredFeature = $nonFilteringFilter->filterFeature($originalFeature);
+
+        $this->assertSame($originalFeature, $filteredFeature);
+    }
+
+    public function testFilterFeatureShouldReturnDifferentInstanceWhenFilteringOutAllScenarios(): void
+    {
+        $scenarios = [new ScenarioNode('A scenario', [], [], '', 1)];
+        $originalFeature = new FeatureNode('A feature', null, [], null, $scenarios, '', '', null, 1);
+        $nonFilteringFilter = $this->createComplexFilter(static fn () => false);
+
+        $filteredFeature = $nonFilteringFilter->filterFeature($originalFeature);
+
+        $this->assertNotSame($originalFeature, $filteredFeature);
+        $this->assertFalse($filteredFeature->hasScenarios());
+    }
+
+    public function testFilterFeatureShouldReturnDifferentInstanceWhenFilteringScenarios(): void
+    {
+        $scenarios = [
+            $scenario1 = new ScenarioNode('Scenario#1', [], [], '', 1),
+            $scenario2 = new ScenarioNode('Scenario#2', [], [], '', 2),
+            $scenario3 = new ScenarioNode('Scenario#3', [], [], '', 3),
+        ];
+        $originalFeature = new FeatureNode('Feature#1', null, [], null, $scenarios, '', '', null, 1);
+        $nonFilteringFilter = $this->createComplexFilter(static fn ($feature, $scenario) => $scenario !== $scenario2);
+
+        $filteredFeature = $nonFilteringFilter->filterFeature($originalFeature);
+
+        $this->assertNotSame($originalFeature, $filteredFeature);
+        $this->assertSame([$scenario1, $scenario3], $filteredFeature->getScenarios());
+    }
+
+    /**
+     * @param Closure(FeatureNode, ScenarioInterface): bool $scenarioMatcher
+     */
+    private function createComplexFilter(Closure $scenarioMatcher): ComplexFilter
+    {
+        return new class($scenarioMatcher) extends ComplexFilter {
+            /**
+             * @param Closure(FeatureNode, ScenarioInterface): bool $scenarioMatcher
+             */
+            public function __construct(
+                private readonly Closure $scenarioMatcher,
+            ) {
             }
 
             public function isFeatureMatch(FeatureNode $feature): bool
             {
-                return true;
+                throw new RuntimeException('Not implemented');
+            }
+
+            public function isScenarioMatch(FeatureNode $feature, ScenarioInterface $scenario): bool
+            {
+                return ($this->scenarioMatcher)($feature, $scenario);
             }
         };
-
-        $filtered = $nonFilteringFilter->filterFeature($feature);
-
-        $this->assertCount(1, $scenarios = $filtered->getScenarios());
-        $this->assertSame('Scenario#1', $scenarios[0]->getTitle());
     }
 }

--- a/tests/Filter/ComplexFilterTest.php
+++ b/tests/Filter/ComplexFilterTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Behat Gherkin Parser.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Behat\Gherkin\Filter;
+
+use Behat\Gherkin\Filter\ComplexFilter;
+use Behat\Gherkin\Node\FeatureNode;
+use Behat\Gherkin\Node\ScenarioInterface;
+use Behat\Gherkin\Node\ScenarioNode;
+
+class ComplexFilterTest extends FilterTestCase
+{
+    public function testFilterFeature(): void
+    {
+        $scenarios = [new ScenarioNode('Scenario#1', [], [], '', 1)];
+        $feature = new FeatureNode('Feature#1', null, [], null, $scenarios, '', '', null, 1);
+
+        $filter = $this->createComplexFilter([$feature], $scenarios);
+
+        $filtered = $filter->filterFeature($feature);
+
+        $this->assertCount(1, $scenarios = $filtered->getScenarios());
+        $this->assertSame('Scenario#1', $scenarios[0]->getTitle());
+    }
+
+    /**
+     * @param list<FeatureNode> $matchingFeatures
+     * @param list<ScenarioInterface> $matchingScenarios
+     */
+    private function createComplexFilter(array $matchingFeatures, array $matchingScenarios): ComplexFilter
+    {
+        return new class($matchingFeatures, $matchingScenarios) extends ComplexFilter {
+            /**
+             * @param list<FeatureNode> $matchingFeatures
+             * @param list<ScenarioInterface> $matchingScenarios
+             */
+            public function __construct(
+                private readonly array $matchingFeatures,
+                private readonly array $matchingScenarios,
+            ) {
+            }
+
+            public function isScenarioMatch(FeatureNode $feature, ScenarioInterface $scenario)
+            {
+                return in_array($feature, $this->matchingFeatures, true)
+                    && in_array($scenario, $this->matchingScenarios, true);
+            }
+
+            public function isFeatureMatch(FeatureNode $feature)
+            {
+                return in_array($feature, $this->matchingFeatures, true);
+            }
+        };
+    }
+}


### PR DESCRIPTION
- added helper methods to construct feature/scenario with one different property (decreases boilerplate code)
- simplified some code:
  - some filtering could be done with lambda or method reference
  - replaced if condition with ternary
  - short-circuited tag matching (theoretically improves tag filtering speed)
- php-cs-fixer decided to fix some code style 🤷 