### PR TITLE
Assert that preg_split does not fail when splitting a table row

### DIFF
--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -586,9 +586,11 @@ class Lexer
 
         $token = $this->takeToken('TableRow');
         $line = mb_substr($line, 1, mb_strlen($line, 'utf8') - 2, 'utf8');
+        $rawColumns = preg_split('/(?<!\\\)\|/u', $line);
+        \assert($rawColumns !== false);
         $columns = array_map(function ($column) {
             return trim(str_replace(['\\|', '\\\\'], ['|', '\\'], $column));
-        }, preg_split('/(?<!\\\)\|/u', $line));
+        }, $rawColumns);
         $token['columns'] = $columns;
 
         $this->consumeLine();


### PR DESCRIPTION
Our regex is valid and does not involve much backtracking, so it has no reason to fail at runtime.

It should also not fail due to invalid UTF-8 (for the `u` modifier) as we already worked with UTF-8 APIs before on the string.