### PR TITLE
Improve tests expecting exceptions

### DIFF
--- a/tests/Cucumber/CompatibilityTest.php
+++ b/tests/Cucumber/CompatibilityTest.php
@@ -184,7 +184,8 @@ class CompatibilityTest extends TestCase
             },
             E_ALL
         );
-        $this->expectException(RuntimeException::class);
+
         $this->expectExceptionMessageMatches($message);
+        $this->expectException(RuntimeException::class);
     }
 }

--- a/tests/Cucumber/CompatibilityTest.php
+++ b/tests/Cucumber/CompatibilityTest.php
@@ -111,6 +111,7 @@ class CompatibilityTest extends TestCase
         if (isset($this->deprecatedInsteadOfParseError[$file->getFilename()])) {
             $this->expectDeprecationErrorMatches($this->deprecatedInsteadOfParseError[$file->getFilename()]);
         } else {
+            // Note that the exception message is not part of compatibility testing and therefore cannot be checked.
             $this->expectException(ParserException::class);
         }
 

--- a/tests/Filter/TagFilterTest.php
+++ b/tests/Filter/TagFilterTest.php
@@ -15,7 +15,7 @@ use Behat\Gherkin\Node\ExampleTableNode;
 use Behat\Gherkin\Node\FeatureNode;
 use Behat\Gherkin\Node\OutlineNode;
 use Behat\Gherkin\Node\ScenarioNode;
-use Exception;
+use ErrorException;
 use PHPUnit\Framework\TestCase;
 
 class TagFilterTest extends TestCase
@@ -303,13 +303,13 @@ class TagFilterTest extends TestCase
     private function expectDeprecationError(): void
     {
         set_error_handler(
-            static function ($errno, $errstr) {
+            static function (int $errNo, string $errStr, string $errFile, int $errLine) {
                 restore_error_handler();
-                throw new Exception($errstr, $errno);
+                throw new ErrorException($errStr, $errNo, filename: $errFile, line: $errLine);
             },
             E_ALL
         );
 
-        $this->expectException(Exception::class);
+        $this->expectException(ErrorException::class);
     }
 }

--- a/tests/Filter/TagFilterTest.php
+++ b/tests/Filter/TagFilterTest.php
@@ -309,6 +309,7 @@ class TagFilterTest extends TestCase
             },
             E_ALL
         );
+
         $this->expectException(Exception::class);
     }
 }

--- a/tests/Keywords/CucumberKeywordsTest.php
+++ b/tests/Keywords/CucumberKeywordsTest.php
@@ -64,8 +64,9 @@ class CucumberKeywordsTest extends KeywordsTestCase
 
     public function testYamlRootMustBeAnArray(): void
     {
-        $this->expectException(ParseException::class);
-        $this->expectExceptionMessage('Root element must be an array, but string found.');
+        $this->expectExceptionObject(
+            new ParseException('Root element must be an array, but string found.')
+        );
 
         new CucumberKeywords("a\nstring");
     }
@@ -85,8 +86,9 @@ class CucumberKeywordsTest extends KeywordsTestCase
                 chmod($tempFile, 0);
             }
 
