### PR TITLE
change: Throw ParserException if Background comes after first Scenario

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -224,7 +224,9 @@ class Parser
                 continue;
             }
 
-            if (!$background && $node instanceof BackgroundNode) {
+            $isBackgroundAllowed = ($background === null && $scenarios === []);
+
+            if ($isBackgroundAllowed && $node instanceof BackgroundNode) {
                 $background = $node;
                 continue;
             }
@@ -235,7 +237,7 @@ class Parser
             }
 
             throw new UnexpectedParserNodeException(
-                match ($background === null && $scenarios === []) {
+                match ($isBackgroundAllowed) {
                     true => 'Background, Scenario or Outline',
                     false => 'Scenario or Outline',
                 },

--- a/tests/Cucumber/extra_testdata/bad/background_after_scenario.feature
+++ b/tests/Cucumber/extra_testdata/bad/background_after_scenario.feature
@@ -1,0 +1,7 @@
+Feature: Feature background cannot come after first scenario
+
+    Scenario:
+        Then I should fail
+
+    Background:
+        Given I am in the wrong sequence

--- a/tests/Cucumber/extra_testdata/bad/background_after_scenario.feature.errors.ndjson
+++ b/tests/Cucumber/extra_testdata/bad/background_after_scenario.feature.errors.ndjson
@@ -1,0 +1,1 @@
+{"parseError":{"message":"(6:5): expected: #EOF, #TableRow, #DocStringSeparator, #StepLine, #TagLine, #ExamplesLine, #ScenarioLine, #RuleLine, #Comment, #Empty, got 'Background:'","source":{"location":{"column":5,"line":6},"uri":"../bad/background_after_scenario.feature"}}}


### PR DESCRIPTION
Gherkin requires that any Feature `Background:` must come before the first Scenario / Scenario Outline in a file (to match the execution order of these steps).

We were previously allowing the background to appear anywhere at the top (Feature) level of the file. This will now throw a ParserException.

Although this could theoretically cause existing features to break, I do not consider it to be a BC break - we are now just being stricter that the input matches the expected schema.

Fixes #328