### PR TITLE
Use the `Yaml::parseFile` API to handle Yaml files

### DIFF
--- a/src/Keywords/CucumberKeywords.php
+++ b/src/Keywords/CucumberKeywords.php
@@ -29,25 +29,10 @@ class CucumberKeywords extends ArrayKeywords
      */
     public function __construct($yaml)
     {
-        // Handle filename explicitly for BC reasons, as Symfony Yaml 3.0 does not do it anymore
-        $file = null;
         if (!str_contains($yaml, "\n") && is_file($yaml)) {
-            if (!is_readable($yaml)) {
-                throw new ParseException(sprintf('Unable to parse "%s" as the file is not readable.', $yaml));
-            }
-
-            $file = $yaml;
-            $yaml = file_get_contents($file);
-        }
-
-        try {
+            $content = Yaml::parseFile($yaml);
+        } else {
             $content = Yaml::parse($yaml);
-        } catch (ParseException $e) {
-            if ($file) {
-                $e->setParsedFile($file);
-            }
-
-            throw $e;
         }
 
         if (!is_array($content)) {

--- a/src/Loader/YamlFileLoader.php
+++ b/src/Loader/YamlFileLoader.php
@@ -50,7 +50,7 @@ class YamlFileLoader extends AbstractFileLoader
     public function load($resource)
     {
         $path = $this->getAbsolutePath($resource);
-        $hash = Yaml::parse(file_get_contents($path));
+        $hash = Yaml::parseFile($path);
 
         $features = $this->loader->load($hash);
 

--- a/tests/Keywords/CucumberKeywordsTest.php
+++ b/tests/Keywords/CucumberKeywordsTest.php
@@ -80,7 +80,7 @@ class CucumberKeywordsTest extends KeywordsTestCase
         );
 
         $this->expectExceptionObject(
-            new ParseException("Unable to parse \"{$file->url()}\" as the file is not readable.")
+            new ParseException("File \"{$file->url()}\" cannot be read.")
         );
 
         new CucumberKeywords($file->url());


### PR DESCRIPTION
This lets the Yaml component deal with the case of failures when reading the file (which it does).