### PR TITLE
Improve type-hinting of the lexer and parser

### DIFF
--- a/src/Keywords/ArrayKeywords.php
+++ b/src/Keywords/ArrayKeywords.php
@@ -13,6 +13,7 @@ namespace Behat\Gherkin\Keywords;
 /**
  * Array initializable keywords holder.
  *
+ * ```
  * $keywords = new Behat\Gherkin\Keywords\ArrayKeywords(array(
  *     'en' => array(
  *         'feature'          => 'Feature',
@@ -39,10 +40,23 @@ namespace Behat\Gherkin\Keywords;
  *         'but'              => 'Но'
  *     )
  * ));
+ * ```
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  *
- * @phpstan-import-type TMultiLanguageKeywords from KeywordsInterface
+ * @phpstan-type TKeywordsArray array{
+ *      feature: string,
+ *      background: string,
+ *      scenario: string,
+ *      scenario_outline: string,
+ *      examples: string,
+ *      given: string,
+ *      when: string,
+ *      then: string,
+ *      and: string,
+ *      but: string,
+ *  }
+ * @phpstan-type TMultiLanguageKeywords array<string, TKeywordsArray>
  */
 class ArrayKeywords implements KeywordsInterface
 {

--- a/src/Keywords/KeywordsInterface.php
+++ b/src/Keywords/KeywordsInterface.php
@@ -14,10 +14,6 @@ namespace Behat\Gherkin\Keywords;
  * Keywords holder interface.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
- *
- * @phpstan-type TLanguage string
- * @phpstan-type TKeywordsArray array{feature: string, background: string, scenario: string, scenario_outline: string, examples: string, given: string, when: string, then: string, and: string, but: string}
- * @phpstan-type TMultiLanguageKeywords array<TLanguage, TKeywordsArray>
  */
 interface KeywordsInterface
 {

--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -28,15 +28,15 @@ use function assert;
  * @final since 4.15.0
  *
  * @phpstan-type TStepKeyword 'Given'|'When'|'Then'|'And'|'But'
- * @phpstan-type TTitleKeyword 'Feature'|'Background'|'Scenario'|'Outline'|'Examples'|'Step'
- * @phpstan-type TTokenType 'Text'|'Comment'|'EOS'|'Newline'|'PyStringOp'|'TableRow'|'Tag'|'Language'|TTitleKeyword
- * @phpstan-type TToken TStringValueToken|TNullValueToken|TKeywordToken|TStepToken|TTagToken|TTableRowToken
+ * @phpstan-type TTitleKeyword 'Feature'|'Background'|'Scenario'|'Outline'|'Examples'
+ * @phpstan-type TTokenType 'Text'|'Comment'|'EOS'|'Newline'|'PyStringOp'|'TableRow'|'Tag'|'Language'|'Step'|TTitleKeyword
+ * @phpstan-type TToken TStringValueToken|TNullValueToken|TTitleToken|TStepToken|TTagToken|TTableRowToken
  * @phpstan-type TStringValueToken array{type: TTokenType, value: string, line: int, deferred: bool}
  * @phpstan-type TNullValueToken array{type: TTokenType, value: null, line: int, deferred: bool}
- * @phpstan-type TKeywordToken array{type: TTokenType, value: null|string, line: int, deferred: bool, keyword: string, indent: int}
- * @phpstan-type TStepToken array{type: TTokenType, value: string, line: int, deferred: bool, keyword_type: string, text: string}
- * @phpstan-type TTagToken array{type: TTokenType, value: null, line: int, deferred: bool, tags: list<string>}
- * @phpstan-type TTableRowToken array{type: TTokenType, value: null, line: int, deferred: bool, columns: list<string>}
+ * @phpstan-type TTitleToken array{type: TTitleKeyword, value: null|non-empty-string, line: int, deferred: bool, keyword: string, indent: int}
+ * @phpstan-type TStepToken array{type: 'Step', value: string, line: int, deferred: bool, keyword_type: string, text: string}
+ * @phpstan-type TTagToken array{type: 'Tag', value: null, line: int, deferred: bool, tags: list<string>}
+ * @phpstan-type TTableRowToken array{type: 'TableRow', value: null, line: int, deferred: bool, columns: list<string>}
  */
 class Lexer
 {
@@ -394,7 +394,7 @@ class Lexer
      *
      * @return array|null
      *
-     * @phpstan-return TKeywordToken|null
+     * @phpstan-return TTitleToken|null
      *
      * @deprecated
      */
@@ -438,7 +438,7 @@ class Lexer
      *
      * @phpstan-param TTokenType $type
      *
-     * @phpstan-return TKeywordToken|null
+     * @phpstan-return TTitleToken|null
      */
     private function scanTitleLine(array $keywords, string $type): ?array
     {
@@ -480,7 +480,7 @@ class Lexer
     /**
      * Returns a regex matching the keywords for the provided type.
      *
-     * @phpstan-param TTitleKeyword|TStepKeyword $type Keyword type
+     * @phpstan-param 'Step'|TTitleKeyword|TStepKeyword $type Keyword type
      *
      * @return string
      *
@@ -519,7 +519,7 @@ class Lexer
      *
      * @return array|null
      *
-     * @phpstan-return TKeywordToken|null
+     * @phpstan-return TTitleToken|null
      */
     protected function scanFeature()
     {
@@ -546,7 +546,7 @@ class Lexer
      *
      * @return array|null
      *
-     * @phpstan-return TKeywordToken|null
+     * @phpstan-return TTitleToken|null
      */
     protected function scanBackground()
     {
@@ -566,7 +566,7 @@ class Lexer
      *
      * @return array|null
      *
-     * @phpstan-return TKeywordToken|null
+     * @phpstan-return TTitleToken|null
      */
     protected function scanScenario()
     {
@@ -587,7 +587,7 @@ class Lexer
      *
      * @return array|null
      *
-     * @phpstan-return TKeywordToken|null
+     * @phpstan-return TTitleToken|null
      */
     protected function scanOutline()
     {
@@ -608,7 +608,7 @@ class Lexer
      *
      * @return array|null
      *
-     * @phpstan-return TKeywordToken|null
+     * @phpstan-return TTitleToken|null
      */
     protected function scanExamples()
     {

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -45,7 +45,7 @@ use Behat\Gherkin\Node\TableNode;
  * @phpstan-import-type TStepToken from Lexer
  * @phpstan-import-type TKeywordToken from Lexer
  * @phpstan-import-type TTableRowToken from Lexer
- * @phpstan-import-type TGeneralKeywordsType from Lexer
+ * @phpstan-import-type TTitleKeyword from Lexer
  *
  * @phpstan-type TParsedExpressionResult FeatureNode|BackgroundNode|ScenarioNode|OutlineNode|ExampleTableNode|TableNode|PyStringNode|StepNode|string
  */
@@ -121,7 +121,7 @@ class Parser implements ParserInterface
      *                 ? TStepToken
      *                 : ($type is 'Text'
      *                     ? TStringValueToken
-     *                     : ($type is TGeneralKeywordsType
+     *                     : ($type is TTitleKeyword
      *                         ? TKeywordToken
      *                         : TNullValueToken|TStringValueToken
      * )))))

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -43,7 +43,7 @@ use Behat\Gherkin\Node\TableNode;
  * @phpstan-import-type TStringValueToken from Lexer
  * @phpstan-import-type TTagToken from Lexer
  * @phpstan-import-type TStepToken from Lexer
- * @phpstan-import-type TKeywordToken from Lexer
+ * @phpstan-import-type TTitleToken from Lexer
  * @phpstan-import-type TTableRowToken from Lexer
  * @phpstan-import-type TTitleKeyword from Lexer
  *
@@ -122,7 +122,7 @@ class Parser implements ParserInterface
      *                 : ($type is 'Text'
      *                     ? TStringValueToken
      *                     : ($type is TTitleKeyword
-     *                         ? TKeywordToken
+     *                         ? TTitleToken
      *                         : TNullValueToken|TStringValueToken
      * )))))
      *
@@ -364,7 +364,7 @@ class Parser implements ParserInterface
     }
 
     /**
-     * @phpstan-param TKeywordToken $token
+     * @phpstan-param TTitleToken $token
      */
     private function parseScenarioOrOutlineBody(array $token): OutlineNode|ScenarioNode
     {

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -28,15 +28,24 @@ use Behat\Gherkin\Node\TableNode;
 /**
  * Gherkin parser.
  *
+ * ```
  * $lexer  = new Behat\Gherkin\Lexer($keywords);
  * $parser = new Behat\Gherkin\Parser($lexer);
  * $featuresArray = $parser->parse('/path/to/feature.feature');
+ * ```
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  *
  * @final since 4.15.0
  *
  * @phpstan-import-type TToken from Lexer
+ * @phpstan-import-type TNullValueToken from Lexer
+ * @phpstan-import-type TStringValueToken from Lexer
+ * @phpstan-import-type TTagToken from Lexer
+ * @phpstan-import-type TStepToken from Lexer
+ * @phpstan-import-type TKeywordToken from Lexer
+ * @phpstan-import-type TTableRowToken from Lexer
+ * @phpstan-import-type TGeneralKeywordsType from Lexer
  *
  * @phpstan-type TParsedExpressionResult FeatureNode|BackgroundNode|ScenarioNode|OutlineNode|ExampleTableNode|TableNode|PyStringNode|StepNode|string
  */
@@ -103,7 +112,19 @@ class Parser implements ParserInterface
      *
      * @return array
      *
-     * @phpstan-return TToken
+     * @phpstan-return (
+     *     $type is 'TableRow'
+     *         ? TTableRowToken
+     *         : ($type is 'Tag'
+     *             ? TTagToken
+     *             : ($type is 'Step'
+     *                 ? TStepToken
+     *                 : ($type is 'Text'
+     *                     ? TStringValueToken
+     *                     : ($type is TGeneralKeywordsType
+     *                         ? TKeywordToken
+     *                         : TNullValueToken|TStringValueToken
+     * )))))
      *
      * @throws ParserException
      */
@@ -199,8 +220,6 @@ class Parser implements ParserInterface
     protected function parseFeature()
     {
         $token = $this->expectTokenType('Feature');
-        \assert(\array_key_exists('keyword', $token));
-        \assert(\array_key_exists('indent', $token));
 
         $title = trim($token['value'] ?? '');
         $description = null;
@@ -283,8 +302,6 @@ class Parser implements ParserInterface
     protected function parseBackground()
     {
         $token = $this->expectTokenType('Background');
-        \assert(\array_key_exists('keyword', $token));
-        \assert(\array_key_exists('indent', $token));
 
         $title = trim($token['value'] ?? '');
         $keyword = $token['keyword'];
@@ -347,12 +364,10 @@ class Parser implements ParserInterface
     }
 
     /**
-     * @phpstan-param TToken $token
+     * @phpstan-param TKeywordToken $token
      */
     private function parseScenarioOrOutlineBody(array $token): OutlineNode|ScenarioNode
     {
-        \assert(\array_key_exists('keyword', $token));
-        \assert(\array_key_exists('indent', $token));
         $title = trim($token['value'] ?? '');
         $tags = $this->popTags();
         $keyword = $token['keyword'];
@@ -463,9 +478,6 @@ class Parser implements ParserInterface
     protected function parseStep()
     {
         $token = $this->expectTokenType('Step');
-        \assert(\is_string($token['value']));
-        \assert(\array_key_exists('keyword_type', $token));
-        \assert(\array_key_exists('text', $token));
 
         $arguments = [];
         while (in_array($predicted = $this->predictTokenType(), ['PyStringOp', 'TableRow', 'Newline', 'Comment'])) {
@@ -492,7 +504,6 @@ class Parser implements ParserInterface
     protected function parseExamples()
     {
         $token = $this->expectTokenType('Examples');
-        \assert(\array_key_exists('keyword', $token));
         $keyword = $token['keyword'];
         $tags = empty($this->tags) ? [] : $this->popTags();
         $table = $this->parseTableRows();
@@ -533,10 +544,7 @@ class Parser implements ParserInterface
 
         $strings = [];
         while ('PyStringOp' !== ($predicted = $this->predictTokenType()) && $predicted === 'Text') {
-            $token = $this->expectTokenType('Text');
-            \assert(\is_string($token['value']));
-
-            $strings[] = $token['value'];
+            $strings[] = $this->expectTokenType('Text')['value'];
         }
 
         $this->expectTokenType('PyStringOp');
@@ -552,7 +560,6 @@ class Parser implements ParserInterface
     protected function parseTags()
     {
         $token = $this->expectTokenType('Tag');
-        \assert(\array_key_exists('tags', $token));
 
         // Validate that the tags are followed by a node that can be tagged
         $this->validateAndGetNextTaggedNodeType();
@@ -580,7 +587,7 @@ class Parser implements ParserInterface
     /**
      * Checks the tags fit the required format.
      *
-     * @param string[] $tags
+     * @param array<array-key, string> $tags
      *
      * @return void
      */
@@ -652,7 +659,6 @@ class Parser implements ParserInterface
             }
 
             $token = $this->expectTokenType('TableRow');
-            \assert(\array_key_exists('columns', $token));
 
             $table[$token['line']] = $token['columns'];
         }

--- a/tests/Keywords/KeywordsTestCase.php
+++ b/tests/Keywords/KeywordsTestCase.php
@@ -10,6 +10,7 @@
 
 namespace Tests\Behat\Gherkin\Keywords;
 
+use Behat\Gherkin\Keywords\ArrayKeywords;
 use Behat\Gherkin\Keywords\KeywordsDumper;
 use Behat\Gherkin\Keywords\KeywordsInterface;
 use Behat\Gherkin\Lexer;
@@ -24,7 +25,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @phpstan-import-type TMultiLanguageKeywords from KeywordsInterface
+ * @phpstan-import-type TMultiLanguageKeywords from ArrayKeywords
  */
 abstract class KeywordsTestCase extends TestCase
 {


### PR DESCRIPTION
Extracted/recovered changes from my phpstan-level-9 PR that:
1. improves type hinting of the parser, lexer and by coincidence, the keywords interface.
2. fixes a few php-level-9 issues