### PR TITLE
test: Add excluded cucumber parity tests for cucumber/gherkin up to 32.0.4

### DIFF
--- a/src/Loader/CucumberNDJsonAstLoader.php
+++ b/src/Loader/CucumberNDJsonAstLoader.php
@@ -51,7 +51,7 @@ class CucumberNDJsonAstLoader implements LoaderInterface
 
         return new FeatureNode(
             $featureJson['name'] ?? null,
-            $featureJson['description'] ? trim($featureJson['description']) : null,
+            $featureJson['description'] ?? null,
             self::getTags($featureJson),
             self::getBackground($featureJson),
             self::getScenarios($featureJson),

--- a/tests/Cucumber/CompatibilityTest.php
+++ b/tests/Cucumber/CompatibilityTest.php
@@ -59,6 +59,7 @@ class CompatibilityTest extends TestCase
      */
     private array $parsedButShouldNotBe = [
         'invalid_language.feature' => 'Invalid language is silently ignored',
+        'unexpected_end_of_file.feature' => 'EOF after tags is ignored',
     ];
 
     /**

--- a/tests/Cucumber/CompatibilityTest.php
+++ b/tests/Cucumber/CompatibilityTest.php
@@ -48,7 +48,6 @@ class CompatibilityTest extends TestCase
         'spaces_in_language.feature' => 'Whitespace not supported around language selector',
         'incomplete_feature_3.feature' => 'file with no feature keyword not handled correctly',
         'rule_without_name_and_description.feature' => 'Rule is wrongly parsed as Description',
-        'escaped_pipes.feature' => 'Feature description has wrong whitespace captured',
         'incomplete_scenario.feature' => 'Wrong background parsing when there are no steps',
         'incomplete_background_2.feature' => 'Wrong background parsing when there are no steps',
     ];
@@ -156,6 +155,15 @@ class CompatibilityTest extends TestCase
     {
         if (is_null($featureNode)) {
             return null;
+        }
+
+        if ($featureNode->getDescription() !== null) {
+            // We currently handle whitespace in feature descriptions differently to cucumber
+            // https://github.com/Behat/Gherkin/issues/209
+            // We need to be able to ignore that difference so that we can still run cucumber tests that
+            // include a description but are covering other features.
+            $trimmedDescription = preg_replace('/^\s+/m', '', $featureNode->getDescription());
+            $this->setPrivateProperty($featureNode, 'description', $trimmedDescription);
         }
 
         foreach ($featureNode->getScenarios() as $scenarioNode) {

--- a/tests/Cucumber/CompatibilityTest.php
+++ b/tests/Cucumber/CompatibilityTest.php
@@ -42,6 +42,7 @@ class CompatibilityTest extends TestCase
         'rule_with_tag.feature' => 'Rule keyword not supported',
         'tags.feature' => 'Rule keyword not supported',
         'descriptions.feature' => 'Examples table descriptions not supported',
+        'extra_table_content.feature' => 'Table without right border triggers a ParserException',
         'incomplete_scenario_outline.feature' => 'Scenario and Scenario outline not yet synonyms',
         'padded_example.feature' => 'Scenario and Scenario outline not yet synonyms',
         'scenario_outline.feature' => 'Scenario and Scenario outline not yet synonyms',

--- a/tests/Cucumber/CompatibilityTest.php
+++ b/tests/Cucumber/CompatibilityTest.php
@@ -42,6 +42,7 @@ class CompatibilityTest extends TestCase
         'rule_with_tag.feature' => 'Rule keyword not supported',
         'tags.feature' => 'Rule keyword not supported',
         'descriptions.feature' => 'Examples table descriptions not supported',
+        'descriptions_with_comments.feature' => 'Examples table descriptions not supported',
         'extra_table_content.feature' => 'Table without right border triggers a ParserException',
         'incomplete_scenario_outline.feature' => 'Scenario and Scenario outline not yet synonyms',
         'padded_example.feature' => 'Scenario and Scenario outline not yet synonyms',


### PR DESCRIPTION
The newer cucumber/gherkin releases have brought in a few more examples that are not handled by our parser.

From reviewing these, each of them has some potential details to consider, so I propose we add them to the exclusion lists (so that we can merge the cucumber/gherkin update branch and i18n changes) and then tackle them separately.

I did notice that one of the excluded tests (and a couple of new ones) were only problematic because we handle whitespace in feature descriptions differently to gherkin - as tracked in #209. Rather than exclude those completely, I've changed the test to normalise the whitespace so that we can still assert the rest of the example matches the expectation.