### PR TITLE
Make private props readonly; fix tests

### DIFF
--- a/src/Cache/FileCache.php
+++ b/src/Cache/FileCache.php
@@ -22,7 +22,7 @@ use Composer\InstalledVersions;
  */
 class FileCache implements CacheInterface
 {
-    private $path;
+    private readonly string $path;
 
     /**
      * Used as part of the cache directory path to invalidate cache if the installed package version changes.
@@ -42,7 +42,7 @@ class FileCache implements CacheInterface
      *
      * @throws CacheException
      */
-    public function __construct($path)
+    public function __construct(string $path)
     {
         $this->path = rtrim($path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . self::getGherkinVersionHash();
 

--- a/src/Filter/NarrativeFilter.php
+++ b/src/Filter/NarrativeFilter.php
@@ -20,19 +20,9 @@ use Behat\Gherkin\Node\ScenarioInterface;
  */
 class NarrativeFilter extends SimpleFilter
 {
-    /**
-     * @var string
-     */
-    private $regex;
-
-    /**
-     * Initializes filter.
-     *
-     * @param string $regex
-     */
-    public function __construct($regex)
-    {
-        $this->regex = $regex;
+    public function __construct(
+        private readonly string $regex,
+    ) {
     }
 
     public function isFeatureMatch(FeatureNode $feature)

--- a/src/Keywords/ArrayKeywords.php
+++ b/src/Keywords/ArrayKeywords.php
@@ -41,21 +41,22 @@ namespace Behat\Gherkin\Keywords;
  * ));
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @phpstan-import-type TMultiLanguageKeywords from KeywordsInterface
  */
 class ArrayKeywords implements KeywordsInterface
 {
-    private $keywords = [];
     private $keywordString = [];
     private $language;
 
     /**
      * Initializes holder with keywords.
      *
-     * @param array $keywords Keywords array
+     * @param TMultiLanguageKeywords $keywords Keywords array
      */
-    public function __construct(array $keywords)
-    {
-        $this->keywords = $keywords;
+    public function __construct(
+        private readonly array $keywords,
+    ) {
     }
 
     /**

--- a/src/Keywords/ArrayKeywords.php
+++ b/src/Keywords/ArrayKeywords.php
@@ -52,7 +52,7 @@ class ArrayKeywords implements KeywordsInterface
     /**
      * Initializes holder with keywords.
      *
-     * @param TMultiLanguageKeywords $keywords Keywords array
+     * @phpstan-param TMultiLanguageKeywords $keywords Keywords array
      */
     public function __construct(
         private readonly array $keywords,

--- a/src/Keywords/KeywordsDumper.php
+++ b/src/Keywords/KeywordsDumper.php
@@ -17,17 +17,11 @@ namespace Behat\Gherkin\Keywords;
  */
 class KeywordsDumper
 {
-    private $keywords;
     private $keywordsDumper;
 
-    /**
-     * Initializes dumper.
-     *
-     * @param KeywordsInterface $keywords Keywords instance
-     */
-    public function __construct(KeywordsInterface $keywords)
-    {
-        $this->keywords = $keywords;
+    public function __construct(
+        private readonly KeywordsInterface $keywords,
+    ) {
         $this->keywordsDumper = [$this, 'dumpKeywords'];
     }
 

--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -27,7 +27,6 @@ class Lexer
     private $trimmedLine;
     private $lineNumber;
     private $eos;
-    private $keywords;
     private $keywordsCache = [];
     private $stepKeywordTypesCache = [];
     private $deferredObjects = [];
@@ -40,14 +39,9 @@ class Lexer
     private $allowSteps = false;
     private $pyStringDelimiter;
 
-    /**
-     * Initializes lexer.
-     *
-     * @param KeywordsInterface $keywords Keywords holder
-     */
-    public function __construct(KeywordsInterface $keywords)
-    {
-        $this->keywords = $keywords;
+    public function __construct(
+        private readonly KeywordsInterface $keywords,
+    ) {
     }
 
     /**

--- a/src/Loader/YamlFileLoader.php
+++ b/src/Loader/YamlFileLoader.php
@@ -20,11 +20,9 @@ use Symfony\Component\Yaml\Yaml;
  */
 class YamlFileLoader extends AbstractFileLoader
 {
-    private $loader;
-
-    public function __construct()
-    {
-        $this->loader = new ArrayLoader();
+    public function __construct(
+        private readonly LoaderInterface $loader = new ArrayLoader(),
+    ) {
     }
 
     /**

--- a/src/Node/BackgroundNode.php
+++ b/src/Node/BackgroundNode.php
@@ -18,36 +18,14 @@ namespace Behat\Gherkin\Node;
 class BackgroundNode implements ScenarioLikeInterface
 {
     /**
-     * @var string
-     */
-    private $title;
-    /**
-     * @var StepNode[]
-     */
-    private $steps = [];
-    /**
-     * @var string
-     */
-    private $keyword;
-    /**
-     * @var int
-     */
-    private $line;
-
-    /**
-     * Initializes background.
-     *
-     * @param string|null $title
      * @param StepNode[] $steps
-     * @param string $keyword
-     * @param int $line
      */
-    public function __construct($title, array $steps, $keyword, $line)
-    {
-        $this->title = $title;
-        $this->steps = $steps;
-        $this->keyword = $keyword;
-        $this->line = $line;
+    public function __construct(
+        private readonly ?string $title,
+        private readonly array $steps,
+        private readonly string $keyword,
+        private readonly int $line,
+    ) {
     }
 
     /**

--- a/src/Node/ExampleNode.php
+++ b/src/Node/ExampleNode.php
@@ -20,41 +20,6 @@ class ExampleNode implements ScenarioInterface, NamedScenarioInterface
     use TaggedNodeTrait;
 
     /**
-     * @var string
-     */
-    private $text;
-    /**
-     * @var string[]
-     */
-    private $tags;
-    /**
-     * @var StepNode[]
-     */
-    private $outlineSteps;
-    /**
-     * @var array<string, string>
-     */
-    private $tokens;
-    /**
-     * @var int
-     */
-    private $line;
-    /**
-     * @var list<StepNode>|null
-     */
-    private $steps;
-    /**
-     * @var string
-     */
-    private $outlineTitle;
-    /**
-     * @var int|null
-     */
-    private $index;
-
-    /**
-     * Initializes outline.
-     *
      * @param string $text The entire row as a string, e.g. "| 1 | 2 | 3 |"
      * @param array<array-key, string> $tags
      * @param array<array-key, StepNode> $outlineSteps
@@ -62,16 +27,18 @@ class ExampleNode implements ScenarioInterface, NamedScenarioInterface
      * @param int $line line number within the feature file
      * @param string|null $outlineTitle original title of the scenario outline
      * @param int|null $index the 1-based index of the row/example within the scenario outline
+     * @param list<StepNode>|null $steps
      */
-    public function __construct($text, array $tags, $outlineSteps, array $tokens, $line, $outlineTitle = null, $index = null)
-    {
-        $this->text = $text;
-        $this->tags = $tags;
-        $this->outlineSteps = $outlineSteps;
-        $this->tokens = $tokens;
-        $this->line = $line;
-        $this->outlineTitle = $outlineTitle;
-        $this->index = $index;
+    public function __construct(
+        private readonly string $text,
+        private readonly array $tags,
+        private readonly array $outlineSteps,
+        private readonly array $tokens,
+        private readonly int $line,
+        private readonly ?string $outlineTitle = null,
+        private readonly ?int $index = null,
+        private ?array $steps = null,
+    ) {
     }
 
     /**
@@ -125,11 +92,11 @@ class ExampleNode implements ScenarioInterface, NamedScenarioInterface
     /**
      * Returns outline steps.
      *
-     * @return StepNode[]
+     * @return list<StepNode>
      */
     public function getSteps()
     {
-        return $this->steps = $this->steps ?: $this->createExampleSteps();
+        return $this->steps ?? ($this->steps = $this->createExampleSteps());
     }
 
     /**
@@ -177,6 +144,23 @@ class ExampleNode implements ScenarioInterface, NamedScenarioInterface
     public function getExampleText(): string
     {
         return $this->text;
+    }
+
+    /**
+     * Returns a copy of this example, but with a different set of steps.
+     */
+    public function withSteps(array $steps): self
+    {
+        return new self(
+            $this->text,
+            $this->tags,
+            $this->outlineSteps,
+            $this->tokens,
+            $this->line,
+            $this->outlineTitle,
+            $this->index,
+            $steps,
+        );
     }
 
     /**

--- a/src/Node/ExampleNode.php
+++ b/src/Node/ExampleNode.php
@@ -20,9 +20,9 @@ class ExampleNode implements ScenarioInterface, NamedScenarioInterface
     use TaggedNodeTrait;
 
     /**
-     * @var list<StepNode>
+     * @var list<StepNode>|null
      */
-    private array $steps;
+    private ?array $steps = null;
 
     /**
      * @param string $text The entire row as a string, e.g. "| 1 | 2 | 3 |"

--- a/src/Node/ExampleNode.php
+++ b/src/Node/ExampleNode.php
@@ -20,6 +20,11 @@ class ExampleNode implements ScenarioInterface, NamedScenarioInterface
     use TaggedNodeTrait;
 
     /**
+     * @var list<StepNode>
+     */
+    private array $steps;
+
+    /**
      * @param string $text The entire row as a string, e.g. "| 1 | 2 | 3 |"
      * @param array<array-key, string> $tags
      * @param array<array-key, StepNode> $outlineSteps
@@ -27,7 +32,6 @@ class ExampleNode implements ScenarioInterface, NamedScenarioInterface
      * @param int $line line number within the feature file
      * @param string|null $outlineTitle original title of the scenario outline
      * @param int|null $index the 1-based index of the row/example within the scenario outline
-     * @param list<StepNode>|null $steps
      */
     public function __construct(
         private readonly string $text,
@@ -37,7 +41,6 @@ class ExampleNode implements ScenarioInterface, NamedScenarioInterface
         private readonly int $line,
         private readonly ?string $outlineTitle = null,
         private readonly ?int $index = null,
-        private ?array $steps = null,
     ) {
     }
 
@@ -144,23 +147,6 @@ class ExampleNode implements ScenarioInterface, NamedScenarioInterface
     public function getExampleText(): string
     {
         return $this->text;
-    }
-
-    /**
-     * Returns a copy of this example, but with a different set of steps.
-     */
-    public function withSteps(array $steps): self
-    {
-        return new self(
-            $this->text,
-            $this->tags,
-            $this->outlineSteps,
-            $this->tokens,
-            $this->line,
-            $this->outlineTitle,
-            $this->index,
-            $steps,
-        );
     }
 
     /**

--- a/src/Node/ExampleNode.php
+++ b/src/Node/ExampleNode.php
@@ -99,7 +99,7 @@ class ExampleNode implements ScenarioInterface, NamedScenarioInterface
      */
     public function getSteps()
     {
-        return $this->steps ?? ($this->steps = $this->createExampleSteps());
+        return $this->steps ??= $this->createExampleSteps();
     }
 
     /**

--- a/src/Node/ExampleTableNode.php
+++ b/src/Node/ExampleTableNode.php
@@ -20,27 +20,14 @@ class ExampleTableNode extends TableNode implements TaggedNodeInterface
     use TaggedNodeTrait;
 
     /**
-     * @var string[]
-     */
-    private $tags;
-
-    /**
-     * @var string
-     */
-    private $keyword;
-
-    /**
-     * Initializes example table.
-     *
      * @param array $table Table in form of [$rowLineNumber => [$val1, $val2, $val3]]
-     * @param string $keyword
      * @param string[] $tags
      */
-    public function __construct(array $table, $keyword, array $tags = [])
-    {
-        $this->keyword = $keyword;
-        $this->tags = $tags;
-
+    public function __construct(
+        array $table,
+        private readonly string $keyword,
+        private readonly array $tags = [],
+    ) {
         parent::__construct($table);
     }
 

--- a/src/Node/FeatureNode.php
+++ b/src/Node/FeatureNode.php
@@ -24,78 +24,25 @@ class FeatureNode implements KeywordNodeInterface, TaggedNodeInterface
     use TaggedNodeTrait;
 
     /**
-     * @var string|null
-     */
-    private $title;
-    /**
-     * @var string|null
-     */
-    private $description;
-    /**
-     * @var string[]
-     */
-    private $tags = [];
-    /**
-     * @var BackgroundNode|null
-     */
-    private $background;
-    /**
-     * @var ScenarioInterface[]
-     */
-    private $scenarios = [];
-    /**
-     * @var string
-     */
-    private $keyword;
-    /**
-     * @var string
-     */
-    private $language;
-    /**
-     * @var string|null
-     */
-    private $file;
-    /**
-     * @var int
-     */
-    private $line;
-
-    /**
-     * Initializes feature.
-     *
-     * @param string|null $title
-     * @param string|null $description
      * @param string[] $tags
      * @param ScenarioInterface[] $scenarios
-     * @param string $keyword
-     * @param string $language
      * @param string|null $file the absolute path to the feature file
-     * @param int $line
      */
     public function __construct(
-        $title,
-        $description,
-        array $tags,
-        ?BackgroundNode $background,
-        array $scenarios,
-        $keyword,
-        $language,
-        $file,
-        $line,
+        private readonly ?string $title,
+        private readonly ?string $description,
+        private readonly array $tags,
+        private readonly ?BackgroundNode $background,
+        private readonly array $scenarios,
+        private readonly string $keyword,
+        private readonly string $language,
+        private readonly ?string $file,
+        private readonly int $line,
     ) {
         // Verify that the feature file is an absolute path.
         if (!empty($file) && !$this->isAbsolutePath($file)) {
             throw new InvalidArgumentException('The file should be an absolute path.');
         }
-        $this->title = $title;
-        $this->description = $description;
-        $this->tags = $tags;
-        $this->background = $background;
-        $this->scenarios = $scenarios;
-        $this->keyword = $keyword;
-        $this->language = $language;
-        $this->file = $file;
-        $this->line = $line;
     }
 
     /**
@@ -224,7 +171,7 @@ class FeatureNode implements KeywordNodeInterface, TaggedNodeInterface
     }
 
     /**
-     * Returns a copy of this feature but with a different set of scenarios.
+     * Returns a copy of this feature, but with a different set of scenarios.
      *
      * @param array<array-key, ScenarioInterface> $scenarios
      */
@@ -236,6 +183,24 @@ class FeatureNode implements KeywordNodeInterface, TaggedNodeInterface
             $this->tags,
             $this->background,
             array_values($scenarios),
+            $this->keyword,
+            $this->language,
+            $this->file,
+            $this->line,
+        );
+    }
+
+    /**
+     * Returns a copy of this feature, but with a different description.
+     */
+    public function withDescription(string $description): self
+    {
+        return new self(
+            $this->title,
+            $description,
+            $this->tags,
+            $this->background,
+            $this->scenarios,
             $this->keyword,
             $this->language,
             $this->file,

--- a/src/Node/FeatureNode.php
+++ b/src/Node/FeatureNode.php
@@ -191,24 +191,6 @@ class FeatureNode implements KeywordNodeInterface, TaggedNodeInterface
     }
 
     /**
-     * Returns a copy of this feature, but with a different description.
-     */
-    public function withDescription(string $description): self
-    {
-        return new self(
-            $this->title,
-            $description,
-            $this->tags,
-            $this->background,
-            $this->scenarios,
-            $this->keyword,
-            $this->language,
-            $this->file,
-            $this->line,
-        );
-    }
-
-    /**
      * Returns whether the file path is an absolute path.
      *
      * @param string|null $file A file path

--- a/src/Node/OutlineNode.php
+++ b/src/Node/OutlineNode.php
@@ -132,7 +132,7 @@ class OutlineNode implements ScenarioInterface
      */
     public function getExamples()
     {
-        return $this->examples ?? ($this->examples = $this->createExamples());
+        return $this->examples ??= $this->createExamples();
     }
 
     /**

--- a/src/Node/OutlineNode.php
+++ b/src/Node/OutlineNode.php
@@ -20,57 +20,27 @@ class OutlineNode implements ScenarioInterface
     use TaggedNodeTrait;
 
     /**
-     * @var string
-     */
-    private $title;
-    /**
-     * @var string[]
-     */
-    private $tags;
-    /**
-     * @var StepNode[]
-     */
-    private $steps;
-    /**
      * @var array<array-key, ExampleTableNode>
      */
-    private $tables;
+    private array $tables;
     /**
-     * @var string
+     * @var ExampleNode[]
      */
-    private $keyword;
-    /**
-     * @var int
-     */
-    private $line;
-    /**
-     * @var ExampleNode[]|null
-     */
-    private $examples;
+    private array $examples;
 
     /**
-     * Initializes outline.
-     *
-     * @param string|null $title
      * @param string[] $tags
      * @param StepNode[] $steps
      * @param ExampleTableNode|array<array-key, ExampleTableNode> $tables
-     * @param string $keyword
-     * @param int $line
      */
     public function __construct(
-        $title,
-        array $tags,
-        array $steps,
-        $tables,
-        $keyword,
-        $line,
+        private readonly ?string $title,
+        private readonly array $tags,
+        private readonly array $steps,
+        array|ExampleTableNode $tables,
+        private readonly string $keyword,
+        private readonly int $line,
     ) {
-        $this->title = $title;
-        $this->tags = $tags;
-        $this->steps = $steps;
-        $this->keyword = $keyword;
-        $this->line = $line;
         $this->tables = is_array($tables) ? $tables : [$tables];
     }
 
@@ -162,7 +132,7 @@ class OutlineNode implements ScenarioInterface
      */
     public function getExamples()
     {
-        return $this->examples = $this->examples ?: $this->createExamples();
+        return $this->examples ?? ($this->examples = $this->createExamples());
     }
 
     /**
@@ -196,15 +166,32 @@ class OutlineNode implements ScenarioInterface
     }
 
     /**
+     * Returns a copy of this outline, but with a different table.
+     *
      * @param array<array-key, ExampleTableNode> $exampleTables
      */
     public function withTables(array $exampleTables): self
     {
-        return new OutlineNode(
+        return new self(
             $this->title,
             $this->tags,
             $this->steps,
             $exampleTables,
+            $this->keyword,
+            $this->line,
+        );
+    }
+
+    /**
+     * Returns a copy of this outline, but with a different set of steps.
+     */
+    public function withSteps(array $steps): self
+    {
+        return new self(
+            $this->title,
+            $this->tags,
+            $steps,
+            $this->tables,
             $this->keyword,
             $this->line,
         );

--- a/src/Node/OutlineNode.php
+++ b/src/Node/OutlineNode.php
@@ -183,21 +183,6 @@ class OutlineNode implements ScenarioInterface
     }
 
     /**
-     * Returns a copy of this outline, but with a different set of steps.
-     */
-    public function withSteps(array $steps): self
-    {
-        return new self(
-            $this->title,
-            $this->tags,
-            $steps,
-            $this->tables,
-            $this->keyword,
-            $this->line,
-        );
-    }
-
-    /**
      * Creates examples for this outline using examples table.
      *
      * @return ExampleNode[]

--- a/src/Node/PyStringNode.php
+++ b/src/Node/PyStringNode.php
@@ -18,24 +18,13 @@ namespace Behat\Gherkin\Node;
 class PyStringNode implements ArgumentInterface
 {
     /**
-     * @var array
-     */
-    private $strings = [];
-    /**
-     * @var int
-     */
-    private $line;
-
-    /**
-     * Initializes PyString.
-     *
      * @param array $strings String in form of [$stringLine]
      * @param int $line Line number where string been started
      */
-    public function __construct(array $strings, $line)
-    {
-        $this->strings = $strings;
-        $this->line = $line;
+    public function __construct(
+        private readonly array $strings,
+        private readonly int $line,
+    ) {
     }
 
     /**

--- a/src/Node/ScenarioInterface.php
+++ b/src/Node/ScenarioInterface.php
@@ -17,12 +17,4 @@ namespace Behat\Gherkin\Node;
  */
 interface ScenarioInterface extends ScenarioLikeInterface, TaggedNodeInterface
 {
-    /**
-     * @todo Altering an interface feels like a BC break. What's the alternative?
-     *
-     * @param list<StepNode> $steps
-     *
-     * @return self
-     */
-    public function withSteps(array $steps);
 }

--- a/src/Node/ScenarioInterface.php
+++ b/src/Node/ScenarioInterface.php
@@ -17,4 +17,12 @@ namespace Behat\Gherkin\Node;
  */
 interface ScenarioInterface extends ScenarioLikeInterface, TaggedNodeInterface
 {
+    /**
+     * @todo Altering an interface feels like a BC break. What's the alternative?
+     *
+     * @param list<StepNode> $steps
+     *
+     * @return self
+     */
+    public function withSteps(array $steps);
 }

--- a/src/Node/ScenarioNode.php
+++ b/src/Node/ScenarioNode.php
@@ -20,41 +20,15 @@ class ScenarioNode implements ScenarioInterface, NamedScenarioInterface
     use TaggedNodeTrait;
 
     /**
-     * @var string
-     */
-    private $title;
-    /**
-     * @var array
-     */
-    private $tags = [];
-    /**
-     * @var StepNode[]
-     */
-    private $steps = [];
-    /**
-     * @var string
-     */
-    private $keyword;
-    /**
-     * @var int
-     */
-    private $line;
-
-    /**
-     * Initializes scenario.
-     *
-     * @param string|null $title
      * @param StepNode[] $steps
-     * @param string $keyword
-     * @param int $line
      */
-    public function __construct($title, array $tags, array $steps, $keyword, $line)
-    {
-        $this->title = $title;
-        $this->tags = $tags;
-        $this->steps = $steps;
-        $this->keyword = $keyword;
-        $this->line = $line;
+    public function __construct(
+        private readonly ?string $title,
+        private readonly array $tags,
+        private readonly array $steps,
+        private readonly string $keyword,
+        private readonly int $line,
+    ) {
     }
 
     /**
@@ -128,5 +102,19 @@ class ScenarioNode implements ScenarioInterface, NamedScenarioInterface
     public function getLine()
     {
         return $this->line;
+    }
+
+    /**
+     * Returns a copy of this scenario, but with a different set of steps.
+     */
+    public function withSteps(array $steps): self
+    {
+        return new self(
+            $this->title,
+            $this->tags,
+            $steps,
+            $this->keyword,
+            $this->line,
+        );
     }
 }

--- a/src/Node/ScenarioNode.php
+++ b/src/Node/ScenarioNode.php
@@ -103,18 +103,4 @@ class ScenarioNode implements ScenarioInterface, NamedScenarioInterface
     {
         return $this->line;
     }
-
-    /**
-     * Returns a copy of this scenario, but with a different set of steps.
-     */
-    public function withSteps(array $steps): self
-    {
-        return new self(
-            $this->title,
-            $this->tags,
-            $steps,
-            $this->keyword,
-            $this->line,
-        );
-    }
 }

--- a/src/Node/StepNode.php
+++ b/src/Node/StepNode.php
@@ -124,34 +124,4 @@ class StepNode implements NodeInterface
     {
         return $this->line;
     }
-
-    /**
-     * Returns a copy of this step, but with a different set of arguments.
-     *
-     * @param ArgumentInterface[] $arguments
-     */
-    public function withArguments(array $arguments): self
-    {
-        return new self(
-            $this->keyword,
-            $this->text,
-            $arguments,
-            $this->line,
-            $this->keywordType,
-        );
-    }
-
-    /**
-     * Returns a copy of this step, but with a different keyword type.
-     */
-    public function withKeywordType(string $keywordType): self
-    {
-        return new self(
-            $this->keyword,
-            $this->text,
-            $this->arguments,
-            $this->line,
-            $keywordType,
-        );
-    }
 }

--- a/src/Node/StepNode.php
+++ b/src/Node/StepNode.php
@@ -19,38 +19,18 @@ use Behat\Gherkin\Exception\NodeException;
  */
 class StepNode implements NodeInterface
 {
-    /**
-     * @var string
-     */
-    private $keyword;
-    /**
-     * @var string
-     */
-    private $keywordType;
-    /**
-     * @var string
-     */
-    private $text;
-    /**
-     * @var ArgumentInterface[]
-     */
-    private $arguments = [];
-    /**
-     * @var int
-     */
-    private $line;
+    private readonly string $keywordType;
 
     /**
-     * Initializes step.
-     *
-     * @param string $keyword
-     * @param string $text
      * @param ArgumentInterface[] $arguments
-     * @param int $line
-     * @param string $keywordType
      */
-    public function __construct($keyword, $text, array $arguments, $line, $keywordType = null)
-    {
+    public function __construct(
+        private readonly string $keyword,
+        private readonly string $text,
+        private readonly array $arguments,
+        private readonly int $line,
+        ?string $keywordType = null,
+    ) {
         if (count($arguments) > 1) {
             throw new NodeException(sprintf(
                 'Steps could have only one argument, but `%s %s` have %d.',
@@ -60,10 +40,6 @@ class StepNode implements NodeInterface
             ));
         }
 
-        $this->keyword = $keyword;
-        $this->text = $text;
-        $this->arguments = $arguments;
-        $this->line = $line;
         $this->keywordType = $keywordType ?: 'Given';
     }
 
@@ -147,5 +123,35 @@ class StepNode implements NodeInterface
     public function getLine()
     {
         return $this->line;
+    }
+
+    /**
+     * Returns a copy of this step, but with a different set of arguments.
+     *
+     * @param ArgumentInterface[] $arguments
+     */
+    public function withArguments(array $arguments): self
+    {
+        return new self(
+            $this->keyword,
+            $this->text,
+            $arguments,
+            $this->line,
+            $this->keywordType,
+        );
+    }
+
+    /**
+     * Returns a copy of this step, but with a different keyword type.
+     */
+    public function withKeywordType(string $keywordType): self
+    {
+        return new self(
+            $this->keyword,
+            $this->text,
+            $this->arguments,
+            $this->line,
+            $keywordType,
+        );
     }
 }

--- a/src/Node/TableNode.php
+++ b/src/Node/TableNode.php
@@ -23,8 +23,6 @@ use ReturnTypeWillChange;
  */
 class TableNode implements ArgumentInterface, IteratorAggregate
 {
-    private array $table;
-
     /**
      * @var array<array-key, int>
      */
@@ -37,9 +35,9 @@ class TableNode implements ArgumentInterface, IteratorAggregate
      *
      * @throws NodeException If the given table is invalid
      */
-    public function __construct(array $table)
-    {
-        $this->table = $table;
+    public function __construct(
+        private array $table,
+    ) {
         $columnCount = null;
 
         foreach ($this->getRows() as $ridx => $row) {

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -46,7 +46,6 @@ class Parser
     public function __construct(
         private readonly Lexer $lexer,
     ) {
-        $this->lexer = $lexer;
     }
 
     /**

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -37,7 +37,6 @@ use Behat\Gherkin\Node\TableNode;
  */
 class Parser
 {
-    private $lexer;
     private $input;
     private $file;
     private $tags = [];
@@ -45,14 +44,9 @@ class Parser
 
     private $passedNodesStack = [];
 
-    /**
-     * Initializes parser.
-     *
-     * @param Lexer $lexer Lexer instance
-     */
-    public function __construct(Lexer $lexer)
-    {
-        $this->lexer = $lexer;
+    public function __construct(
+        private readonly Lexer $lexer,
+    ) {
     }
 
     /**

--- a/tests/Cucumber/CompatibilityTest.php
+++ b/tests/Cucumber/CompatibilityTest.php
@@ -210,8 +210,13 @@ class CompatibilityTest extends TestCase
         return new StepNode(
             $stepNode->getKeyword(),
             $stepNode->getText(),
+            // CucumberNDJsonParser does not currently parse tables / pystrings attached to a step
+            // See https://github.com/Behat/Gherkin/issues/320            
             [],
             $stepNode->getLine(),
+            // We cannot compare the keywordsType property on a StepNode because this concept
+            // is specific to Behat/Gherkin and there is no equivalent value in the cucumber/gherkin
+            // test data.
             ''
         );
     }

--- a/tests/Cucumber/CompatibilityTest.php
+++ b/tests/Cucumber/CompatibilityTest.php
@@ -211,7 +211,7 @@ class CompatibilityTest extends TestCase
             $stepNode->getKeyword(),
             $stepNode->getText(),
             // CucumberNDJsonParser does not currently parse tables / pystrings attached to a step
-            // See https://github.com/Behat/Gherkin/issues/320            
+            // See https://github.com/Behat/Gherkin/issues/320
             [],
             $stepNode->getLine(),
             // We cannot compare the keywordsType property on a StepNode because this concept


### PR DESCRIPTION
Closes #318.

1. Makes all immutable private properties readonly, when possible.
2. Additionally, declares the correct property type (since it's a requirement of using `readonly`)
3. Adds more normalizer methods and fixes the relevant test