### PR TITLE
Use a custom object comparator to ignore the keywordType of StepNode

### DIFF
--- a/tests/Cucumber/StepNodeComparator.php
+++ b/tests/Cucumber/StepNodeComparator.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Behat Gherkin Parser.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Behat\Gherkin\Cucumber;
+
+use Behat\Gherkin\Node\StepNode;
+use SebastianBergmann\Comparator\ObjectComparator;
+
+final class StepNodeComparator extends ObjectComparator
+{
+    public function accepts(mixed $expected, mixed $actual): bool
+    {
+        return $expected instanceof StepNode && $actual instanceof StepNode;
+    }
+
+    protected function toArray(object $object): array
+    {
+        $array = parent::toArray($object);
+
+        // We cannot compare the keywordsType property on a StepNode because this concept
+        // is specific to Behat/Gherkin and there is no equivalent value in the cucumber/gherkin
+        // test data.
+        // cucumber/gherkin has the equivalent concept in their pickle steps instead.
+        unset($array['keywordType']);
+
+        return $array;
+    }
+}


### PR DESCRIPTION
The keywordType of our StepNode is not a concept that exists in the Gherkin AST of cucumber. It actually corresponds to the pickle step type in their architecture.
Using a dedicated object comparator (registered only for cucumber compatibility tests) allows to ignore that property without having to normalize steps, which makes the code a lot clearer.

The handling of the feature description is kept in a normalization step as this is related to a parity difference with cucumber which is meant to be solved at some point instead.