### PR TITLE
test: Make CucumberND name reading consistent

### DIFF
--- a/src/Loader/CucumberNDJsonAstLoader.php
+++ b/src/Loader/CucumberNDJsonAstLoader.php
@@ -50,8 +50,8 @@ class CucumberNDJsonAstLoader implements LoaderInterface
         $featureJson = $json['gherkinDocument']['feature'];
 
         return new FeatureNode(
-            $featureJson['name'] ?? null,
-            $featureJson['description'] ?? null,
+            $featureJson['name'],
+            $featureJson['description'],
             self::getTags($featureJson),
             self::getBackground($featureJson),
             self::getScenarios($featureJson),
@@ -83,7 +83,7 @@ class CucumberNDJsonAstLoader implements LoaderInterface
                 static function ($child) {
                     if ($child['scenario']['examples']) {
                         return new OutlineNode(
-                            $child['scenario']['name'] ?? null,
+                            $child['scenario']['name'],
                             self::getTags($child['scenario']),
                             self::getSteps($child['scenario']['steps'] ?? []),
                             self::getTables($child['scenario']['examples']),


### PR DESCRIPTION
According [to the spec](https://github.com/cucumber/messages/blob/e1537b07e511feb6405ed9aa00261ff79d8a9710/jsonschema/GherkinDocument.json#L160C19-L162C23), 'name' is always required and must not be null (simply search for 'name' and you'll see that it is defined as "type: string" and is always listed in "required").

The description is in a similar situation, except that we are also trimming it on top, [for historical reasons](https://github.com/Behat/Gherkin/issues/209) (to make the CucumberND input compatible with our parser).

Technically, these changes are not backword compatible, but not following the spec should be considered undefined behaviour, or?