### PR TITLE
Add precise type info to solve phpstan errors

### DIFF
--- a/src/Cache/CacheInterface.php
+++ b/src/Cache/CacheInterface.php
@@ -43,6 +43,8 @@ interface CacheInterface
      *
      * @param string $path Feature path
      * @param FeatureNode $feature Feature instance
+     *
+     * @return void
      */
     public function write($path, FeatureNode $feature);
 }

--- a/src/Cache/FileCache.php
+++ b/src/Cache/FileCache.php
@@ -100,6 +100,8 @@ class FileCache implements CacheInterface
      *
      * @param string $path Feature path
      * @param FeatureNode $feature Feature instance
+     *
+     * @return void
      */
     public function write($path, FeatureNode $feature)
     {

--- a/src/Cache/MemoryCache.php
+++ b/src/Cache/MemoryCache.php
@@ -20,8 +20,14 @@ use Behat\Gherkin\Node\FeatureNode;
  */
 class MemoryCache implements CacheInterface
 {
-    private $features = [];
-    private $timestamps = [];
+    /**
+     * @var array<string, FeatureNode>
+     */
+    private array $features = [];
+    /**
+     * @var array<string, int>
+     */
+    private array $timestamps = [];
 
     /**
      * Checks that cache for feature exists and is fresh.
@@ -57,6 +63,8 @@ class MemoryCache implements CacheInterface
      *
      * @param string $path Feature path
      * @param FeatureNode $feature Feature instance
+     *
+     * @return void
      */
     public function write($path, FeatureNode $feature)
     {

--- a/src/Exception/UnexpectedTaggedNodeException.php
+++ b/src/Exception/UnexpectedTaggedNodeException.php
@@ -10,8 +10,16 @@
 
 namespace Behat\Gherkin\Exception;
 
+use Behat\Gherkin\Lexer;
+
+/**
+ * @phpstan-import-type TToken from Lexer
+ */
 class UnexpectedTaggedNodeException extends ParserException
 {
+    /**
+     * @phpstan-param TToken $taggedToken
+     */
     public function __construct(
         public readonly array $taggedToken,
         public readonly ?string $sourceFile,

--- a/src/Filter/NameFilter.php
+++ b/src/Filter/NameFilter.php
@@ -20,6 +20,9 @@ use Behat\Gherkin\Node\ScenarioInterface;
  */
 class NameFilter extends SimpleFilter
 {
+    /**
+     * @var string
+     */
     protected $filterString;
 
     /**

--- a/src/Filter/TagFilter.php
+++ b/src/Filter/TagFilter.php
@@ -21,6 +21,9 @@ use Behat\Gherkin\Node\ScenarioInterface;
  */
 class TagFilter extends ComplexFilter
 {
+    /**
+     * @var string
+     */
     protected $filterString;
 
     /**

--- a/src/Gherkin.php
+++ b/src/Gherkin.php
@@ -15,6 +15,7 @@ use Behat\Gherkin\Filter\LineFilter;
 use Behat\Gherkin\Filter\LineRangeFilter;
 use Behat\Gherkin\Loader\FileLoaderInterface;
 use Behat\Gherkin\Loader\LoaderInterface;
+use Behat\Gherkin\Node\FeatureNode;
 
 /**
  * Gherkin manager.
@@ -43,6 +44,8 @@ class Gherkin
      * Adds loader to manager.
      *
      * @param LoaderInterface $loader Feature loader
+     *
+     * @return void
      */
     public function addLoader(LoaderInterface $loader)
     {
@@ -53,6 +56,8 @@ class Gherkin
      * Adds filter to manager.
      *
      * @param FeatureFilterInterface $filter Feature filter
+     *
+     * @return void
      */
     public function addFilter(FeatureFilterInterface $filter)
     {
@@ -63,6 +68,8 @@ class Gherkin
      * Sets filters to the parser.
      *
      * @param array<array-key, FeatureFilterInterface> $filters
+     *
+     * @return void
      */
     public function setFilters(array $filters)
     {
@@ -74,6 +81,8 @@ class Gherkin
      * Sets base features path.
      *
      * @param string $path Loaders base path
+     *
+     * @return void
      */
     public function setBasePath($path)
     {
@@ -90,7 +99,7 @@ class Gherkin
      * @param mixed $resource Resource to load
      * @param array<array-key, FeatureFilterInterface> $filters Additional filters
      *
-     * @return array
+     * @return list<FeatureNode>
      */
     public function load($resource, array $filters = [])
     {

--- a/src/Keywords/ArrayKeywords.php
+++ b/src/Keywords/ArrayKeywords.php
@@ -46,8 +46,11 @@ namespace Behat\Gherkin\Keywords;
  */
 class ArrayKeywords implements KeywordsInterface
 {
-    private $keywordString = [];
-    private $language;
+    /**
+     * @var array<string, string>
+     */
+    private array $keywordString = [];
+    private string $language = 'en';
 
     /**
      * Initializes holder with keywords.
@@ -63,6 +66,8 @@ class ArrayKeywords implements KeywordsInterface
      * Sets keywords holder language.
      *
      * @param string $language Language name
+     *
+     * @return void
      */
     public function setLanguage($language)
     {

--- a/src/Keywords/KeywordsDumper.php
+++ b/src/Keywords/KeywordsDumper.php
@@ -17,6 +17,9 @@ namespace Behat\Gherkin\Keywords;
  */
 class KeywordsDumper
 {
+    /**
+     * @var callable(list<string>, bool): string
+     */
     private $keywordsDumper;
 
     public function __construct(
@@ -30,7 +33,9 @@ class KeywordsDumper
      *
      * Callable should accept 2 arguments (array $keywords and bool $isShort)
      *
-     * @param callable $mapper Mapper function
+     * @param callable(list<string>, bool): string $mapper Mapper function
+     *
+     * @return void
      */
     public function setKeywordsDumperFunction($mapper)
     {
@@ -40,7 +45,7 @@ class KeywordsDumper
     /**
      * Defaults keywords dumper.
      *
-     * @param array $keywords Keywords list
+     * @param list<string> $keywords Keywords list
      * @param bool $isShort Is short version
      *
      * @return string
@@ -64,6 +69,8 @@ class KeywordsDumper
      * @param bool $excludeAsterisk
      *
      * @return string|array String for short version and array of features for extended
+     *
+     * @phpstan-return ($short is true ? string : list<string>)
      */
     public function dump($language, $short = true, $excludeAsterisk = false)
     {
@@ -95,6 +102,7 @@ class KeywordsDumper
      *
      * @param string $keyword Item keyword
      * @param bool $short Dump short version?
+     * @param bool $excludeAsterisk
      *
      * @return string
      */
@@ -151,6 +159,7 @@ class KeywordsDumper
      *
      * @param string $keyword Item keyword
      * @param bool $short Dump short version?
+     * @param bool $excludeAsterisk
      *
      * @return string
      */
@@ -185,6 +194,7 @@ class KeywordsDumper
      *
      * @param string $keyword Item keyword
      * @param bool $short Dump short version?
+     * @param bool $excludeAsterisk
      *
      * @return string
      */
@@ -243,6 +253,7 @@ class KeywordsDumper
      *
      * @param string $keyword Item keyword
      * @param bool $short Dump short version?
+     * @param bool $excludeAsterisk
      *
      * @return string
      */
@@ -317,6 +328,7 @@ class KeywordsDumper
      * @param string $keywords Item keyword
      * @param string $text Step text
      * @param bool $short Dump short version?
+     * @param bool $excludeAsterisk
      *
      * @return string
      */

--- a/src/Keywords/KeywordsInterface.php
+++ b/src/Keywords/KeywordsInterface.php
@@ -25,6 +25,8 @@ interface KeywordsInterface
      * Sets keywords holder language.
      *
      * @param string $language Language name
+     *
+     * @return void
      */
     public function setLanguage($language);
 

--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -18,28 +18,45 @@ use LogicException;
  * Gherkin lexer.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @phpstan-type TToken array{type: string, line: int, value: int|string|null, deferred: bool, tags?: list<string>, keyword?: string, keyword_type?: string, text?: string, indent?: int, columns?: list<string>}
  */
 class Lexer
 {
-    private $language;
-    private $lines;
-    private $linesCount;
-    private $line;
-    private $trimmedLine;
-    private $lineNumber;
-    private $eos;
-    private $keywordsCache = [];
-    private $stepKeywordTypesCache = [];
-    private $deferredObjects = [];
-    private $deferredObjectsCount = 0;
-    private $stashedToken;
-    private $inPyString = false;
-    private $pyStringSwallow = 0;
-    private $allowLanguageTag = true;
-    private $allowFeature = true;
-    private $allowMultilineArguments = false;
-    private $allowSteps = false;
-    private $pyStringDelimiter;
+    private string $language;
+    /**
+     * @var list<string>
+     */
+    private array $lines;
+    private int $linesCount;
+    private string $line;
+    private ?string $trimmedLine = null;
+    private int $lineNumber;
+    private bool $eos;
+    /**
+     * @var array<string, string>
+     */
+    private array $keywordsCache = [];
+    /**
+     * @var array<string, list<string>>
+     */
+    private array $stepKeywordTypesCache = [];
+    /**
+     * @phpstan-var list<TToken>
+     */
+    private array $deferredObjects = [];
+    private int $deferredObjectsCount = 0;
+    /**
+     * @phpstan-var TToken|null
+     */
+    private ?array $stashedToken = null;
+    private bool $inPyString = false;
+    private int $pyStringSwallow = 0;
+    private bool $allowLanguageTag = true;
+    private bool $allowFeature = true;
+    private bool $allowMultilineArguments = false;
+    private bool $allowSteps = false;
+    private ?string $pyStringDelimiter = null;
 
     public function __construct(
         private readonly KeywordsInterface $keywords,
@@ -51,6 +68,8 @@ class Lexer
      *
      * @param string $input Input string
      * @param string $language Language name
+     *
+     * @return void
      *
      * @throws LexerException
      */
@@ -121,6 +140,8 @@ class Lexer
      * Returns next token or previously stashed one.
      *
      * @return array
+     *
+     * @phpstan-return TToken
      */
     public function getAdvancedToken()
     {
@@ -130,7 +151,9 @@ class Lexer
     /**
      * Defers token.
      *
-     * @param array $token Token to defer
+     * @phpstan-param TToken $token Token to defer
+     *
+     * @return void
      */
     public function deferToken(array $token)
     {
@@ -143,6 +166,8 @@ class Lexer
      * Predicts the upcoming token without passing over it.
      *
      * @return array
+     *
+     * @phpstan-return TToken
      */
     public function predictToken()
     {
@@ -166,6 +191,8 @@ class Lexer
      * @param int|string|null $value Token value
      *
      * @return array
+     *
+     * @phpstan-return TToken
      */
     public function takeToken($type, $value = null)
     {
@@ -179,6 +206,8 @@ class Lexer
 
     /**
      * Consumes line from input & increments line counter.
+     *
+     * @return void
      */
     protected function consumeLine()
     {
@@ -196,6 +225,8 @@ class Lexer
 
     /**
      * Consumes first part of line from input without incrementing the line number.
+     *
+     * @return void
      */
     protected function consumeLineUntil(int $trimmedOffset)
     {
@@ -217,6 +248,8 @@ class Lexer
      * Returns stashed token or null if hasn't.
      *
      * @return array|null
+     *
+     * @phpstan-return TToken|null
      */
     protected function getStashedToken()
     {
@@ -230,6 +263,8 @@ class Lexer
      * Returns deferred token or null if hasn't.
      *
      * @return array|null
+     *
+     * @phpstan-return TToken|null
      */
     protected function getDeferredToken()
     {
@@ -246,6 +281,8 @@ class Lexer
      * Returns next token from input.
      *
      * @return array
+     *
+     * @phpstan-return TToken
      */
     protected function getNextToken()
     {
@@ -274,6 +311,8 @@ class Lexer
      * @param string $type Expected token type
      *
      * @return array|null
+     *
+     * @phpstan-return TToken|null
      */
     protected function scanInput($regex, $type)
     {
@@ -294,6 +333,8 @@ class Lexer
      * @param string $type Expected token type
      *
      * @return array|null
+     *
+     * @phpstan-return TToken|null
      */
     protected function scanInputForKeywords($keywords, $type)
     {
@@ -332,6 +373,8 @@ class Lexer
      * Scans EOS from input & returns it if found.
      *
      * @return array|null
+     *
+     * @phpstan-return TToken|null
      */
     protected function scanEOS()
     {
@@ -376,6 +419,8 @@ class Lexer
      * Scans Feature from input & returns it if found.
      *
      * @return array|null
+     *
+     * @phpstan-return TToken|null
      */
     protected function scanFeature()
     {
@@ -391,6 +436,8 @@ class Lexer
      * Scans Background from input & returns it if found.
      *
      * @return array|null
+     *
+     * @phpstan-return TToken|null
      */
     protected function scanBackground()
     {
@@ -401,6 +448,8 @@ class Lexer
      * Scans Scenario from input & returns it if found.
      *
      * @return array|null
+     *
+     * @phpstan-return TToken|null
      */
     protected function scanScenario()
     {
@@ -411,6 +460,8 @@ class Lexer
      * Scans Scenario Outline from input & returns it if found.
      *
      * @return array|null
+     *
+     * @phpstan-return TToken|null
      */
     protected function scanOutline()
     {
@@ -421,6 +472,8 @@ class Lexer
      * Scans Scenario Outline Examples from input & returns it if found.
      *
      * @return array|null
+     *
+     * @phpstan-return TToken|null
      */
     protected function scanExamples()
     {
@@ -431,6 +484,8 @@ class Lexer
      * Scans Step from input & returns it if found.
      *
      * @return array|null
+     *
+     * @phpstan-return TToken|null
      */
     protected function scanStep()
     {
@@ -458,6 +513,8 @@ class Lexer
      * Scans PyString from input & returns it if found.
      *
      * @return array|null
+     *
+     * @phpstan-return TToken|null
      */
     protected function scanPyStringOp()
     {
@@ -493,6 +550,8 @@ class Lexer
      * Scans PyString content.
      *
      * @return array|null
+     *
+     * @phpstan-return TToken|null
      */
     protected function scanPyStringContent()
     {
@@ -511,6 +570,8 @@ class Lexer
      * Scans Table Row from input & returns it if found.
      *
      * @return array|null
+     *
+     * @phpstan-return TToken|null
      */
     protected function scanTableRow()
     {
@@ -539,6 +600,8 @@ class Lexer
      * Scans Tags from input & returns it if found.
      *
      * @return array|null
+     *
+     * @phpstan-return TToken|null
      */
     protected function scanTags()
     {
@@ -567,6 +630,8 @@ class Lexer
      * Scans Language specifier from input & returns it if found.
      *
      * @return array|null
+     *
+     * @phpstan-return TToken|null
      */
     protected function scanLanguage()
     {
@@ -596,6 +661,8 @@ class Lexer
      * Scans Comment from input & returns it if found.
      *
      * @return array|null
+     *
+     * @phpstan-return TToken|null
      */
     protected function scanComment()
     {
@@ -618,6 +685,8 @@ class Lexer
      * Scans Newline from input & returns it if found.
      *
      * @return array|null
+     *
+     * @phpstan-return TToken|null
      */
     protected function scanNewline()
     {
@@ -634,7 +703,9 @@ class Lexer
     /**
      * Scans text from input & returns it if found.
      *
-     * @return array|null
+     * @return array
+     *
+     * @phpstan-return TToken
      */
     protected function scanText()
     {

--- a/src/Loader/AbstractFileLoader.php
+++ b/src/Loader/AbstractFileLoader.php
@@ -17,12 +17,17 @@ namespace Behat\Gherkin\Loader;
  */
 abstract class AbstractFileLoader implements FileLoaderInterface
 {
+    /**
+     * @var string|null
+     */
     protected $basePath;
 
     /**
      * Sets base features path.
      *
      * @param string $path Base loader path
+     *
+     * @return void
      */
     public function setBasePath($path)
     {

--- a/src/Loader/DirectoryLoader.php
+++ b/src/Loader/DirectoryLoader.php
@@ -22,6 +22,9 @@ use RecursiveIteratorIterator;
  */
 class DirectoryLoader extends AbstractFileLoader
 {
+    /**
+     * @var Gherkin
+     */
     protected $gherkin;
 
     /**

--- a/src/Loader/FileLoaderInterface.php
+++ b/src/Loader/FileLoaderInterface.php
@@ -21,6 +21,8 @@ interface FileLoaderInterface extends LoaderInterface
      * Sets base features path.
      *
      * @param string $path Base loader path
+     *
+     * @return void
      */
     public function setBasePath($path);
 }

--- a/src/Loader/GherkinFileLoader.php
+++ b/src/Loader/GherkinFileLoader.php
@@ -21,14 +21,20 @@ use Behat\Gherkin\Parser;
  */
 class GherkinFileLoader extends AbstractFileLoader
 {
+    /**
+     * @var Parser
+     */
     protected $parser;
+    /**
+     * @var CacheInterface|null
+     */
     protected $cache;
 
     /**
      * Initializes loader.
      *
      * @param Parser $parser Parser
-     * @param CacheInterface $cache Cache layer
+     * @param CacheInterface|null $cache Cache layer
      */
     public function __construct(Parser $parser, ?CacheInterface $cache = null)
     {
@@ -40,6 +46,8 @@ class GherkinFileLoader extends AbstractFileLoader
      * Sets cache layer.
      *
      * @param CacheInterface $cache Cache layer
+     *
+     * @return void
      */
     public function setCache(CacheInterface $cache)
     {
@@ -89,7 +97,7 @@ class GherkinFileLoader extends AbstractFileLoader
      *
      * @param string $path Feature path
      *
-     * @return FeatureNode
+     * @return FeatureNode|null
      */
     protected function parseFeature($path)
     {

--- a/src/Node/ExampleNode.php
+++ b/src/Node/ExampleNode.php
@@ -26,7 +26,7 @@ class ExampleNode implements ScenarioInterface, NamedScenarioInterface
 
     /**
      * @param string $text The entire row as a string, e.g. "| 1 | 2 | 3 |"
-     * @param array<array-key, string> $tags
+     * @param list<string> $tags
      * @param array<array-key, StepNode> $outlineSteps
      * @param array<string, string> $tokens
      * @param int $line line number within the feature file
@@ -125,7 +125,7 @@ class ExampleNode implements ScenarioInterface, NamedScenarioInterface
     /**
      * Returns outline title.
      *
-     * @return string
+     * @return string|null
      */
     public function getOutlineTitle()
     {

--- a/src/Node/ExampleTableNode.php
+++ b/src/Node/ExampleTableNode.php
@@ -20,8 +20,8 @@ class ExampleTableNode extends TableNode implements TaggedNodeInterface
     use TaggedNodeTrait;
 
     /**
-     * @param array $table Table in form of [$rowLineNumber => [$val1, $val2, $val3]]
-     * @param string[] $tags
+     * @param array<int, list<string>> $table Table in form of [$rowLineNumber => [$val1, $val2, $val3]]
+     * @param list<string> $tags
      */
     public function __construct(
         array $table,

--- a/src/Node/FeatureNode.php
+++ b/src/Node/FeatureNode.php
@@ -24,7 +24,7 @@ class FeatureNode implements KeywordNodeInterface, TaggedNodeInterface
     use TaggedNodeTrait;
 
     /**
-     * @param string[] $tags
+     * @param list<string> $tags
      * @param ScenarioInterface[] $scenarios
      * @param string|null $file the absolute path to the feature file
      */

--- a/src/Node/OutlineNode.php
+++ b/src/Node/OutlineNode.php
@@ -29,7 +29,7 @@ class OutlineNode implements ScenarioInterface
     private array $examples;
 
     /**
-     * @param string[] $tags
+     * @param list<string> $tags
      * @param StepNode[] $steps
      * @param ExampleTableNode|array<array-key, ExampleTableNode> $tables
      */

--- a/src/Node/PyStringNode.php
+++ b/src/Node/PyStringNode.php
@@ -18,7 +18,7 @@ namespace Behat\Gherkin\Node;
 class PyStringNode implements ArgumentInterface
 {
     /**
-     * @param array $strings String in form of [$stringLine]
+     * @param list<string> $strings String in form of [$stringLine]
      * @param int $line Line number where string been started
      */
     public function __construct(
@@ -40,7 +40,7 @@ class PyStringNode implements ArgumentInterface
     /**
      * Returns entire PyString lines set.
      *
-     * @return array
+     * @return list<string>
      */
     public function getStrings()
     {

--- a/src/Node/ScenarioNode.php
+++ b/src/Node/ScenarioNode.php
@@ -21,6 +21,7 @@ class ScenarioNode implements ScenarioInterface, NamedScenarioInterface
 
     /**
      * @param StepNode[] $steps
+     * @param list<string> $tags
      */
     public function __construct(
         private readonly ?string $title,

--- a/src/Node/TableNode.php
+++ b/src/Node/TableNode.php
@@ -31,7 +31,7 @@ class TableNode implements ArgumentInterface, IteratorAggregate
     /**
      * Initializes table.
      *
-     * @param array $table Table in form of [$rowLineNumber => [$val1, $val2, $val3]]
+     * @param array<int, array> $table Table in form of [$rowLineNumber => [$val1, $val2, $val3]]
      *
      * @throws NodeException If the given table is invalid
      */
@@ -181,7 +181,7 @@ class TableNode implements ArgumentInterface, IteratorAggregate
     /**
      * Returns table definition lines.
      *
-     * @return array
+     * @return list<int>
      */
     public function getLines()
     {
@@ -274,7 +274,7 @@ class TableNode implements ArgumentInterface, IteratorAggregate
      * Converts row into delimited string.
      *
      * @param int $rowNum Row number
-     * @param callable $wrapper Wrapper function
+     * @param callable(string, int): string $wrapper Wrapper function
      *
      * @return string
      */
@@ -340,6 +340,8 @@ class TableNode implements ArgumentInterface, IteratorAggregate
     /**
      * Obtains and adds rows from another table to the current table.
      * The second table should have the same structure as the current one.
+     *
+     * @return void
      *
      * @deprecated remove together with OutlineNode::getExampleTable
      */

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -35,12 +35,17 @@ use Behat\Gherkin\Node\TableNode;
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * @phpstan-type TParsedExpressionResult FeatureNode|BackgroundNode|ScenarioNode|OutlineNode|ExampleTableNode|TableNode|PyStringNode|StepNode|string
+ *
+ * @phpstan-import-type TToken from Lexer
  */
 class Parser
 {
-    private $input;
-    private $file;
-    private $tags = [];
+    private string $input;
+    private ?string $file = null;
+    /**
+     * @var list<string>
+     */
+    private array $tags = [];
 
     public function __construct(
         private readonly Lexer $lexer,
@@ -51,7 +56,7 @@ class Parser
      * Parses input & returns features array.
      *
      * @param string $input Gherkin string document
-     * @param string $file File name
+     * @param string|null $file File name
      *
      * @return FeatureNode|null
      *
@@ -99,6 +104,8 @@ class Parser
      *
      * @return array
      *
+     * @phpstan-return TToken
+     *
      * @throws ParserException
      */
     protected function expectTokenType($type)
@@ -125,6 +132,8 @@ class Parser
      * @param string $type Token type
      *
      * @return array|null
+     *
+     * @phpstan-return TToken|null
      */
     protected function acceptTokenType($type)
     {
@@ -317,6 +326,9 @@ class Parser
         return $this->parseScenarioOrOutlineBody($this->expectTokenType('Outline'));
     }
 
+    /**
+     * @phpstan-param TToken $token
+     */
     private function parseScenarioOrOutlineBody(array $token): OutlineNode|ScenarioNode
     {
         $title = trim($token['value'] ?? '');
@@ -531,7 +543,7 @@ class Parser
     /**
      * Returns current set of tags and clears tag buffer.
      *
-     * @return array
+     * @return list<string>
      */
     protected function popTags()
     {
@@ -545,6 +557,8 @@ class Parser
      * Checks the tags fit the required format.
      *
      * @param string[] $tags
+     *
+     * @return void
      */
     protected function guardTags(array $tags)
     {

--- a/tests/Cucumber/StepNodeComparator.php
+++ b/tests/Cucumber/StepNodeComparator.php
@@ -20,6 +20,9 @@ final class StepNodeComparator extends ObjectComparator
         return $expected instanceof StepNode && $actual instanceof StepNode;
     }
 
+    /**
+     * @return array<mixed>
+     */
     protected function toArray(object $object): array
     {
         $array = parent::toArray($object);

--- a/tests/Node/TableNodeTest.php
+++ b/tests/Node/TableNodeTest.php
@@ -35,6 +35,7 @@ class TableNodeTest extends TestCase
             new NodeException("Table row '0' is expected to be array, got string")
         );
 
+        // @phpstan-ignore argument.type (we are explicitly testing an invalid instantiation)
         new TableNode([
             'everzet', 'antono',
         ]);

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -119,7 +119,7 @@ final class ParserTest extends TestCase
     }
 
     /**
-     * @return iterable<array{expectedException: Exception, featureText: string|list<array<string, mixed>>}>
+     * @return iterable<array{expectedException: Exception, featureText: string}>
      */
     public static function parserErrorDataProvider(): iterable
     {


### PR DESCRIPTION
This solves all phpstan level 6 errors except in 3 files:

- ArrayLoader and CucumberNDJsonAstLoader will be handled in separate PRs as adding types for them involves describing the shape of the array structures they process. Handling them separately will simplifying the review (as each of them will probably have a diff close to the full size of the diff of this PR due to that) => see #333 and #334 
- TableNode, because the types to use to fix errors depend on the discussion in #285