### PR TITLE
change: Do not throw on `.feature` file that does not contain a Feature

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -82,7 +82,7 @@ class Parser
         while ($this->predictTokenType() !== 'EOS') {
             $node = $this->parseExpression();
 
-            if ($node === "\n") {
+            if ($node === "\n" || $node === '') {
                 continue;
             }
 

--- a/tests/Cucumber/CompatibilityTest.php
+++ b/tests/Cucumber/CompatibilityTest.php
@@ -51,7 +51,6 @@ class CompatibilityTest extends TestCase
         'feature_keyword_in_scenario_description.feature' => 'Scenario descriptions not supported',
         'padded_example.feature' => 'Table padding is not trimmed as aggressively',
         'spaces_in_language.feature' => 'Whitespace not supported around language selector',
-        'incomplete_feature_3.feature' => 'file with no feature keyword not handled correctly',
         'rule_without_name_and_description.feature' => 'Rule is wrongly parsed as Description',
         'incomplete_scenario.feature' => 'Wrong background parsing when there are no steps',
         'incomplete_background_2.feature' => 'Wrong background parsing when there are no steps',

--- a/tests/Cucumber/CompatibilityTest.php
+++ b/tests/Cucumber/CompatibilityTest.php
@@ -52,8 +52,7 @@ class CompatibilityTest extends TestCase
         'padded_example.feature' => 'Table padding is not trimmed as aggressively',
         'spaces_in_language.feature' => 'Whitespace not supported around language selector',
         'rule_without_name_and_description.feature' => 'Rule is wrongly parsed as Description',
-        'incomplete_scenario.feature' => 'Wrong background parsing when there are no steps',
-        'incomplete_background_2.feature' => 'Wrong background parsing when there are no steps',
+        'incomplete_background_2.feature' => 'Background descriptions not supported',
     ];
 
     /**


### PR DESCRIPTION
For parity with cucumber/gherkin - if there is no Feature tag then we
may get an empty line before the final EOS, which we should ignore.

Also adds a cucumber parity test that is now passing, and updates the
reason why another is still failing.

Fixes #208