### PR TITLE
ci: Add conventional title to gherkin update, error on missing asserts

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -98,4 +98,4 @@ jobs:
           BRANCH_NAME: ${{ steps.check-existing-pr.outputs.commit_branch }}
           COMMIT_MSG: ${{ steps.cucumber.outputs.commit_msg }}
           PR_EXISTS: ${{ steps.check-existing-pr.outputs.exists }}
-          PR_TITLE: Update to cucumber/gherkin ${{ steps.cucumber.outputs.cucumber_version }}
+          PR_TITLE: "chore: Update to cucumber/gherkin ${{ steps.cucumber.outputs.cucumber_version }}"

--- a/bin/update_cucumber
+++ b/bin/update_cucumber
@@ -15,7 +15,7 @@ set_error_handler(static fn ($code, $msg, $file, $line) => throw new ErrorExcept
 if (ini_get('zend.assertions') !== '1') {
     // Ensure our assertions are actually processed. Otherwise any code inside the assert() call is compiled out
     echo "This script must be run with zend.assertions set to 1\n";
-    exit;
+    exit(1);
 }
 
 $updater = new


### PR DESCRIPTION
Minor improvements to the cucumber update workflow, including properly failing if asserts are not enabled (as spotted by @stof in https://github.com/Behat/Gherkin/pull/302#pullrequestreview-2807971749)