### PR TITLE
Define and change phpdoc order coding style

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -26,6 +26,17 @@ return (new PhpCsFixer\Config())
         ],
         'concat_space' => ['spacing' => 'one'],
         'phpdoc_align' => ['align' => 'left'],
+        'phpdoc_order' => [
+            'order' => [
+                'phpstan-import-type',
+                'phpstan-type',
+                'param',
+                'phpstan-param',
+                'return',
+                'phpstan-return',
+                'throws',
+            ],
+        ],
         'heredoc_to_nowdoc' => true,
         'heredoc_indentation' => ['indentation' => 'same_as_start'],
         'single_line_throw' => false,

--- a/src/Loader/ArrayLoader.php
+++ b/src/Loader/ArrayLoader.php
@@ -55,9 +55,9 @@ class ArrayLoader implements LoaderInterface
      *
      * @param mixed $resource Resource to load
      *
-     * @return list<FeatureNode>
-     *
      * @phpstan-param TArrayResource $resource
+     *
+     * @return list<FeatureNode>
      */
     public function load($resource)
     {

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -34,9 +34,9 @@ use Behat\Gherkin\Node\TableNode;
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  *
- * @phpstan-type TParsedExpressionResult FeatureNode|BackgroundNode|ScenarioNode|OutlineNode|ExampleTableNode|TableNode|PyStringNode|StepNode|string
- *
  * @phpstan-import-type TToken from Lexer
+ *
+ * @phpstan-type TParsedExpressionResult FeatureNode|BackgroundNode|ScenarioNode|OutlineNode|ExampleTableNode|TableNode|PyStringNode|StepNode|string
  */
 class Parser
 {


### PR DESCRIPTION
The current/default style doesn't handle the `@phpstan-` cases, which as I see, we will have more often.

This CS change ensures they stay uniform.