### PR TITLE
Parse `Scenario Outline` with no examples as a `Scenario`

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -327,7 +327,7 @@ class Parser
     /**
      * Parses scenario token & returns it's node.
      *
-     * @return ScenarioNode
+     * @return OutlineNode|ScenarioNode
      *
      * @throws ParserException
      */
@@ -339,24 +339,13 @@ class Parser
     /**
      * Parses scenario outline token & returns it's node.
      *
-     * @return OutlineNode
+     * @return OutlineNode|ScenarioNode
      *
      * @throws ParserException
      */
     protected function parseOutline()
     {
-        $node = $this->parseScenarioOrOutlineBody($this->expectTokenType('Outline'));
-
-        if (!($node instanceof OutlineNode && $node->hasExamples())) {
-            throw new ParserException(sprintf(
-                'Outline should have examples table, but got none for outline "%s" on line: %d%s',
-                $node->getTitle(),
-                $node->getLine(),
-                $this->file ? ' in file: ' . $this->file : ''
-            ));
-        }
-
-        return $node;
+        return $this->parseScenarioOrOutlineBody($this->expectTokenType('Outline'));
     }
 
     private function parseScenarioOrOutlineBody(array $token): OutlineNode|ScenarioNode

--- a/tests/Cucumber/CompatibilityTest.php
+++ b/tests/Cucumber/CompatibilityTest.php
@@ -174,12 +174,26 @@ class CompatibilityTest extends TestCase
             // include a description but are covering other features.
             $feature->getDescription() === null ? null : preg_replace('/^\s+/m', '', $feature->getDescription()),
             $feature->getTags(),
-            $feature->getBackground(),
+            $this->normaliseBackground($feature->getBackground()),
             array_map($this->normaliseScenario(...), $feature->getScenarios()),
             $feature->getKeyword(),
             $feature->getLanguage(),
             $feature->getFile(),
             $feature->getLine(),
+        );
+    }
+
+    private function normaliseBackground(?BackgroundNode $background): ?BackgroundNode
+    {
+        if ($background === null) {
+            return $background;
+        }
+
+        return new BackgroundNode(
+            $background->getTitle(),
+            array_map($this->normaliseStep(...), $background->getSteps()),
+            $background->getKeyword(),
+            $background->getLine(),
         );
     }
 

--- a/tests/Cucumber/CompatibilityTest.php
+++ b/tests/Cucumber/CompatibilityTest.php
@@ -14,6 +14,7 @@ use Behat\Gherkin\Exception\ParserException;
 use Behat\Gherkin\Keywords;
 use Behat\Gherkin\Lexer;
 use Behat\Gherkin\Loader\CucumberNDJsonAstLoader;
+use Behat\Gherkin\Node\BackgroundNode;
 use Behat\Gherkin\Node\FeatureNode;
 use Behat\Gherkin\Node\OutlineNode;
 use Behat\Gherkin\Node\ScenarioInterface;
@@ -49,7 +50,6 @@ class CompatibilityTest extends TestCase
         'descriptions.feature' => 'Examples table descriptions not supported',
         'descriptions_with_comments.feature' => 'Examples table descriptions not supported',
         'extra_table_content.feature' => 'Table without right border triggers a ParserException',
-        'incomplete_scenario_outline.feature' => 'Outline without Examples table triggers a ParserException',
         'padded_example.feature' => 'Table padding is not trimmed as aggressively',
         'spaces_in_language.feature' => 'Whitespace not supported around language selector',
         'incomplete_feature_3.feature' => 'file with no feature keyword not handled correctly',

--- a/tests/Loader/CucumberNDJsonAstLoaderTest.php
+++ b/tests/Loader/CucumberNDJsonAstLoaderTest.php
@@ -219,7 +219,14 @@ final class CucumberNDJsonAstLoaderTest extends TestCase
                     [],
                     null,
                     [
-                        new OutlineNode('Examples Scenario', [], [], [], 'outline', 2),
+                        new OutlineNode(
+                            'Examples Scenario',
+                            [],
+                            [],
+                            new ExampleTableNode([], 'example'),
+                            'outline',
+                            2,
+                        ),
                     ],
                     'feature',
                     'en',

--- a/tests/ParserExceptionsTest.php
+++ b/tests/ParserExceptionsTest.php
@@ -164,21 +164,6 @@ class ParserExceptionsTest extends TestCase
         $this->gherkin->parse($feature);
     }
 
-    public function testEmptyOutline(): void
-    {
-        $feature = <<<'GHERKIN'
-        Feature: Some feature
-
-            Scenario Outline:
-        GHERKIN;
-
-        $this->expectExceptionObject(
-            new ParserException('Outline should have examples table, but got none for outline "" on line: 3')
-        );
-
-        $this->gherkin->parse($feature);
-    }
-
     public function testMultipleFeatures(): void
     {
         $feature = <<<'GHERKIN'


### PR DESCRIPTION
Continues #153 and builds on #294 (where I gave a wrong steer on the NDJson loading) and #316.

Instead of throwing an exception if a `Scenario Outline` has no examples, we will just parse it as a `Scenario` - this matches the behaviour of cucumber/gherkin.