-            $this->expectException(ParseException::class);
-            $this->expectExceptionMessage("Unable to parse \"$tempFile\" as the file is not readable.");
+            $this->expectExceptionObject(
+                new ParseException("Unable to parse \"$tempFile\" as the file is not readable.")
+            );
 
             new CucumberKeywords($tempFile);
         } finally {

--- a/tests/Node/StepNodeTest.php
+++ b/tests/Node/StepNodeTest.php
@@ -20,7 +20,9 @@ class StepNodeTest extends TestCase
 {
     public function testThatStepCanHaveOnlyOneArgument(): void
     {
-        $this->expectException(NodeException::class);
+        $this->expectExceptionObject(
+            new NodeException('Steps could have only one argument, but `Gangway! I am on the page:` have 2.g')
+        );
 
         new StepNode('Gangway!', 'I am on the page:', [
             new PyStringNode(['one', 'two'], 11),

--- a/tests/Node/StepNodeTest.php
+++ b/tests/Node/StepNodeTest.php
@@ -21,7 +21,7 @@ class StepNodeTest extends TestCase
     public function testThatStepCanHaveOnlyOneArgument(): void
     {
         $this->expectExceptionObject(
-            new NodeException('Steps could have only one argument, but `Gangway! I am on the page:` have 2.g')
+            new NodeException('Steps could have only one argument, but `Gangway! I am on the page:` have 2.')
         );
 
         new StepNode('Gangway!', 'I am on the page:', [

--- a/tests/Node/TableNodeTest.php
+++ b/tests/Node/TableNodeTest.php
@@ -19,6 +19,7 @@ class TableNodeTest extends TestCase
     public function testConstructorExpectsSameNumberOfColumnsInEachRow(): void
     {
         $this->expectException(NodeException::class);
+
         new TableNode([
             ['username', 'password'],
             ['everzet'],
@@ -28,8 +29,9 @@ class TableNodeTest extends TestCase
 
     public function testConstructorExpectsTwoDimensionalArray(): void
     {
-        $this->expectException(NodeException::class);
-        $this->expectExceptionMessage("Table row '0' is expected to be array, got string");
+        $this->expectExceptionObject(
+            new NodeException("Table row '0' is expected to be array, got string")
+        );
 
         new TableNode([
             'everzet', 'antono',
@@ -38,8 +40,9 @@ class TableNodeTest extends TestCase
 
     public function testConstructorExpectsScalarCellValue(): void
     {
-        $this->expectException(NodeException::class);
-        $this->expectExceptionMessage("Table cell at row '0', col '0' is expected to be scalar, got array");
+        $this->expectExceptionObject(
+            new NodeException("Table cell at row '0', col '0' is expected to be scalar, got array")
+        );
 
         new TableNode([
             [['everzet', 'antono']],
@@ -48,8 +51,9 @@ class TableNodeTest extends TestCase
 
     public function testConstructorExpectsEqualRowLengths(): void
     {
-        $this->expectException(NodeException::class);
-        $this->expectExceptionMessage("Table row '1' is expected to have 2 columns, got 1");
+        $this->expectExceptionObject(
+            new NodeException("Table row '1' is expected to have 2 columns, got 1")
+        );
 
         new TableNode([
             ['everzet', 'antono'],
@@ -303,17 +307,17 @@ class TableNodeTest extends TestCase
 
     public function testMergeRowsFromTableWrongHeaderNameExceptionThrown(): void
     {
-        $this->expectException(NodeException::class);
         $table = new TableNode([
             5 => ['id', 'username', 'password'],
             10 => ['42', 'everzet', 'qwerty'],
             13 => ['2', 'antono', 'pa$sword'],
         ]);
-
         $new = new TableNode([
             25 => ['id', 'QWE', 'password'],
             210 => ['242', '2everzet', '2qwerty'],
         ]);
+
+        $this->expectException(NodeException::class);
 
         $table->mergeRowsFromTable($new);
     }
@@ -330,34 +334,34 @@ class TableNodeTest extends TestCase
 
     public function testMergeRowsFromTableWrongHeaderOrderExceptionThrown(): void
     {
-        $this->expectException(NodeException::class);
         $table = new TableNode([
             5 => ['id', 'username', 'password'],
             10 => ['42', 'everzet', 'qwerty'],
             13 => ['2', 'antono', 'pa$sword'],
         ]);
-
         $new = new TableNode([
             25 => ['id', 'password', 'username'],
             210 => ['242', '2everzet', '2qwerty'],
         ]);
+
+        $this->expectException(NodeException::class);
 
         $table->mergeRowsFromTable($new);
     }
 
     public function testMergeRowsFromTableWrongHeaderSizeExceptionThrown(): void
     {
-        $this->expectException(NodeException::class);
         $table = new TableNode([
             5 => ['id', 'username', 'password'],
             10 => ['42', 'everzet', 'qwerty'],
             13 => ['2', 'antono', 'pa$sword'],
         ]);
-
         $new = new TableNode([
             25 => ['id', 'username'],
             210 => ['242', '2everzet'],
         ]);
+
+        $this->expectException(NodeException::class);
 
         $table->mergeRowsFromTable($new);
     }

--- a/tests/Node/TableNodeTest.php
+++ b/tests/Node/TableNodeTest.php
@@ -18,7 +18,9 @@ class TableNodeTest extends TestCase
 {
     public function testConstructorExpectsSameNumberOfColumnsInEachRow(): void
     {
-        $this->expectException(NodeException::class);
+        $this->expectExceptionObject(
+            new NodeException("Table row '1' is expected to have 2 columns, got 1")
+        );
 
         new TableNode([
             ['username', 'password'],
@@ -317,14 +319,18 @@ class TableNodeTest extends TestCase
             210 => ['242', '2everzet', '2qwerty'],
         ]);
 
-        $this->expectException(NodeException::class);
+        $this->expectExceptionObject(
+            new NodeException('Tables have different structure. Cannot merge one into another')
+        );
 
         $table->mergeRowsFromTable($new);
     }
 
     public function testGetTableFromListWithMultidimensionalArrayArgument(): void
     {
-        $this->expectException(NodeException::class);
+        $this->expectExceptionObject(
+            new NodeException('List is not a one-dimensional array.')
+        );
 
         TableNode::fromList([
             [1, 2, 3],
@@ -344,7 +350,9 @@ class TableNodeTest extends TestCase
             210 => ['242', '2everzet', '2qwerty'],
         ]);
 
-        $this->expectException(NodeException::class);
+        $this->expectExceptionObject(
+            new NodeException('Tables have different structure. Cannot merge one into another')
+        );
 
         $table->mergeRowsFromTable($new);
     }
@@ -361,7 +369,9 @@ class TableNodeTest extends TestCase
             210 => ['242', '2everzet'],
         ]);
 
-        $this->expectException(NodeException::class);
+        $this->expectExceptionObject(
+            new NodeException('Tables have different structure. Cannot merge one into another')
+        );
 
         $table->mergeRowsFromTable($new);
     }

--- a/tests/ParserExceptionsTest.php
+++ b/tests/ParserExceptionsTest.php
@@ -172,6 +172,7 @@ class ParserExceptionsTest extends TestCase
         GHERKIN;
 
         $this->expectException(ParserException::class);
+
         $this->gherkin->parse($feature);
     }
 
@@ -184,6 +185,7 @@ class ParserExceptionsTest extends TestCase
         GHERKIN;
 
         $this->expectException(ParserException::class);
+
         $this->gherkin->parse($feature);
     }
 
@@ -199,6 +201,7 @@ class ParserExceptionsTest extends TestCase
         GHERKIN;
 
         $this->expectException(ParserException::class);
+
         $this->gherkin->parse($feature);
     }
 
@@ -213,6 +216,7 @@ class ParserExceptionsTest extends TestCase
         GHERKIN;
 
         $this->expectException(ParserException::class);
+
         $this->gherkin->parse($feature);
     }
 
@@ -228,6 +232,7 @@ class ParserExceptionsTest extends TestCase
         GHERKIN;
 
         $this->expectException(ParserException::class);
+
         $this->gherkin->parse($feature);
     }
 
@@ -243,6 +248,7 @@ class ParserExceptionsTest extends TestCase
         GHERKIN;
 
         $this->expectException(ParserException::class);
+
         $this->gherkin->parse($feature);
     }
 
@@ -259,6 +265,7 @@ class ParserExceptionsTest extends TestCase
         GHERKIN;
 
         $this->expectException(ParserException::class);
+
         $this->gherkin->parse($feature);
     }
 
@@ -271,6 +278,7 @@ class ParserExceptionsTest extends TestCase
         GHERKIN;
 
         $this->expectException(ParserException::class);
+
         $this->gherkin->parse($feature);
     }
 
@@ -286,6 +294,7 @@ class ParserExceptionsTest extends TestCase
         GHERKIN;
 
         $this->expectException(ParserException::class);
+
         $this->gherkin->parse($feature);
     }
 }

--- a/tests/ParserExceptionsTest.php
+++ b/tests/ParserExceptionsTest.php
@@ -159,7 +159,7 @@ class ParserExceptionsTest extends TestCase
         $this->assertEquals($secondTitle, $scenarios[1]->getTitle());
     }
 
-    public function testAmbigiousLanguage(): void
+    public function testAmbiguousLanguage(): void
     {
         $feature = <<<'GHERKIN'
         # language: en
@@ -171,7 +171,9 @@ class ParserExceptionsTest extends TestCase
             Given something wrong
         GHERKIN;
 
-        $this->expectException(ParserException::class);
+        $this->expectExceptionObject(
+            new ParserException('Ambiguous language specifiers on lines: 1 and 3')
+        );
 
         $this->gherkin->parse($feature);
     }
@@ -184,7 +186,9 @@ class ParserExceptionsTest extends TestCase
             Scenario Outline:
         GHERKIN;
 
-        $this->expectException(ParserException::class);
+        $this->expectExceptionObject(
+            new ParserException('Outline should have examples table, but got none for outline "" on line: 3')
+        );
 
         $this->gherkin->parse($feature);
     }
@@ -200,7 +204,9 @@ class ParserExceptionsTest extends TestCase
                 Then some additional step
         GHERKIN;
 
-        $this->expectException(ParserException::class);
+        $this->expectExceptionObject(
+            new ParserException('Expected Scenario, Outline or Background, but got Step on line: 6')
+        );
 
         $this->gherkin->parse($feature);
     }
@@ -215,7 +221,9 @@ class ParserExceptionsTest extends TestCase
                 Given some step
         GHERKIN;
 
-        $this->expectException(ParserException::class);
+        $this->expectExceptionObject(
+            new ParserException('Background can not be tagged, but it is on line: 4')
+        );
 
         $this->gherkin->parse($feature);
     }
@@ -231,7 +239,9 @@ class ParserExceptionsTest extends TestCase
                     some text
         GHERKIN;
 
-        $this->expectException(ParserException::class);
+        $this->expectExceptionObject(
+            new ParserException('Expected PyStringOp token, but got EOS on line: 7')
+        );
 
         $this->gherkin->parse($feature);
     }
@@ -247,7 +257,9 @@ class ParserExceptionsTest extends TestCase
                 Aaand some step
         GHERKIN;
 
-        $this->expectException(ParserException::class);
+        $this->expectExceptionObject(
+            new ParserException('Expected Step, but got text: "        Aaand some step"')
+        );
 
         $this->gherkin->parse($feature);
     }
@@ -264,7 +276,9 @@ class ParserExceptionsTest extends TestCase
                 Aaand some step
         GHERKIN;
 
-        $this->expectException(ParserException::class);
+        $this->expectExceptionObject(
+            new ParserException('Each Feature could have only one Background, but found multiple on lines 3 and 6')
+        );
 
         $this->gherkin->parse($feature);
     }
@@ -277,7 +291,9 @@ class ParserExceptionsTest extends TestCase
         Feature:
         GHERKIN;
 
-        $this->expectException(ParserException::class);
+        $this->expectExceptionObject(
+            new ParserException('Expected Scenario, Outline or Background, but got Feature on line: 3')
+        );
 
         $this->gherkin->parse($feature);
     }
@@ -293,7 +309,9 @@ class ParserExceptionsTest extends TestCase
                 | 42  | 42
         GHERKIN;
 
-        $this->expectException(ParserException::class);
+        $this->expectExceptionObject(
+            new ParserException('Expected Step, but got text: "        | foo | bar"')
+        );
 
         $this->gherkin->parse($feature);
     }


### PR DESCRIPTION
This started out from [this suggestion](https://github.com/Behat/Gherkin/pull/294/files#r2000707025), but then I saw a few other issues which I also fixed:
- exception message should be checked first since failures would be more informative (original issue)
  - also applies to message pattern matching
- many `expectException()`+`expectExceptionMessage()` cases could be replaced with `expectExceptionObject()`
- in a few cases we expected the exception too early, which could have hidden the real source of failure
- minor code style improvement: blank line between expectation and action