### PR TITLE
change: Throw ParserException if file ends with tags

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -569,6 +569,15 @@ class Parser
         }
 
         $nextType = $this->predictTokenType();
+
+        if ($nextType === 'EOS') {
+            throw new ParserException(sprintf(
+                'Unexpected end of file after tags on line %d%s',
+                $token['line'],
+                $this->file ? ' in file: ' . $this->file : '',
+            ));
+        }
+
         if (!isset($possibleTransitions[$currentType]) || in_array($nextType, $possibleTransitions[$currentType])) {
             return $this->parseExpression();
         }

--- a/tests/Cucumber/CompatibilityTest.php
+++ b/tests/Cucumber/CompatibilityTest.php
@@ -59,6 +59,7 @@ class CompatibilityTest extends TestCase
      */
     private array $parsedButShouldNotBe = [
         'invalid_language.feature' => 'Invalid language is silently ignored',
+        'unexpected_end_of_file.feature' => 'EOF after tags is ignored',
     ];
 
     /**

--- a/tests/Cucumber/CompatibilityTest.php
+++ b/tests/Cucumber/CompatibilityTest.php
@@ -48,7 +48,6 @@ class CompatibilityTest extends TestCase
         'spaces_in_language.feature' => 'Whitespace not supported around language selector',
         'incomplete_feature_3.feature' => 'file with no feature keyword not handled correctly',
         'rule_without_name_and_description.feature' => 'Rule is wrongly parsed as Description',
-        'escaped_pipes.feature' => 'Feature description has wrong whitespace captured',
         'incomplete_scenario.feature' => 'Wrong background parsing when there are no steps',
         'incomplete_background_2.feature' => 'Wrong background parsing when there are no steps',
     ];
@@ -156,6 +155,15 @@ class CompatibilityTest extends TestCase
     {
         if (is_null($featureNode)) {
             return null;
+        }
+
+        if ($featureNode->getDescription() !== null) {
+            // We currently handle whitespace in feature descriptions differently to cucumber
+            // https://github.com/Behat/Gherkin/issues/209
+            // We need to be able to ignore that difference so that we can still run cucumber tests that
+            // include a description but are covering other features.
+            $trimmedDescription = preg_replace('/^\s+/m', '', $featureNode->getDescription());
+            $this->setPrivateProperty($featureNode, 'description', $trimmedDescription);
         }
 
         foreach ($featureNode->getScenarios() as $scenarioNode) {

--- a/tests/Cucumber/CompatibilityTest.php
+++ b/tests/Cucumber/CompatibilityTest.php
@@ -42,6 +42,7 @@ class CompatibilityTest extends TestCase
         'rule_with_tag.feature' => 'Rule keyword not supported',
         'tags.feature' => 'Rule keyword not supported',
         'descriptions.feature' => 'Examples table descriptions not supported',
+        'extra_table_content.feature' => 'Table without right border triggers a ParserException',
         'incomplete_scenario_outline.feature' => 'Scenario and Scenario outline not yet synonyms',
         'padded_example.feature' => 'Scenario and Scenario outline not yet synonyms',
         'scenario_outline.feature' => 'Scenario and Scenario outline not yet synonyms',

--- a/tests/Cucumber/CompatibilityTest.php
+++ b/tests/Cucumber/CompatibilityTest.php
@@ -42,6 +42,7 @@ class CompatibilityTest extends TestCase
         'rule_with_tag.feature' => 'Rule keyword not supported',
         'tags.feature' => 'Rule keyword not supported',
         'descriptions.feature' => 'Examples table descriptions not supported',
+        'descriptions_with_comments.feature' => 'Examples table descriptions not supported',
         'extra_table_content.feature' => 'Table without right border triggers a ParserException',
         'incomplete_scenario_outline.feature' => 'Scenario and Scenario outline not yet synonyms',
         'padded_example.feature' => 'Scenario and Scenario outline not yet synonyms',

--- a/tests/Cucumber/CompatibilityTest.php
+++ b/tests/Cucumber/CompatibilityTest.php
@@ -59,7 +59,6 @@ class CompatibilityTest extends TestCase
      */
     private array $parsedButShouldNotBe = [
         'invalid_language.feature' => 'Invalid language is silently ignored',
-        'unexpected_end_of_file.feature' => 'EOF after tags is ignored',
     ];
 
     /**

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -48,14 +48,18 @@ final class ParserTest extends TestCase
     {
         $parser = $this->createGherkinParser();
 
-        $parser->parse(
-            <<<'FEATURE'
-            Feature:
-            Scenario:
-            Given step
-            @skipped
-            FEATURE
-        );
+        try {
+            $parser->parse(
+                <<<'FEATURE'
+                Feature:
+                Scenario:
+                Given step
+                @skipped
+                FEATURE,
+            );
+        } catch (ParserException) {
+            // expected - features cannot end with tags
+        }
         $feature2 = $parser->parse(
             <<<'FEATURE'
             Feature:


### PR DESCRIPTION
**Based on #311 - only the last commit is new in this branch**.

For parity with cucumber/gherkin, do not accept feature files that end with `@tags` with no subsequent content.

cucumber/gherkin is relatively permissive about incomplete files in some cases (for example, it is explicitly valid to have a file with a Feature: but no scenarios, or a Scenario: with no steps). I suspect this is intentional to avoid parser errors while iterating on a feature.

However, the presence of `@tags` at the end of the file is unusual and suggests that the file is incomplete or damaged. cucumber/gherkin treats this as an exception and so should we.