### PR TITLE
change: Throw ParserException if file ends with tags

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -569,6 +569,15 @@ class Parser
         }
 
         $nextType = $this->predictTokenType();
+
+        if ($nextType === 'EOS') {
+            throw new ParserException(sprintf(
+                'Unexpected end of file after tags on line %d%s',
+                $token['line'],
+                $this->file ? ' in file: ' . $this->file : '',
+            ));
+        }
+
         if (!isset($possibleTransitions[$currentType]) || in_array($nextType, $possibleTransitions[$currentType])) {
             return $this->parseExpression();
         }

--- a/tests/Cucumber/CompatibilityTest.php
+++ b/tests/Cucumber/CompatibilityTest.php
@@ -59,7 +59,6 @@ class CompatibilityTest extends TestCase
      */
     private array $parsedButShouldNotBe = [
         'invalid_language.feature' => 'Invalid language is silently ignored',
-        'unexpected_end_of_file.feature' => 'EOF after tags is ignored',
     ];
 
     /**

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -48,14 +48,19 @@ final class ParserTest extends TestCase
     {
         $parser = $this->createGherkinParser();
 
-        $parser->parse(
-            <<<'FEATURE'
-            Feature:
-            Scenario:
-            Given step
-            @skipped
-            FEATURE
-        );
+        try {
+            $parser->parse(
+                <<<'FEATURE'
+                Feature:
+                Scenario:
+                Given step
+                @skipped
+                FEATURE,
+            );
+        } catch (ParserException $e) {
+            // expected - features cannot end with tags
+            $this->assertSame('Unexpected end of file after tags on line 5', $e->getMessage());
+        }
         $feature2 = $parser->parse(
             <<<'FEATURE'
             Feature:


### PR DESCRIPTION
For parity with cucumber/gherkin, do not accept feature files that end with `@tags` with no subsequent content.

cucumber/gherkin is relatively permissive about incomplete files in some cases (for example, it is explicitly valid to have a file with a Feature: but no scenarios, or a Scenario: with no steps). I suspect this is intentional to avoid parser errors while iterating on a partially-complete feature file.

However, the presence of `@tags` at the end of the file is unusual and suggests that the file is incomplete or damaged. cucumber/gherkin treats this as an exception and so should we.