### PR TITLE
feat: Introduce a DialectProviderInterface matching the modern cucumber API

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -81,6 +81,9 @@ jobs:
       - run: composer update
         if: steps.cucumber.outputs.cucumber_updated == 'yes'
 
+      - run: cp vendor/cucumber/gherkin-monorepo/gherkin-languages.json resources/
+        if: steps.cucumber.outputs.cucumber_updated == 'yes'
+
       - run: bin/update_i18n
         if: steps.cucumber.outputs.cucumber_updated == 'yes'
 

--- a/resources/gherkin-languages.json
+++ b/resources/gherkin-languages.json
@@ -1,0 +1,3831 @@
+{
+  "af": {
+    "and": [
+      "* ",
+      "En "
+    ],
+    "background": [
+      "Agtergrond"
+    ],
+    "but": [
+      "* ",
+      "Maar "
+    ],
+    "examples": [
+      "Voorbeelde"
+    ],
+    "feature": [
+      "Funksie",
+      "Besigheid Behoefte",
+      "Vermoë"
+    ],
+    "given": [
+      "* ",
+      "Gegewe "
+    ],
+    "name": "Afrikaans",
+    "native": "Afrikaans",
+    "rule": [
+      "Regel"
+    ],
+    "scenario": [
+      "Voorbeeld",
+      "Situasie"
+    ],
+    "scenarioOutline": [
+      "Situasie Uiteensetting"
+    ],
+    "then": [
+      "* ",
+      "Dan "
+    ],
+    "when": [
+      "* ",
+      "Wanneer "
+    ]
+  },
+  "am": {
+    "and": [
+      "* ",
+      "Եվ "
+    ],
+    "background": [
+      "Կոնտեքստ"
+    ],
+    "but": [
+      "* ",
+      "Բայց "
+    ],
+    "examples": [
+      "Օրինակներ"
+    ],
+    "feature": [
+      "Ֆունկցիոնալություն",
+      "Հատկություն"
+    ],
+    "given": [
+      "* ",
+      "Դիցուք "
+    ],
+    "name": "Armenian",
+    "native": "հայերեն",
+    "rule": [
+      "Rule"
+    ],
+    "scenario": [
+      "Օրինակ",
+      "Սցենար"
+    ],
+    "scenarioOutline": [
+      "Սցենարի կառուցվացքը"
+    ],
+    "then": [
+      "* ",
+      "Ապա "
+    ],
+    "when": [
+      "* ",
+      "Եթե ",
+      "Երբ "
+    ]
+  },
+  "an": {
+    "and": [
+      "* ",
+      "Y ",
+      "E "
+    ],
+    "background": [
+      "Antecedents"
+    ],
+    "but": [
+      "* ",
+      "Pero "
+    ],
+    "examples": [
+      "Eixemplos"
+    ],
+    "feature": [
+      "Caracteristica"
+    ],
+    "given": [
+      "* ",
+      "Dau ",
+      "Dada ",
+      "Daus ",
+      "Dadas "
+    ],
+    "name": "Aragonese",
+    "native": "Aragonés",
+    "rule": [
+      "Rule"
+    ],
+    "scenario": [
+      "Eixemplo",
+      "Caso"
+    ],
+    "scenarioOutline": [
+      "Esquema del caso"
+    ],
+    "then": [
+      "* ",
+      "Alavez ",
+      "Allora ",
+      "Antonces "
+    ],
+    "when": [
+      "* ",
+      "Cuan "
+    ]
+  },
+  "ar": {
+    "and": [
+      "* ",
+      "و "
+    ],
+    "background": [
+      "الخلفية"
+    ],
+    "but": [
+      "* ",
+      "لكن "
+    ],
+    "examples": [
+      "امثلة"
+    ],
+    "feature": [
+      "خاصية"
+    ],
+    "given": [
+      "* ",
+      "بفرض "
+    ],
+    "name": "Arabic",
+    "native": "العربية",
+    "rule": [
+      "Rule"
+    ],
+    "scenario": [
+      "مثال",
+      "سيناريو"
+    ],
+    "scenarioOutline": [
+      "سيناريو مخطط"
+    ],
+    "then": [
+      "* ",
+      "اذاً ",
+      "ثم "
+    ],
+    "when": [
+      "* ",
+      "متى ",
+      "عندما "
+    ]
+  },
+  "ast": {
+    "and": [
+      "* ",
+      "Y ",
+      "Ya "
+    ],
+    "background": [
+      "Antecedentes"
+    ],
+    "but": [
+      "* ",
+      "Peru "
+    ],
+    "examples": [
+      "Exemplos"
+    ],
+    "feature": [
+      "Carauterística"
+    ],
+    "given": [
+      "* ",
+      "Dáu ",
+      "Dada ",
+      "Daos ",
+      "Daes "
+    ],
+    "name": "Asturian",
+    "native": "asturianu",
+    "rule": [
+      "Rule"
+    ],
+    "scenario": [
+      "Exemplo",
+      "Casu"
+    ],
+    "scenarioOutline": [
+      "Esbozu del casu"
+    ],
+    "then": [
+      "* ",
+      "Entós "
+    ],
+    "when": [
+      "* ",
+      "Cuando "
+    ]
+  },
+  "az": {
+    "and": [
+      "* ",
+      "Və ",
+      "Həm "
+    ],
+    "background": [
+      "Keçmiş",
+      "Kontekst"
+    ],
+    "but": [
+      "* ",
+      "Amma ",
+      "Ancaq "
+    ],
+    "examples": [
+      "Nümunələr"
+    ],
+    "feature": [
+      "Özəllik"
+    ],
+    "given": [
+      "* ",
+      "Tutaq ki ",
+      "Verilir "
+    ],
+    "name": "Azerbaijani",
+    "native": "Azərbaycanca",
+    "rule": [
+      "Rule"
+    ],
+    "scenario": [
+      "Nümunə",
+      "Ssenari"
+    ],
+    "scenarioOutline": [
+      "Ssenarinin strukturu"
+    ],
+    "then": [
+      "* ",
+      "O halda "
+    ],
+    "when": [
+      "* ",
+      "Əgər ",
+      "Nə vaxt ki "
+    ]
+  },
+  "be": {
+    "and": [
+      "* ",
+      "I ",
+      "Ды ",
+      "Таксама "
+    ],
+    "background": [
+      "Кантэкст"
+    ],
+    "but": [
+      "* ",
+      "Але ",
+      "Інакш "
+    ],
+    "examples": [
+      "Прыклады"
+    ],
+    "feature": [
+      "Функцыянальнасць",
+      "Фіча"
+    ],
+    "given": [
+      "* ",
+      "Няхай ",
+      "Дадзена "
+    ],
+    "name": "Belarusian",
+    "native": "Беларуская",
+    "rule": [
+      "Правілы"
+    ],
+    "scenario": [
+      "Сцэнарый",
+      "Cцэнар"
+    ],
+    "scenarioOutline": [
+      "Шаблон сцэнарыя",
+      "Узор сцэнара"
+    ],
+    "then": [
+      "* ",
+      "Тады "
+    ],
+    "when": [
+      "* ",
+      "Калі "
+    ]
+  },
+  "bg": {
+    "and": [
+      "* ",
+      "И "
+    ],
+    "background": [
+      "Предистория"
+    ],
+    "but": [
+      "* ",
+      "Но "
+    ],
+    "examples": [
+      "Примери"
+    ],
+    "feature": [
+      "Функционалност"
+    ],
+    "given": [
+      "* ",
+      "Дадено "
+    ],
+    "name": "Bulgarian",
+    "native": "български",
+    "rule": [
+      "Правило"
+    ],
+    "scenario": [
+      "Пример",
+      "Сценарий"
+    ],
+    "scenarioOutline": [
+      "Рамка на сценарий"
+    ],
+    "then": [
+      "* ",
+      "То "
+    ],
+    "when": [
+      "* ",
+      "Когато "
+    ]
+  },
+  "bm": {
+    "and": [
+      "* ",
+      "Dan "
+    ],
+    "background": [
+      "Latar Belakang"
+    ],
+    "but": [
+      "* ",
+      "Tetapi ",
+      "Tapi "
+    ],
+    "examples": [
+      "Contoh"
+    ],
+    "feature": [
+      "Fungsi"
+    ],
+    "given": [
+      "* ",
+      "Diberi ",
+      "Bagi "
+    ],
+    "name": "Malay",
+    "native": "Bahasa Melayu",
+    "rule": [
+      "Rule"
+    ],
+    "scenario": [
+      "Senario",
+      "Situasi",
+      "Keadaan"
+    ],
+    "scenarioOutline": [
+      "Kerangka Senario",
+      "Kerangka Situasi",
+      "Kerangka Keadaan",
+      "Garis Panduan Senario"
+    ],
+    "then": [
+      "* ",
+      "Maka ",
+      "Kemudian "
+    ],
+    "when": [
+      "* ",
+      "Apabila "
+    ]
+  },
+  "bs": {
+    "and": [
+      "* ",
+      "I ",
+      "A "
+    ],
+    "background": [
+      "Pozadina"
+    ],
+    "but": [
+      "* ",
+      "Ali "
+    ],
+    "examples": [
+      "Primjeri"
+    ],
+    "feature": [
+      "Karakteristika"
+    ],
+    "given": [
+      "* ",
+      "Dato "
+    ],
+    "name": "Bosnian",
+    "native": "Bosanski",
+    "rule": [
+      "Rule"
+    ],
+    "scenario": [
+      "Primjer",
+      "Scenariju",
+      "Scenario"
+    ],
+    "scenarioOutline": [
+      "Scenariju-obris",
+      "Scenario-outline"
+    ],
+    "then": [
+      "* ",
+      "Zatim "
+    ],
+    "when": [
+      "* ",
+      "Kada "
+    ]
+  },
+  "ca": {
+    "and": [
+      "* ",
+      "I "
+    ],
+    "background": [
+      "Rerefons",
+      "Antecedents"
+    ],
+    "but": [
+      "* ",
+      "Però "
+    ],
+    "examples": [
+      "Exemples"
+    ],
+    "feature": [
+      "Característica",
+      "Funcionalitat"
+    ],
+    "given": [
+      "* ",
+      "Donat ",
+      "Donada ",
+      "Atès ",
+      "Atesa "
+    ],
+    "name": "Catalan",
+    "native": "català",
+    "rule": [
+      "Rule"
+    ],
+    "scenario": [
+      "Exemple",
+      "Escenari"
+    ],
+    "scenarioOutline": [
+      "Esquema de l'escenari"
+    ],
+    "then": [
+      "* ",
+      "Aleshores ",
+      "Cal "
+    ],
+    "when": [
+      "* ",
+      "Quan "
+    ]
+  },
+  "cs": {
+    "and": [
+      "* ",
+      "A také ",
+      "A "
+    ],
+    "background": [
+      "Pozadí",
+      "Kontext"
+    ],
+    "but": [
+      "* ",
+      "Ale "
+    ],
+    "examples": [
+      "Příklady"
+    ],
+    "feature": [
+      "Požadavek"
+    ],
+    "given": [
+      "* ",
+      "Pokud ",
+      "Za předpokladu "
+    ],
+    "name": "Czech",
+    "native": "Česky",
+    "rule": [
+      "Pravidlo"
+    ],
+    "scenario": [
+      "Příklad",
+      "Scénář"
+    ],
+    "scenarioOutline": [
+      "Náčrt Scénáře",
+      "Osnova scénáře"
+    ],
+    "then": [
+      "* ",
+      "Pak "
+    ],
+    "when": [
+      "* ",
+      "Když "
+    ]
+  },
+  "cy-GB": {
+    "and": [
+      "* ",
+      "A "
+    ],
+    "background": [
+      "Cefndir"
+    ],
+    "but": [
+      "* ",
+      "Ond "
+    ],
+    "examples": [
+      "Enghreifftiau"
+    ],
+    "feature": [
+      "Arwedd"
+    ],
+    "given": [
+      "* ",
+      "Anrhegedig a "
+    ],
+    "name": "Welsh",
+    "native": "Cymraeg",
+    "rule": [
+      "Rule"
+    ],
+    "scenario": [
+      "Enghraifft",
+      "Scenario"
+    ],
+    "scenarioOutline": [
+      "Scenario Amlinellol"
+    ],
+    "then": [
+      "* ",
+      "Yna "
+    ],
+    "when": [
+      "* ",
+      "Pryd "
+    ]
+  },
+  "da": {
+    "and": [
+      "* ",
+      "Og "
+    ],
+    "background": [
+      "Baggrund"
+    ],
+    "but": [
+      "* ",
+      "Men "
+    ],
+    "examples": [
+      "Eksempler"
+    ],
+    "feature": [
+      "Egenskab"
+    ],
+    "given": [
+      "* ",
+      "Givet "
+    ],
+    "name": "Danish",
+    "native": "dansk",
+    "rule": [
+      "Regel"
+    ],
+    "scenario": [
+      "Eksempel",
+      "Scenarie"
+    ],
+    "scenarioOutline": [
+      "Abstrakt Scenario"
+    ],
+    "then": [
+      "* ",
+      "Så "
+    ],
+    "when": [
+      "* ",
+      "Når "
+    ]
+  },
+  "de": {
+    "and": [
+      "* ",
+      "Und "
+    ],
+    "background": [
+      "Grundlage",
+      "Hintergrund",
+      "Voraussetzungen",
+      "Vorbedingungen"
+    ],
+    "but": [
+      "* ",
+      "Aber "
+    ],
+    "examples": [
+      "Beispiele"
+    ],
+    "feature": [
+      "Funktionalität",
+      "Funktion"
+    ],
+    "given": [
+      "* ",
+      "Angenommen ",
+      "Gegeben sei ",
+      "Gegeben seien "
+    ],
+    "name": "German",
+    "native": "Deutsch",
+    "rule": [
+      "Rule",
+      "Regel"
+    ],
+    "scenario": [
+      "Beispiel",
+      "Szenario"
+    ],
+    "scenarioOutline": [
+      "Szenariogrundriss",
+      "Szenarien"
+    ],
+    "then": [
+      "* ",
+      "Dann "
+    ],
+    "when": [
+      "* ",
+      "Wenn "
+    ]
+  },
+  "el": {
+    "and": [
+      "* ",
+      "Και "
+    ],
+    "background": [
+      "Υπόβαθρο"
+    ],
+    "but": [
+      "* ",
+      "Αλλά "
+    ],
+    "examples": [
+      "Παραδείγματα",
+      "Σενάρια"
+    ],
+    "feature": [
+      "Δυνατότητα",
+      "Λειτουργία"
+    ],
+    "given": [
+      "* ",
+      "Δεδομένου "
+    ],
+    "name": "Greek",
+    "native": "Ελληνικά",
+    "rule": [
+      "Rule"
+    ],
+    "scenario": [
+      "Παράδειγμα",
+      "Σενάριο"
+    ],
+    "scenarioOutline": [
+      "Περιγραφή Σεναρίου",
+      "Περίγραμμα Σεναρίου"
+    ],
+    "then": [
+      "* ",
+      "Τότε "
+    ],
+    "when": [
+      "* ",
+      "Όταν "
+    ]
+  },
+  "em": {
+    "and": [
+      "* ",
+      "😂"
+    ],
+    "background": [
+      "💤"
+    ],
+    "but": [
+      "* ",
+      "😔"
+    ],
+    "examples": [
+      "📓"
+    ],
+    "feature": [
+      "📚"
+    ],
+    "given": [
+      "* ",
+      "😐"
+    ],
+    "name": "Emoji",
+    "native": "😀",
+    "rule": [
+      "Rule"
+    ],
+    "scenario": [
+      "🥒",
+      "📕"
+    ],
+    "scenarioOutline": [
+      "📖"
+    ],
+    "then": [
+      "* ",
+      "🙏"
+    ],
+    "when": [
+      "* ",
+      "🎬"
+    ]
+  },
+  "en": {
+    "and": [
+      "* ",
+      "And "
+    ],
+    "background": [
+      "Background"
+    ],
+    "but": [
+      "* ",
+      "But "
+    ],
+    "examples": [
+      "Examples",
+      "Scenarios"
+    ],
+    "feature": [
+      "Feature",
+      "Business Need",
+      "Ability"
+    ],
+    "given": [
+      "* ",
+      "Given "
+    ],
+    "name": "English",
+    "native": "English",
+    "rule": [
+      "Rule"
+    ],
+    "scenario": [
+      "Example",
+      "Scenario"
+    ],
+    "scenarioOutline": [
+      "Scenario Outline",
+      "Scenario Template"
+    ],
+    "then": [
+      "* ",
+      "Then "
+    ],
+    "when": [
+      "* ",
+      "When "
+    ]
+  },
+  "en-Scouse": {
+    "and": [
+      "* ",
+      "An "
+    ],
+    "background": [
+      "Dis is what went down"
+    ],
+    "but": [
+      "* ",
+      "Buh "
+    ],
+    "examples": [
+      "Examples"
+    ],
+    "feature": [
+      "Feature"
+    ],
+    "given": [
+      "* ",
+      "Givun ",
+      "Youse know when youse got "
+    ],
+    "name": "Scouse",
+    "native": "Scouse",
+    "rule": [
+      "Rule"
+    ],
+    "scenario": [
+      "The thing of it is"
+    ],
+    "scenarioOutline": [
+      "Wharrimean is"
+    ],
+    "then": [
+      "* ",
+      "Dun ",
+      "Den youse gotta "
+    ],
+    "when": [
+      "* ",
+      "Wun ",
+      "Youse know like when "
+    ]
+  },
+  "en-au": {
+    "and": [
+      "* ",
+      "Too right "
+    ],
+    "background": [
+      "First off"
+    ],
+    "but": [
+      "* ",
+      "Yeah nah "
+    ],
+    "examples": [
+      "You'll wanna"
+    ],
+    "feature": [
+      "Pretty much"
+    ],
+    "given": [
+      "* ",
+      "Y'know "
+    ],
+    "name": "Australian",
+    "native": "Australian",
+    "rule": [
+      "Rule"
+    ],
+    "scenario": [
+      "Awww, look mate"
+    ],
+    "scenarioOutline": [
+      "Reckon it's like"
+    ],
+    "then": [
+      "* ",
+      "But at the end of the day I reckon "
+    ],
+    "when": [
+      "* ",
+      "It's just unbelievable "
+    ]
+  },
+  "en-lol": {
+    "and": [
+      "* ",
+      "AN "
+    ],
+    "background": [
+      "B4"
+    ],
+    "but": [
+      "* ",
+      "BUT "
+    ],
+    "examples": [
+      "EXAMPLZ"
+    ],
+    "feature": [
+      "OH HAI"
+    ],
+    "given": [
+      "* ",
+      "I CAN HAZ "
+    ],
+    "name": "LOLCAT",
+    "native": "LOLCAT",
+    "rule": [
+      "Rule"
+    ],
+    "scenario": [
+      "MISHUN"
+    ],
+    "scenarioOutline": [
+      "MISHUN SRSLY"
+    ],
+    "then": [
+      "* ",
+      "DEN "
+    ],
+    "when": [
+      "* ",
+      "WEN "
+    ]
+  },
+  "en-old": {
+    "and": [
+      "* ",
+      "Ond ",
+      "7 "
+    ],
+    "background": [
+      "Aer",
+      "Ær"
+    ],
+    "but": [
+      "* ",
+      "Ac "
+    ],
+    "examples": [
+      "Se the",
+      "Se þe",
+      "Se ðe"
+    ],
+    "feature": [
+      "Hwaet",
+      "Hwæt"
+    ],
+    "given": [
+      "* ",
+      "Thurh ",
+      "Þurh ",
+      "Ðurh "
+    ],
+    "name": "Old English",
+    "native": "Englisc",
+    "rule": [
+      "Rule"
+    ],
+    "scenario": [
+      "Swa"
+    ],
+    "scenarioOutline": [
+      "Swa hwaer swa",
+      "Swa hwær swa"
+    ],
+    "then": [
+      "* ",
+      "Tha ",
+      "Þa ",
+      "Ða ",
+      "Tha the ",
+      "Þa þe ",
+      "Ða ðe "
+    ],
+    "when": [
+      "* ",
+      "Bæþsealf ",
+      "Bæþsealfa ",
+      "Bæþsealfe ",
+      "Ciricæw ",
+      "Ciricæwe ",
+      "Ciricæwa "
+    ]
+  },
+  "en-pirate": {
+    "and": [
+      "* ",
+      "Aye "
+    ],
+    "background": [
+      "Yo-ho-ho"
+    ],
+    "but": [
+      "* ",
+      "Avast! "
+    ],
+    "examples": [
+      "Dead men tell no tales"
+    ],
+    "feature": [
+      "Ahoy matey!"
+    ],
+    "given": [
+      "* ",
+      "Gangway! "
+    ],
+    "name": "Pirate",
+    "native": "Pirate",
+    "rule": [
+      "Rule"
+    ],
+    "scenario": [
+      "Heave to"
+    ],
+    "scenarioOutline": [
+      "Shiver me timbers"
+    ],
+    "then": [
+      "* ",
+      "Let go and haul "
+    ],
+    "when": [
+      "* ",
+      "Blimey! "
+    ]
+  },
+    "en-tx": {
+    "and": [
+      "Come hell or high water "
+    ],
+    "background": [
+      "Lemme tell y'all a story"
+    ],
+    "but": [
+      "Well now hold on, I'll you what "
+    ],
+    "examples": [
+      "Now that's a story longer than a cattle drive in July"
+    ],
+    "feature": [
+      "This ain’t my first rodeo",
+      "All gussied up"
+    ],
+    "given": [
+      "Fixin' to ",
+      "All git out "
+    ],
+    "name": "Texas",
+    "native": "Texas",
+    "rule": [
+      "Rule "
+    ],
+    "scenario": [
+      "All hat and no cattle"
+    ],
+    "scenarioOutline": [
+      "Serious as a snake bite",
+      "Busy as a hound in flea season"
+    ],
+    "then": [
+      "There’s no tree but bears some fruit "
+    ],
+    "when": [
+      "Quick out of the chute "
+    ]
+  },
+  "eo": {
+    "and": [
+      "* ",
+      "Kaj "
+    ],
+    "background": [
+      "Fono"
+    ],
+    "but": [
+      "* ",
+      "Sed "
+    ],
+    "examples": [
+      "Ekzemploj"
+    ],
+    "feature": [
+      "Trajto"
+    ],
+    "given": [
+      "* ",
+      "Donitaĵo ",
+      "Komence "
+    ],
+    "name": "Esperanto",
+    "native": "Esperanto",
+    "rule": [
+      "Regulo"
+    ],
+    "scenario": [
+      "Ekzemplo",
+      "Scenaro",
+      "Kazo"
+    ],
+    "scenarioOutline": [
+      "Konturo de la scenaro",
+      "Skizo",
+      "Kazo-skizo"
+    ],
+    "then": [
+      "* ",
+      "Do "
+    ],
+    "when": [
+      "* ",
+      "Se "
+    ]
+  },
+  "es": {
+    "and": [
+      "* ",
+      "Y ",
+      "E "
+    ],
+    "background": [
+      "Antecedentes"
+    ],
+    "but": [
+      "* ",
+      "Pero "
+    ],
+    "examples": [
+      "Ejemplos"
+    ],
+    "feature": [
+      "Característica",
+      "Necesidad del negocio",
+      "Requisito"
+    ],
+    "given": [
+      "* ",
+      "Dado ",
+      "Dada ",
+      "Dados ",
+      "Dadas "
+    ],
+    "name": "Spanish",
+    "native": "español",
+    "rule": [
+      "Regla",
+      "Regla de negocio"
+    ],
+    "scenario": [
+      "Ejemplo",
+      "Escenario"
+    ],
+    "scenarioOutline": [
+      "Esquema del escenario"
+    ],
+    "then": [
+      "* ",
+      "Entonces "
+    ],
+    "when": [
+      "* ",
+      "Cuando "
+    ]
+  },
+  "et": {
+    "and": [
+      "* ",
+      "Ja "
+    ],
+    "background": [
+      "Taust"
+    ],
+    "but": [
+      "* ",
+      "Kuid "
+    ],
+    "examples": [
+      "Juhtumid"
+    ],
+    "feature": [
+      "Omadus"
+    ],
+    "given": [
+      "* ",
+      "Eeldades "
+    ],
+    "name": "Estonian",
+    "native": "eesti keel",
+    "rule": [
+      "Reegel"
+    ],
+    "scenario": [
+      "Juhtum",
+      "Stsenaarium"
+    ],
+    "scenarioOutline": [
+      "Raamjuhtum",
+      "Raamstsenaarium"
+    ],
+    "then": [
+      "* ",
+      "Siis "
+    ],
+    "when": [
+      "* ",
+      "Kui "
+    ]
+  },
+  "fa": {
+    "and": [
+      "* ",
+      "و "
+    ],
+    "background": [
+      "زمینه"
+    ],
+    "but": [
+      "* ",
+      "اما "
+    ],
+    "examples": [
+      "نمونه ها"
+    ],
+    "feature": [
+      "وِیژگی"
+    ],
+    "given": [
+      "* ",
+      "با فرض "
+    ],
+    "name": "Persian",
+    "native": "فارسی",
+    "rule": [
+      "Rule"
+    ],
+    "scenario": [
+      "مثال",
+      "سناریو"
+    ],
+    "scenarioOutline": [
+      "الگوی سناریو"
+    ],
+    "then": [
+      "* ",
+      "آنگاه "
+    ],
+    "when": [
+      "* ",
+      "هنگامی "
+    ]
+  },
+  "fi": {
+    "and": [
+      "* ",
+      "Ja "
+    ],
+    "background": [
+      "Tausta"
+    ],
+    "but": [
+      "* ",
+      "Mutta "
+    ],
+    "examples": [
+      "Tapaukset"
+    ],
+    "feature": [
+      "Ominaisuus"
+    ],
+    "given": [
+      "* ",
+      "Oletetaan "
+    ],
+    "name": "Finnish",
+    "native": "suomi",
+    "rule": [
+      "Rule"
+    ],
+    "scenario": [
+      "Tapaus"
+    ],
+    "scenarioOutline": [
+      "Tapausaihio"
+    ],
+    "then": [
+      "* ",
+      "Niin "
+    ],
+    "when": [
+      "* ",
+      "Kun "
+    ]
+  },
+  "fr": {
+    "and": [
+      "* ",
+      "Et que ",
+      "Et qu'",
+      "Et "
+    ],
+    "background": [
+      "Contexte"
+    ],
+    "but": [
+      "* ",
+      "Mais que ",
+      "Mais qu'",
+      "Mais "
+    ],
+    "examples": [
+      "Exemples"
+    ],
+    "feature": [
+      "Fonctionnalité"
+    ],
+    "given": [
+      "* ",
+      "Soit ",
+      "Sachant que ",
+      "Sachant qu'",
+      "Sachant ",
+      "Etant donné que ",
+      "Etant donné qu'",
+      "Etant donné ",
+      "Etant donnée ",
+      "Etant donnés ",
+      "Etant données ",
+      "Étant donné que ",
+      "Étant donné qu'",
+      "Étant donné ",
+      "Étant donnée ",
+      "Étant donnés ",
+      "Étant données "
+    ],
+    "name": "French",
+    "native": "français",
+    "rule": [
+      "Règle"
+    ],
+    "scenario": [
+      "Exemple",
+      "Scénario"
+    ],
+    "scenarioOutline": [
+      "Plan du scénario",
+      "Plan du Scénario"
+    ],
+    "then": [
+      "* ",
+      "Alors ",
+      "Donc "
+    ],
+    "when": [
+      "* ",
+      "Quand ",
+      "Lorsque ",
+      "Lorsqu'"
+    ]
+  },
+  "ga": {
+    "and": [
+      "* ",
+      "Agus "
+    ],
+    "background": [
+      "Cúlra"
+    ],
+    "but": [
+      "* ",
+      "Ach "
+    ],
+    "examples": [
+      "Samplaí"
+    ],
+    "feature": [
+      "Gné"
+    ],
+    "given": [
+      "* ",
+      "Cuir i gcás go ",
+      "Cuir i gcás nach ",
+      "Cuir i gcás gur ",
+      "Cuir i gcás nár "
+    ],
+    "name": "Irish",
+    "native": "Gaeilge",
+    "rule": [
+      "Riail"
+    ],
+    "scenario": [
+      "Sampla",
+      "Cás"
+    ],
+    "scenarioOutline": [
+      "Cás Achomair"
+    ],
+    "then": [
+      "* ",
+      "Ansin "
+    ],
+    "when": [
+      "* ",
+      "Nuair a ",
+      "Nuair nach ",
+      "Nuair ba ",
+      "Nuair nár "
+    ]
+  },
+  "gj": {
+    "and": [
+      "* ",
+      "અને "
+    ],
+    "background": [
+      "બેકગ્રાઉન્ડ"
+    ],
+    "but": [
+      "* ",
+      "પણ "
+    ],
+    "examples": [
+      "ઉદાહરણો"
+    ],
+    "feature": [
+      "લક્ષણ",
+      "વ્યાપાર જરૂર",
+      "ક્ષમતા"
+    ],
+    "given": [
+      "* ",
+      "આપેલ છે "
+    ],
+    "name": "Gujarati",
+    "native": "ગુજરાતી",
+    "rule": [
+      "નિયમ"
+    ],
+    "scenario": [
+      "ઉદાહરણ",
+      "સ્થિતિ"
+    ],
+    "scenarioOutline": [
+      "પરિદ્દશ્ય રૂપરેખા",
+      "પરિદ્દશ્ય ઢાંચો"
+    ],
+    "then": [
+      "* ",
+      "પછી "
+    ],
+    "when": [
+      "* ",
+      "ક્યારે "
+    ]
+  },
+  "gl": {
+    "and": [
+      "* ",
+      "E "
+    ],
+    "background": [
+      "Contexto"
+    ],
+    "but": [
+      "* ",
+      "Mais ",
+      "Pero "
+    ],
+    "examples": [
+      "Exemplos"
+    ],
+    "feature": [
+      "Característica"
+    ],
+    "given": [
+      "* ",
+      "Dado ",
+      "Dada ",
+      "Dados ",
+      "Dadas "
+    ],
+    "name": "Galician",
+    "native": "galego",
+    "rule": [
+      "Rule"
+    ],
+    "scenario": [
+      "Exemplo",
+      "Escenario"
+    ],
+    "scenarioOutline": [
+      "Esbozo do escenario"
+    ],
+    "then": [
+      "* ",
+      "Entón ",
+      "Logo "
+    ],
+    "when": [
+      "* ",
+      "Cando "
+    ]
+  },
+  "he": {
+    "and": [
+      "* ",
+      "וגם "
+    ],
+    "background": [
+      "רקע"
+    ],
+    "but": [
+      "* ",
+      "אבל "
+    ],
+    "examples": [
+      "דוגמאות"
+    ],
+    "feature": [
+      "תכונה"
+    ],
+    "given": [
+      "* ",
+      "בהינתן "
+    ],
+    "name": "Hebrew",
+    "native": "עברית",
+    "rule": [
+      "כלל"
+    ],
+    "scenario": [
+      "דוגמא",
+      "תרחיש"
+    ],
+    "scenarioOutline": [
+      "תבנית תרחיש"
+    ],
+    "then": [
+      "* ",
+      "אז ",
+      "אזי "
+    ],
+    "when": [
+      "* ",
+      "כאשר "
+    ]
+  },
+  "hi": {
+    "and": [
+      "* ",
+      "और ",
+      "तथा "
+    ],
+    "background": [
+      "पृष्ठभूमि"
+    ],
+    "but": [
+      "* ",
+      "पर ",
+      "परन्तु ",
+      "किन्तु "
+    ],
+    "examples": [
+      "उदाहरण"
+    ],
+    "feature": [
+      "रूप लेख"
+    ],
+    "given": [
+      "* ",
+      "अगर ",
+      "यदि ",
+      "चूंकि "
+    ],
+    "name": "Hindi",
+    "native": "हिंदी",
+    "rule": [
+      "नियम"
+    ],
+    "scenario": [
+      "परिदृश्य"
+    ],
+    "scenarioOutline": [
+      "परिदृश्य रूपरेखा"
+    ],
+    "then": [
+      "* ",
+      "तब ",
+      "तदा "
+    ],
+    "when": [
+      "* ",
+      "जब ",
+      "कदा "
+    ]
+  },
+  "hr": {
+    "and": [
+      "* ",
+      "I "
+    ],
+    "background": [
+      "Pozadina"
+    ],
+    "but": [
+      "* ",
+      "Ali "
+    ],
+    "examples": [
+      "Primjeri",
+      "Scenariji"
+    ],
+    "feature": [
+      "Osobina",
+      "Mogućnost",
+      "Mogucnost"
+    ],
+    "given": [
+      "* ",
+      "Zadan ",
+      "Zadani ",
+      "Zadano ",
+      "Ukoliko "
+    ],
+    "name": "Croatian",
+    "native": "hrvatski",
+    "rule": [
+      "Rule"
+    ],
+    "scenario": [
+      "Primjer",
+      "Scenarij"
+    ],
+    "scenarioOutline": [
+      "Skica",
+      "Koncept"
+    ],
+    "then": [
+      "* ",
+      "Onda "
+    ],
+    "when": [
+      "* ",
+      "Kada ",
+      "Kad "
+    ]
+  },
+  "ht": {
+    "and": [
+      "* ",
+      "Ak ",
+      "Epi ",
+      "E "
+    ],
+    "background": [
+      "Kontèks",
+      "Istorik"
+    ],
+    "but": [
+      "* ",
+      "Men "
+    ],
+    "examples": [
+      "Egzanp"
+    ],
+    "feature": [
+      "Karakteristik",
+      "Mak",
+      "Fonksyonalite"
+    ],
+    "given": [
+      "* ",
+      "Sipoze ",
+      "Sipoze ke ",
+      "Sipoze Ke "
+    ],
+    "name": "Creole",
+    "native": "kreyòl",
+    "rule": [
+      "Rule"
+    ],
+    "scenario": [
+      "Senaryo"
+    ],
+    "scenarioOutline": [
+      "Plan senaryo",
+      "Plan Senaryo",
+      "Senaryo deskripsyon",
+      "Senaryo Deskripsyon",
+      "Dyagram senaryo",
+      "Dyagram Senaryo"
+    ],
+    "then": [
+      "* ",
+      "Lè sa a ",
+      "Le sa a "
+    ],
+    "when": [
+      "* ",
+      "Lè ",
+      "Le "
+    ]
+  },
+  "hu": {
+    "and": [
+      "* ",
+      "És "
+    ],
+    "background": [
+      "Háttér"
+    ],
+    "but": [
+      "* ",
+      "De "
+    ],
+    "examples": [
+      "Példák"
+    ],
+    "feature": [
+      "Jellemző"
+    ],
+    "given": [
+      "* ",
+      "Amennyiben ",
+      "Adott "
+    ],
+    "name": "Hungarian",
+    "native": "magyar",
+    "rule": [
+      "Szabály"
+    ],
+    "scenario": [
+      "Példa",
+      "Forgatókönyv"
+    ],
+    "scenarioOutline": [
+      "Forgatókönyv vázlat"
+    ],
+    "then": [
+      "* ",
+      "Akkor "
+    ],
+    "when": [
+      "* ",
+      "Majd ",
+      "Ha ",
+      "Amikor "
+    ]
+  },
+  "id": {
+    "and": [
+      "* ",
+      "Dan "
+    ],
+    "background": [
+      "Dasar",
+      "Latar Belakang"
+    ],
+    "but": [
+      "* ",
+      "Tapi ",
+      "Tetapi "
+    ],
+    "examples": [
+      "Contoh",
+      "Misal"
+    ],
+    "feature": [
+      "Fitur"
+    ],
+    "given": [
+      "* ",
+      "Dengan ",
+      "Diketahui ",
+      "Diasumsikan ",
+      "Bila ",
+      "Jika "
+    ],
+    "name": "Indonesian",
+    "native": "Bahasa Indonesia",
+    "rule": [
+      "Rule",
+      "Aturan"
+    ],
+    "scenario": [
+      "Skenario"
+    ],
+    "scenarioOutline": [
+      "Skenario konsep",
+      "Garis-Besar Skenario"
+    ],
+    "then": [
+      "* ",
+      "Maka ",
+      "Kemudian "
+    ],
+    "when": [
+      "* ",
+      "Ketika "
+    ]
+  },
+  "is": {
+    "and": [
+      "* ",
+      "Og "
+    ],
+    "background": [
+      "Bakgrunnur"
+    ],
+    "but": [
+      "* ",
+      "En "
+    ],
+    "examples": [
+      "Dæmi",
+      "Atburðarásir"
+    ],
+    "feature": [
+      "Eiginleiki"
+    ],
+    "given": [
+      "* ",
+      "Ef "
+    ],
+    "name": "Icelandic",
+    "native": "Íslenska",
+    "rule": [
+      "Rule"
+    ],
+    "scenario": [
+      "Atburðarás"
+    ],
+    "scenarioOutline": [
+      "Lýsing Atburðarásar",
+      "Lýsing Dæma"
+    ],
+    "then": [
+      "* ",
+      "Þá "
+    ],
+    "when": [
+      "* ",
+      "Þegar "
+    ]
+  },
+  "it": {
+    "and": [
+      "* ",
+      "E ",
+      "Ed "
+    ],
+    "background": [
+      "Contesto"
+    ],
+    "but": [
+      "* ",
+      "Ma "
+    ],
+    "examples": [
+      "Esempi"
+    ],
+    "feature": [
+      "Funzionalità",
+      "Esigenza di Business",
+      "Abilità"
+    ],
+    "given": [
+      "* ",
+      "Dato ",
+      "Data ",
+      "Dati ",
+      "Date "
+    ],
+    "name": "Italian",
+    "native": "italiano",
+    "rule": [
+      "Regola"
+    ],
+    "scenario": [
+      "Esempio",
+      "Scenario"
+    ],
+    "scenarioOutline": [
+      "Schema dello scenario"
+    ],
+    "then": [
+      "* ",
+      "Allora "
+    ],
+    "when": [
+      "* ",
+      "Quando "
+    ]
+  },
+  "ja": {
+    "and": [
+      "* ",
+      "且つ",
+      "かつ"
+    ],
+    "background": [
+      "背景"
+    ],
+    "but": [
+      "* ",
+      "然し",
+      "しかし",
+      "但し",
+      "ただし"
+    ],
+    "examples": [
+      "例",
+      "サンプル"
+    ],
+    "feature": [
+      "フィーチャ",
+      "機能"
+    ],
+    "given": [
+      "* ",
+      "前提"
+    ],
+    "name": "Japanese",
+    "native": "日本語",
+    "rule": [
+      "ルール"
+    ],
+    "scenario": [
+      "シナリオ"
+    ],
+    "scenarioOutline": [
+      "シナリオアウトライン",
+      "シナリオテンプレート",
+      "テンプレ",
+      "シナリオテンプレ"
+    ],
+    "then": [
+      "* ",
+      "ならば"
+    ],
+    "when": [
+      "* ",
+      "もし"
+    ]
+  },
+  "jv": {
+    "and": [
+      "* ",
+      "Lan "
+    ],
+    "background": [
+      "Dasar"
+    ],
+    "but": [
+      "* ",
+      "Tapi ",
+      "Nanging ",
+      "Ananging "
+    ],
+    "examples": [
+      "Conto",
+      "Contone"
+    ],
+    "feature": [
+      "Fitur"
+    ],
+    "given": [
+      "* ",
+      "Nalika ",
+      "Nalikaning "
+    ],
+    "name": "Javanese",
+    "native": "Basa Jawa",
+    "rule": [
+      "Rule"
+    ],
+    "scenario": [
+      "Skenario"
+    ],
+    "scenarioOutline": [
+      "Konsep skenario"
+    ],
+    "then": [
+      "* ",
+      "Njuk ",
+      "Banjur "
+    ],
+    "when": [
+      "* ",
+      "Manawa ",
+      "Menawa "
+    ]
+  },
+  "ka": {
+    "and": [
+      "* ",
+      "და ",
+      "ასევე "
+    ],
+    "background": [
+      "კონტექსტი"
+    ],
+    "but": [
+      "* ",
+      "მაგრამ ",
+      "თუმცა "
+    ],
+    "examples": [
+      "მაგალითები"
+    ],
+    "feature": [
+      "თვისება",
+      "მოთხოვნა"
+    ],
+    "given": [
+      "* ",
+      "მოცემული ",
+      "მოცემულია ",
+      "ვთქვათ "
+    ],
+    "name": "Georgian",
+    "native": "ქართული",
+    "rule": [
+      "წესი"
+    ],
+    "scenario": [
+      "მაგალითად",
+      "მაგალითი",
+      "მაგ",
+      "სცენარი"
+    ],
+    "scenarioOutline": [
+      "სცენარის ნიმუში",
+      "სცენარის შაბლონი",
+      "ნიმუში",
+      "შაბლონი"
+    ],
+    "then": [
+      "* ",
+      "მაშინ "
+    ],
+    "when": [
+      "* ",
+      "როდესაც ",
+      "როცა ",
+      "როგორც კი ",
+      "თუ "
+    ]
+  },
+  "kn": {
+    "and": [
+      "* ",
+      "ಮತ್ತು "
+    ],
+    "background": [
+      "ಹಿನ್ನೆಲೆ"
+    ],
+    "but": [
+      "* ",
+      "ಆದರೆ "
+    ],
+    "examples": [
+      "ಉದಾಹರಣೆಗಳು"
+    ],
+    "feature": [
+      "ಹೆಚ್ಚಳ"
+    ],
+    "given": [
+      "* ",
+      "ನೀಡಿದ "
+    ],
+    "name": "Kannada",
+    "native": "ಕನ್ನಡ",
+    "rule": [
+      "Rule"
+    ],
+    "scenario": [
+      "ಉದಾಹರಣೆ",
+      "ಕಥಾಸಾರಾಂಶ"
+    ],
+    "scenarioOutline": [
+      "ವಿವರಣೆ"
+    ],
+    "then": [
+      "* ",
+      "ನಂತರ "
+    ],
+    "when": [
+      "* ",
+      "ಸ್ಥಿತಿಯನ್ನು "
+    ]
+  },
+  "ko": {
+    "and": [
+      "* ",
+      "그리고 "
+    ],
+    "background": [
+      "배경"
+    ],
+    "but": [
+      "* ",
+      "하지만 ",
+      "단 "
+    ],
+    "examples": [
+      "예"
+    ],
+    "feature": [
+      "기능"
+    ],
+    "given": [
+      "* ",
+      "조건 ",
+      "먼저 "
+    ],
+    "name": "Korean",
+    "native": "한국어",
+    "rule": [
+      "Rule"
+    ],
+    "scenario": [
+      "시나리오"
+    ],
+    "scenarioOutline": [
+      "시나리오 개요"
+    ],
+    "then": [
+      "* ",
+      "그러면 "
+    ],
+    "when": [
+      "* ",
+      "만일 ",
+      "만약 "
+    ]
+  },
+  "lt": {
+    "and": [
+      "* ",
+      "Ir "
+    ],
+    "background": [
+      "Kontekstas"
+    ],
+    "but": [
+      "* ",
+      "Bet "
+    ],
+    "examples": [
+      "Pavyzdžiai",
+      "Scenarijai",
+      "Variantai"
+    ],
+    "feature": [
+      "Savybė"
+    ],
+    "given": [
+      "* ",
+      "Duota "
+    ],
+    "name": "Lithuanian",
+    "native": "lietuvių kalba",
+    "rule": [
+      "Rule"
+    ],
+    "scenario": [
+      "Pavyzdys",
+      "Scenarijus"
+    ],
+    "scenarioOutline": [
+      "Scenarijaus šablonas"
+    ],
+    "then": [
+      "* ",
+      "Tada "
+    ],
+    "when": [
+      "* ",
+      "Kai "
+    ]
+  },
+  "lu": {
+    "and": [
+      "* ",
+      "an ",
+      "a "
+    ],
+    "background": [
+      "Hannergrond"
+    ],
+    "but": [
+      "* ",
+      "awer ",
+      "mä "
+    ],
+    "examples": [
+      "Beispiller"
+    ],
+    "feature": [
+      "Funktionalitéit"
+    ],
+    "given": [
+      "* ",
+      "ugeholl "
+    ],
+    "name": "Luxemburgish",
+    "native": "Lëtzebuergesch",
+    "rule": [
+      "Rule"
+    ],
+    "scenario": [
+      "Beispill",
+      "Szenario"
+    ],
+    "scenarioOutline": [
+      "Plang vum Szenario"
+    ],
+    "then": [
+      "* ",
+      "dann "
+    ],
+    "when": [
+      "* ",
+      "wann "
+    ]
+  },
+  "lv": {
+    "and": [
+      "* ",
+      "Un "
+    ],
+    "background": [
+      "Konteksts",
+      "Situācija"
+    ],
+    "but": [
+      "* ",
+      "Bet "
+    ],
+    "examples": [
+      "Piemēri",
+      "Paraugs"
+    ],
+    "feature": [
+      "Funkcionalitāte",
+      "Fīča"
+    ],
+    "given": [
+      "* ",
+      "Kad "
+    ],
+    "name": "Latvian",
+    "native": "latviešu",
+    "rule": [
+      "Rule"
+    ],
+    "scenario": [
+      "Piemērs",
+      "Scenārijs"
+    ],
+    "scenarioOutline": [
+      "Scenārijs pēc parauga"
+    ],
+    "then": [
+      "* ",
+      "Tad "
+    ],
+    "when": [
+      "* ",
+      "Ja "
+    ]
+  },
+  "mk-Cyrl": {
+    "and": [
+      "* ",
+      "И "
+    ],
+    "background": [
+      "Контекст",
+      "Содржина"
+    ],
+    "but": [
+      "* ",
+      "Но "
+    ],
+    "examples": [
+      "Примери",
+      "Сценарија"
+    ],
+    "feature": [
+      "Функционалност",
+      "Бизнис потреба",
+      "Можност"
+    ],
+    "given": [
+      "* ",
+      "Дадено ",
+      "Дадена "
+    ],
+    "name": "Macedonian",
+    "native": "Македонски",
+    "rule": [
+      "Rule"
+    ],
+    "scenario": [
+      "Пример",
+      "Сценарио",
+      "На пример"
+    ],
+    "scenarioOutline": [
+      "Преглед на сценарија",
+      "Скица",
+      "Концепт"
+    ],
+    "then": [
+      "* ",
+      "Тогаш "
+    ],
+    "when": [
+      "* ",
+      "Кога "
+    ]
+  },
+  "mk-Latn": {
+    "and": [
+      "* ",
+      "I "
+    ],
+    "background": [
+      "Kontekst",
+      "Sodrzhina"
+    ],
+    "but": [
+      "* ",
+      "No "
+    ],
+    "examples": [
+      "Primeri",
+      "Scenaria"
+    ],
+    "feature": [
+      "Funkcionalnost",
+      "Biznis potreba",
+      "Mozhnost"
+    ],
+    "given": [
+      "* ",
+      "Dadeno ",
+      "Dadena "
+    ],
+    "name": "Macedonian (Latin)",
+    "native": "Makedonski (Latinica)",
+    "rule": [
+      "Rule"
+    ],
+    "scenario": [
+      "Scenario",
+      "Na primer"
+    ],
+    "scenarioOutline": [
+      "Pregled na scenarija",
+      "Skica",
+      "Koncept"
+    ],
+    "then": [
+      "* ",
+      "Togash "
+    ],
+    "when": [
+      "* ",
+      "Koga "
+    ]
+  },
+  "mn": {
+    "and": [
+      "* ",
+      "Мөн ",
+      "Тэгээд "
+    ],
+    "background": [
+      "Агуулга"
+    ],
+    "but": [
+      "* ",
+      "Гэхдээ ",
+      "Харин "
+    ],
+    "examples": [
+      "Тухайлбал"
+    ],
+    "feature": [
+      "Функц",
+      "Функционал"
+    ],
+    "given": [
+      "* ",
+      "Өгөгдсөн нь ",
+      "Анх "
+    ],
+    "name": "Mongolian",
+    "native": "монгол",
+    "rule": [
+      "Rule"
+    ],
+    "scenario": [
+      "Сценар"
+    ],
+    "scenarioOutline": [
+      "Сценарын төлөвлөгөө"
+    ],
+    "then": [
+      "* ",
+      "Тэгэхэд ",
+      "Үүний дараа "
+    ],
+    "when": [
+      "* ",
+      "Хэрэв "
+    ]
+  },
+  "ne": {
+    "and": [
+      "* ",
+      "र ",
+      "अनि "
+    ],
+    "background": [
+      "पृष्ठभूमी"
+    ],
+    "but": [
+      "* ",
+      "तर "
+    ],
+    "examples": [
+      "उदाहरण",
+      "उदाहरणहरु"
+    ],
+    "feature": [
+      "सुविधा",
+      "विशेषता"
+    ],
+    "given": [
+      "* ",
+      "दिइएको ",
+      "दिएको ",
+      "यदि "
+    ],
+    "name": "Nepali",
+    "native": "नेपाली",
+    "rule": [
+      "नियम"
+    ],
+    "scenario": [
+      "परिदृश्य"
+    ],
+    "scenarioOutline": [
+      "परिदृश्य रूपरेखा"
+    ],
+    "then": [
+      "* ",
+      "त्यसपछि ",
+      "अनी "
+    ],
+    "when": [
+      "* ",
+      "जब "
+    ]
+  },
+  "nl": {
+    "and": [
+      "* ",
+      "En "
+    ],
+    "background": [
+      "Achtergrond"
+    ],
+    "but": [
+      "* ",
+      "Maar "
+    ],
+    "examples": [
+      "Voorbeelden"
+    ],
+    "feature": [
+      "Functionaliteit"
+    ],
+    "given": [
+      "* ",
+      "Gegeven ",
+      "Stel "
+    ],
+    "name": "Dutch",
+    "native": "Nederlands",
+    "rule": [
+      "Regel"
+    ],
+    "scenario": [
+      "Voorbeeld",
+      "Scenario"
+    ],
+    "scenarioOutline": [
+      "Abstract Scenario"
+    ],
+    "then": [
+      "* ",
+      "Dan "
+    ],
+    "when": [
+      "* ",
+      "Als ",
+      "Wanneer "
+    ]
+  },
+  "no": {
+    "and": [
+      "* ",
+      "Og "
+    ],
+    "background": [
+      "Bakgrunn"
+    ],
+    "but": [
+      "* ",
+      "Men "
+    ],
+    "examples": [
+      "Eksempler"
+    ],
+    "feature": [
+      "Egenskap"
+    ],
+    "given": [
+      "* ",
+      "Gitt "
+    ],
+    "name": "Norwegian",
+    "native": "norsk",
+    "rule": [
+      "Regel"
+    ],
+    "scenario": [
+      "Eksempel",
+      "Scenario"
+    ],
+    "scenarioOutline": [
+      "Scenariomal",
+      "Abstrakt Scenario"
+    ],
+    "then": [
+      "* ",
+      "Så "
+    ],
+    "when": [
+      "* ",
+      "Når "
+    ]
+  },
+  "pa": {
+    "and": [
+      "* ",
+      "ਅਤੇ "
+    ],
+    "background": [
+      "ਪਿਛੋਕੜ"
+    ],
+    "but": [
+      "* ",
+      "ਪਰ "
+    ],
+    "examples": [
+      "ਉਦਾਹਰਨਾਂ"
+    ],
+    "feature": [
+      "ਖਾਸੀਅਤ",
+      "ਮੁਹਾਂਦਰਾ",
+      "ਨਕਸ਼ ਨੁਹਾਰ"
+    ],
+    "given": [
+      "* ",
+      "ਜੇਕਰ ",
+      "ਜਿਵੇਂ ਕਿ "
+    ],
+    "name": "Panjabi",
+    "native": "ਪੰਜਾਬੀ",
+    "rule": [
+      "Rule"
+    ],
+    "scenario": [
+      "ਉਦਾਹਰਨ",
+      "ਪਟਕਥਾ"
+    ],
+    "scenarioOutline": [
+      "ਪਟਕਥਾ ਢਾਂਚਾ",
+      "ਪਟਕਥਾ ਰੂਪ ਰੇਖਾ"
+    ],
+    "then": [
+      "* ",
+      "ਤਦ "
+    ],
+    "when": [
+      "* ",
+      "ਜਦੋਂ "
+    ]
+  },
+  "pl": {
+    "and": [
+      "* ",
+      "Oraz ",
+      "I "
+    ],
+    "background": [
+      "Założenia"
+    ],
+    "but": [
+      "* ",
+      "Ale "
+    ],
+    "examples": [
+      "Przykłady"
+    ],
+    "feature": [
+      "Właściwość",
+      "Funkcja",
+      "Aspekt",
+      "Potrzeba biznesowa"
+    ],
+    "given": [
+      "* ",
+      "Zakładając ",
+      "Mając ",
+      "Zakładając, że "
+    ],
+    "name": "Polish",
+    "native": "polski",
+    "rule": [
+      "Zasada",
+      "Reguła"
+    ],
+    "scenario": [
+      "Przykład",
+      "Scenariusz"
+    ],
+    "scenarioOutline": [
+      "Szablon scenariusza"
+    ],
+    "then": [
+      "* ",
+      "Wtedy "
+    ],
+    "when": [
+      "* ",
+      "Jeżeli ",
+      "Jeśli ",
+      "Gdy ",
+      "Kiedy "
+    ]
+  },
+  "pt": {
+    "and": [
+      "* ",
+      "E "
+    ],
+    "background": [
+      "Contexto",
+      "Cenário de Fundo",
+      "Cenario de Fundo",
+      "Fundo"
+    ],
+    "but": [
+      "* ",
+      "Mas "
+    ],
+    "examples": [
+      "Exemplos",
+      "Cenários",
+      "Cenarios"
+    ],
+    "feature": [
+      "Funcionalidade",
+      "Característica",
+      "Caracteristica"
+    ],
+    "given": [
+      "* ",
+      "Dado ",
+      "Dada ",
+      "Dados ",
+      "Dadas "
+    ],
+    "name": "Portuguese",
+    "native": "português",
+    "rule": [
+      "Regra"
+    ],
+    "scenario": [
+      "Exemplo",
+      "Cenário",
+      "Cenario"
+    ],
+    "scenarioOutline": [
+      "Esquema do Cenário",
+      "Esquema do Cenario",
+      "Delineação do Cenário",
+      "Delineacao do Cenario"
+    ],
+    "then": [
+      "* ",
+      "Então ",
+      "Entao "
+    ],
+    "when": [
+      "* ",
+      "Quando "
+    ]
+  },
+  "ro": {
+    "and": [
+      "* ",
+      "Si ",
+      "Și ",
+      "Şi "
+    ],
+    "background": [
+      "Context"
+    ],
+    "but": [
+      "* ",
+      "Dar "
+    ],
+    "examples": [
+      "Exemple"
+    ],
+    "feature": [
+      "Functionalitate",
+      "Funcționalitate",
+      "Funcţionalitate"
+    ],
+    "given": [
+      "* ",
+      "Date fiind ",
+      "Dat fiind ",
+      "Dată fiind",
+      "Dati fiind ",
+      "Dați fiind ",
+      "Daţi fiind "
+    ],
+    "name": "Romanian",
+    "native": "română",
+    "rule": [
+      "Rule"
+    ],
+    "scenario": [
+      "Exemplu",
+      "Scenariu"
+    ],
+    "scenarioOutline": [
+      "Structura scenariu",
+      "Structură scenariu"
+    ],
+    "then": [
+      "* ",
+      "Atunci "
+    ],
+    "when": [
+      "* ",
+      "Cand ",
+      "Când "
+    ]
+  },
+  "ru": {
+    "and": [
+      "* ",
+      "И ",
+      "К тому же ",
+      "Также "
+    ],
+    "background": [
+      "Предыстория",
+      "Контекст"
+    ],
+    "but": [
+      "* ",
+      "Но ",
+      "А ",
+      "Иначе "
+    ],
+    "examples": [
+      "Примеры"
+    ],
+    "feature": [
+      "Функция",
+      "Функциональность",
+      "Функционал",
+      "Свойство",
+      "Фича"
+    ],
+    "given": [
+      "* ",
+      "Допустим ",
+      "Дано ",
+      "Пусть "
+    ],
+    "name": "Russian",
+    "native": "русский",
+    "rule": [
+      "Правило"
+    ],
+    "scenario": [
+      "Пример",
+      "Сценарий"
+    ],
+    "scenarioOutline": [
+      "Структура сценария",
+      "Шаблон сценария"
+    ],
+    "then": [
+      "* ",
+      "То ",
+      "Затем ",
+      "Тогда "
+    ],
+    "when": [
+      "* ",
+      "Когда ",
+      "Если "
+    ]
+  },
+  "sk": {
+    "and": [
+      "* ",
+      "A ",
+      "A tiež ",
+      "A taktiež ",
+      "A zároveň "
+    ],
+    "background": [
+      "Pozadie"
+    ],
+    "but": [
+      "* ",
+      "Ale "
+    ],
+    "examples": [
+      "Príklady"
+    ],
+    "feature": [
+      "Požiadavka",
+      "Funkcia",
+      "Vlastnosť"
+    ],
+    "given": [
+      "* ",
+      "Pokiaľ ",
+      "Za predpokladu "
+    ],
+    "name": "Slovak",
+    "native": "Slovensky",
+    "rule": [
+      "Rule"
+    ],
+    "scenario": [
+      "Príklad",
+      "Scenár"
+    ],
+    "scenarioOutline": [
+      "Náčrt Scenáru",
+      "Náčrt Scenára",
+      "Osnova Scenára"
+    ],
+    "then": [
+      "* ",
+      "Tak ",
+      "Potom "
+    ],
+    "when": [
+      "* ",
+      "Keď ",
+      "Ak "
+    ]
+  },
+  "sl": {
+    "and": [
+      "In ",
+      "Ter "
+    ],
+    "background": [
+      "Kontekst",
+      "Osnova",
+      "Ozadje"
+    ],
+    "but": [
+      "Toda ",
+      "Ampak ",
+      "Vendar "
+    ],
+    "examples": [
+      "Primeri",
+      "Scenariji"
+    ],
+    "feature": [
+      "Funkcionalnost",
+      "Funkcija",
+      "Možnosti",
+      "Moznosti",
+      "Lastnost",
+      "Značilnost"
+    ],
+    "given": [
+      "Dano ",
+      "Podano ",
+      "Zaradi ",
+      "Privzeto "
+    ],
+    "name": "Slovenian",
+    "native": "Slovenski",
+    "rule": [
+      "Rule"
+    ],
+    "scenario": [
+      "Primer",
+      "Scenarij"
+    ],
+    "scenarioOutline": [
+      "Struktura scenarija",
+      "Skica",
+      "Koncept",
+      "Oris scenarija",
+      "Osnutek"
+    ],
+    "then": [
+      "Nato ",
+      "Potem ",
+      "Takrat "
+    ],
+    "when": [
+      "Ko ",
+      "Ce ",
+      "Če ",
+      "Kadar "
+    ]
+  },
+  "sr-Cyrl": {
+    "and": [
+      "* ",
+      "И "
+    ],
+    "background": [
+      "Контекст",
+      "Основа",
+      "Позадина"
+    ],
+    "but": [
+      "* ",
+      "Али "
+    ],
+    "examples": [
+      "Примери",
+      "Сценарији"
+    ],
+    "feature": [
+      "Функционалност",
+      "Могућност",
+      "Особина"
+    ],
+    "given": [
+      "* ",
+      "За дато ",
+      "За дате ",
+      "За дати "
+    ],
+    "name": "Serbian",
+    "native": "Српски",
+    "rule": [
+      "Правило"
+    ],
+    "scenario": [
+      "Сценарио",
+      "Пример"
+    ],
+    "scenarioOutline": [
+      "Структура сценарија",
+      "Скица",
+      "Концепт"
+    ],
+    "then": [
+      "* ",
+      "Онда "
+    ],
+    "when": [
+      "* ",
+      "Када ",
+      "Кад "
+    ]
+  },
+  "sr-Latn": {
+    "and": [
+      "* ",
+      "I "
+    ],
+    "background": [
+      "Kontekst",
+      "Osnova",
+      "Pozadina"
+    ],
+    "but": [
+      "* ",
+      "Ali "
+    ],
+    "examples": [
+      "Primeri",
+      "Scenariji"
+    ],
+    "feature": [
+      "Funkcionalnost",
+      "Mogućnost",
+      "Mogucnost",
+      "Osobina"
+    ],
+    "given": [
+      "* ",
+      "Za dato ",
+      "Za date ",
+      "Za dati "
+    ],
+    "name": "Serbian (Latin)",
+    "native": "Srpski (Latinica)",
+    "rule": [
+      "Pravilo"
+    ],
+    "scenario": [
+      "Scenario",
+      "Primer"
+    ],
+    "scenarioOutline": [
+      "Struktura scenarija",
+      "Skica",
+      "Koncept"
+    ],
+    "then": [
+      "* ",
+      "Onda "
+    ],
+    "when": [
+      "* ",
+      "Kada ",
+      "Kad "
+    ]
+  },
+  "sv": {
+    "and": [
+      "* ",
+      "Och "
+    ],
+    "background": [
+      "Bakgrund"
+    ],
+    "but": [
+      "* ",
+      "Men "
+    ],
+    "examples": [
+      "Exempel"
+    ],
+    "feature": [
+      "Egenskap"
+    ],
+    "given": [
+      "* ",
+      "Givet "
+    ],
+    "name": "Swedish",
+    "native": "Svenska",
+    "rule": [
+      "Regel"
+    ],
+    "scenario": [
+      "Scenario"
+    ],
+    "scenarioOutline": [
+      "Abstrakt Scenario",
+      "Scenariomall"
+    ],
+    "then": [
+      "* ",
+      "Så "
+    ],
+    "when": [
+      "* ",
+      "När "
+    ]
+  },
+  "ta": {
+    "and": [
+      "* ",
+      "மேலும் ",
+      "மற்றும் "
+    ],
+    "background": [
+      "பின்னணி"
+    ],
+    "but": [
+      "* ",
+      "ஆனால் "
+    ],
+    "examples": [
+      "எடுத்துக்காட்டுகள்",
+      "காட்சிகள்",
+      "நிலைமைகளில்"
+    ],
+    "feature": [
+      "அம்சம்",
+      "வணிக தேவை",
+      "திறன்"
+    ],
+    "given": [
+      "* ",
+      "கொடுக்கப்பட்ட "
+    ],
+    "name": "Tamil",
+    "native": "தமிழ்",
+    "rule": [
+      "Rule"
+    ],
+    "scenario": [
+      "உதாரணமாக",
+      "காட்சி"
+    ],
+    "scenarioOutline": [
+      "காட்சி சுருக்கம்",
+      "காட்சி வார்ப்புரு"
+    ],
+    "then": [
+      "* ",
+      "அப்பொழுது "
+    ],
+    "when": [
+      "* ",
+      "எப்போது "
+    ]
+  },
+  "th": {
+    "and": [
+      "* ",
+      "และ "
+    ],
+    "background": [
+      "แนวคิด"
+    ],
+    "but": [
+      "* ",
+      "แต่ "
+    ],
+    "examples": [
+      "ชุดของตัวอย่าง",
+      "ชุดของเหตุการณ์"
+    ],
+    "feature": [
+      "โครงหลัก",
+      "ความต้องการทางธุรกิจ",
+      "ความสามารถ"
+    ],
+    "given": [
+      "* ",
+      "กำหนดให้ "
+    ],
+    "name": "Thai",
+    "native": "ไทย",
+    "rule": [
+      "Rule"
+    ],
+    "scenario": [
+      "เหตุการณ์"
+    ],
+    "scenarioOutline": [
+      "สรุปเหตุการณ์",
+      "โครงสร้างของเหตุการณ์"
+    ],
+    "then": [
+      "* ",
+      "ดังนั้น "
+    ],
+    "when": [
+      "* ",
+      "เมื่อ "
+    ]
+  },
+  "te": {
+    "and": [
+      "* ",
+      "మరియు "
+    ],
+    "background": [
+      "నేపథ్యం"
+    ],
+    "but": [
+      "* ",
+      "కాని "
+    ],
+    "examples": [
+      "ఉదాహరణలు"
+    ],
+    "feature": [
+      "గుణము"
+    ],
+    "given": [
+      "* ",
+      "చెప్పబడినది "
+    ],
+    "name": "Telugu",
+    "native": "తెలుగు",
+    "rule": [
+      "Rule"
+    ],
+    "scenario": [
+      "ఉదాహరణ",
+      "సన్నివేశం"
+    ],
+    "scenarioOutline": [
+      "కథనం"
+    ],
+    "then": [
+      "* ",
+      "అప్పుడు "
+    ],
+    "when": [
+      "* ",
+      "ఈ పరిస్థితిలో "
+    ]
+  },
+  "tlh": {
+    "and": [
+      "* ",
+      "'ej ",
+      "latlh "
+    ],
+    "background": [
+      "mo'"
+    ],
+    "but": [
+      "* ",
+      "'ach ",
+      "'a "
+    ],
+    "examples": [
+      "ghantoH",
+      "lutmey"
+    ],
+    "feature": [
+      "Qap",
+      "Qu'meH 'ut",
+      "perbogh",
+      "poQbogh malja'",
+      "laH"
+    ],
+    "given": [
+      "* ",
+      "ghu' noblu' ",
+      "DaH ghu' bejlu' "
+    ],
+    "name": "Klingon",
+    "native": "tlhIngan",
+    "rule": [
+      "Rule"
+    ],
+    "scenario": [
+      "lut"
+    ],
+    "scenarioOutline": [
+      "lut chovnatlh"
+    ],
+    "then": [
+      "* ",
+      "vaj "
+    ],
+    "when": [
+      "* ",
+      "qaSDI' "
+    ]
+  },
+  "tr": {
+    "and": [
+      "* ",
+      "Ve "
+    ],
+    "background": [
+      "Geçmiş"
+    ],
+    "but": [
+      "* ",
+      "Fakat ",
+      "Ama "
+    ],
+    "examples": [
+      "Örnekler"
+    ],
+    "feature": [
+      "Özellik"
+    ],
+    "given": [
+      "* ",
+      "Diyelim ki "
+    ],
+    "name": "Turkish",
+    "native": "Türkçe",
+    "rule": [
+      "Kural"
+    ],
+    "scenario": [
+      "Örnek",
+      "Senaryo"
+    ],
+    "scenarioOutline": [
+      "Senaryo taslağı"
+    ],
+    "then": [
+      "* ",
+      "O zaman "
+    ],
+    "when": [
+      "* ",
+      "Eğer ki "
+    ]
+  },
+  "tt": {
+    "and": [
+      "* ",
+      "Һәм ",
+      "Вә "
+    ],
+    "background": [
+      "Кереш"
+    ],
+    "but": [
+      "* ",
+      "Ләкин ",
+      "Әмма "
+    ],
+    "examples": [
+      "Үрнәкләр",
+      "Мисаллар"
+    ],
+    "feature": [
+      "Мөмкинлек",
+      "Үзенчәлеклелек"
+    ],
+    "given": [
+      "* ",
+      "Әйтик "
+    ],
+    "name": "Tatar",
+    "native": "Татарча",
+    "rule": [
+      "Rule"
+    ],
+    "scenario": [
+      "Сценарий"
+    ],
+    "scenarioOutline": [
+      "Сценарийның төзелеше"
+    ],
+    "then": [
+      "* ",
+      "Нәтиҗәдә "
+    ],
+    "when": [
+      "* ",
+      "Әгәр "
+    ]
+  },
+  "uk": {
+    "and": [
+      "* ",
+      "І ",
+      "А також ",
+      "Та "
+    ],
+    "background": [
+      "Передумова"
+    ],
+    "but": [
+      "* ",
+      "Але "
+    ],
+    "examples": [
+      "Приклади"
+    ],
+    "feature": [
+      "Функціонал"
+    ],
+    "given": [
+      "* ",
+      "Припустимо ",
+      "Припустимо, що ",
+      "Нехай ",
+      "Дано "
+    ],
+    "name": "Ukrainian",
+    "native": "Українська",
+    "rule": [
+      "Rule"
+    ],
+    "scenario": [
+      "Приклад",
+      "Сценарій"
+    ],
+    "scenarioOutline": [
+      "Структура сценарію"
+    ],
+    "then": [
+      "* ",
+      "То ",
+      "Тоді "
+    ],
+    "when": [
+      "* ",
+      "Якщо ",
+      "Коли "
+    ]
+  },
+  "ur": {
+    "and": [
+      "* ",
+      "اور "
+    ],
+    "background": [
+      "پس منظر"
+    ],
+    "but": [
+      "* ",
+      "لیکن "
+    ],
+    "examples": [
+      "مثالیں"
+    ],
+    "feature": [
+      "صلاحیت",
+      "کاروبار کی ضرورت",
+      "خصوصیت"
+    ],
+    "given": [
+      "* ",
+      "اگر ",
+      "بالفرض ",
+      "فرض کیا "
+    ],
+    "name": "Urdu",
+    "native": "اردو",
+    "rule": [
+      "Rule"
+    ],
+    "scenario": [
+      "منظرنامہ"
+    ],
+    "scenarioOutline": [
+      "منظر نامے کا خاکہ"
+    ],
+    "then": [
+      "* ",
+      "پھر ",
+      "تب "
+    ],
+    "when": [
+      "* ",
+      "جب "
+    ]
+  },
+  "uz": {
+    "and": [
+      "* ",
+      "Ва "
+    ],
+    "background": [
+      "Тарих"
+    ],
+    "but": [
+      "* ",
+      "Лекин ",
+      "Бирок ",
+      "Аммо "
+    ],
+    "examples": [
+      "Мисоллар"
+    ],
+    "feature": [
+      "Функционал"
+    ],
+    "given": [
+      "* ",
+      "Belgilangan "
+    ],
+    "name": "Uzbek",
+    "native": "Узбекча",
+    "rule": [
+      "Rule"
+    ],
+    "scenario": [
+      "Сценарий"
+    ],
+    "scenarioOutline": [
+      "Сценарий структураси"
+    ],
+    "then": [
+      "* ",
+      "Унда "
+    ],
+    "when": [
+      "* ",
+      "Агар "
+    ]
+  },
+  "vi": {
+    "and": [
+      "* ",
+      "Và "
+    ],
+    "background": [
+      "Bối cảnh"
+    ],
+    "but": [
+      "* ",
+      "Nhưng "
+    ],
+    "examples": [
+      "Dữ liệu"
+    ],
+    "feature": [
+      "Tính năng"
+    ],
+    "given": [
+      "* ",
+      "Biết ",
+      "Cho "
+    ],
+    "name": "Vietnamese",
+    "native": "Tiếng Việt",
+    "rule": [
+      "Quy tắc"
+    ],
+    "scenario": [
+      "Tình huống",
+      "Kịch bản"
+    ],
+    "scenarioOutline": [
+      "Khung tình huống",
+      "Khung kịch bản"
+    ],
+    "then": [
+      "* ",
+      "Thì "
+    ],
+    "when": [
+      "* ",
+      "Khi "
+    ]
+  },
+  "zh-CN": {
+    "and": [
+      "* ",
+      "而且",
+      "并且",
+      "同时"
+    ],
+    "background": [
+      "背景"
+    ],
+    "but": [
+      "* ",
+      "但是"
+    ],
+    "examples": [
+      "例子"
+    ],
+    "feature": [
+      "功能"
+    ],
+    "given": [
+      "* ",
+      "假如",
+      "假设",
+      "假定"
+    ],
+    "name": "Chinese simplified",
+    "native": "简体中文",
+    "rule": [
+      "Rule",
+      "规则"
+    ],
+    "scenario": [
+      "场景",
+      "剧本"
+    ],
+    "scenarioOutline": [
+      "场景大纲",
+      "剧本大纲"
+    ],
+    "then": [
+      "* ",
+      "那么"
+    ],
+    "when": [
+      "* ",
+      "当"
+    ]
+  },
+  "ml": {
+    "and": [
+      "* ",
+      "ഒപ്പം"
+    ],
+    "background": [
+      "പശ്ചാത്തലം"
+    ],
+    "but": [
+      "* ",
+      "പക്ഷേ"
+    ],
+    "examples": [
+      "ഉദാഹരണങ്ങൾ"
+    ],
+    "feature": [
+      "സവിശേഷത"
+    ],
+    "given": [
+      "* ",
+      "നൽകിയത്"
+    ],
+    "name": "Malayalam",
+    "native": "മലയാളം",
+    "rule": [
+      "നിയമം"
+    ],
+    "scenario": [
+      "രംഗം"
+    ],
+    "scenarioOutline": [
+      "സാഹചര്യത്തിന്റെ രൂപരേഖ"
+    ],
+    "then": [
+      "* ",
+      "പിന്നെ"
+    ],
+    "when": [
+      "എപ്പോൾ"
+    ]
+  },
+  "zh-TW": {
+    "and": [
+      "* ",
+      "而且",
+      "並且",
+      "同時"
+    ],
+    "background": [
+      "背景"
+    ],
+    "but": [
+      "* ",
+      "但是"
+    ],
+    "examples": [
+      "例子"
+    ],
+    "feature": [
+      "功能"
+    ],
+    "given": [
+      "* ",
+      "假如",
+      "假設",
+      "假定"
+    ],
+    "name": "Chinese traditional",
+    "native": "繁體中文",
+    "rule": [
+      "Rule"
+    ],
+    "scenario": [
+      "場景",
+      "劇本"
+    ],
+    "scenarioOutline": [
+      "場景大綱",
+      "劇本大綱"
+    ],
+    "then": [
+      "* ",
+      "那麼"
+    ],
+    "when": [
+      "* ",
+      "當"
+    ]
+  },
+  "mr": {
+    "and": [
+      "* ",
+      "आणि ",
+      "तसेच "
+    ],
+    "background": [
+      "पार्श्वभूमी"
+    ],
+    "but": [
+      "* ",
+      "पण ",
+      "परंतु "
+    ],
+    "examples": [
+      "उदाहरण"
+    ],
+    "feature": [
+      "वैशिष्ट्य",
+      "सुविधा"
+    ],
+    "given": [
+      "* ",
+      "जर",
+      "दिलेल्या प्रमाणे "
+    ],
+    "name": "Marathi",
+    "native": "मराठी",
+    "rule": [
+      "नियम"
+    ],
+    "scenario": [
+      "परिदृश्य"
+    ],
+    "scenarioOutline": [
+      "परिदृश्य रूपरेखा"
+    ],
+    "then": [
+      "* ",
+      "मग ",
+      "तेव्हा "
+    ],
+    "when": [
+      "* ",
+      "जेव्हा "
+    ]
+  },
+  "amh": {
+    "and": [
+      "* ",
+      "እና "
+    ],
+    "background": [
+      "ቅድመ ሁኔታ",
+      "መነሻ",
+      "መነሻ ሀሳብ"
+    ],
+    "but": [
+      "* ",
+      "ግን "
+    ],
+    "examples": [
+      "ምሳሌዎች",
+      "ሁናቴዎች"
+    ],
+    "feature": [
+      "ስራ",
+      "የተፈለገው ስራ",
+      "የሚፈለገው ድርጊት"
+    ],
+    "given": [
+      "* ",
+      "የተሰጠ "
+    ],
+    "name": "Amharic",
+    "native": "አማርኛ",
+    "rule": [
+      "ህግ"
+    ],
+    "scenario": [
+      "ምሳሌ",
+      "ሁናቴ"
+    ],
+    "scenarioOutline": [
+      "ሁናቴ ዝርዝር",
+      "ሁናቴ አብነት"
+    ],
+    "then": [
+      "* ",
+      "ከዚያ "
+    ],
+    "when": [
+      "* ",
+      "መቼ "
+    ]
+  }
+}

--- a/src/Dialect/CucumberDialectProvider.php
+++ b/src/Dialect/CucumberDialectProvider.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Behat Gherkin Parser.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Gherkin\Dialect;
+
+use Behat\Gherkin\Exception\NoSuchLanguageException;
+
+/**
+ * A dialect provider that loads the dialects based on the gherkin-languages.json file copied from the Cucumber project.
+ *
+ * @phpstan-import-type TDialectData from GherkinDialect
+ */
+final class CucumberDialectProvider implements DialectProviderInterface
+{
+    /**
+     * @var non-empty-array<non-empty-string, TDialectData>
+     */
+    private readonly array $dialects;
+
+    public function __construct()
+    {
+        $json = file_get_contents(__DIR__ . '/../../resources/gherkin-languages.json');
+        \assert($json !== false);
+        /**
+         * Here we force the type checker to assume the decoded JSON has the correct
+         * structure, rather than validating it. This is safe because it's not dynamic.
+         *
+         * @var non-empty-array<non-empty-string, TDialectData> $data
+         */
+        $data = json_decode($json, true, flags: JSON_THROW_ON_ERROR);
+        $this->dialects = $data;
+    }
+
+    /**
+     * @param non-empty-string $language
+     *
+     * @throws NoSuchLanguageException
+     */
+    public function getDialect(string $language): GherkinDialect
+    {
+        if (!isset($this->dialects[$language])) {
+            throw new NoSuchLanguageException($language);
+        }
+
+        return new GherkinDialect($language, $this->dialects[$language]);
+    }
+
+    public function getDefaultDialect(): GherkinDialect
+    {
+        return $this->getDialect('en');
+    }
+}

--- a/src/Dialect/DialectProviderInterface.php
+++ b/src/Dialect/DialectProviderInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Behat Gherkin Parser.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Gherkin\Dialect;
+
+use Behat\Gherkin\Exception\NoSuchLanguageException;
+
+interface DialectProviderInterface
+{
+    /**
+     * @param non-empty-string $language
+     *
+     * @throws NoSuchLanguageException when the language is not supported
+     */
+    public function getDialect(string $language): GherkinDialect;
+
+    public function getDefaultDialect(): GherkinDialect;
+}

--- a/src/Dialect/GherkinDialect.php
+++ b/src/Dialect/GherkinDialect.php
@@ -1,0 +1,159 @@
+<?php
+
+/*
+ * This file is part of the Behat Gherkin Parser.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Gherkin\Dialect;
+
+/**
+ * @phpstan-type TDialectData array{
+ *     feature: non-empty-list<non-empty-string>,
+ *     background: non-empty-list<non-empty-string>,
+ *     scenario: non-empty-list<non-empty-string>,
+ *     scenarioOutline: non-empty-list<non-empty-string>,
+ *     examples: non-empty-list<non-empty-string>,
+ *     rule: non-empty-list<non-empty-string>,
+ *     given: non-empty-list<non-empty-string>,
+ *     when: non-empty-list<non-empty-string>,
+ *     then: non-empty-list<non-empty-string>,
+ *     and: non-empty-list<non-empty-string>,
+ *     but: non-empty-list<non-empty-string>,
+ * }
+ */
+final class GherkinDialect
+{
+    /**
+     * @var non-empty-list<non-empty-string>|null
+     */
+    private ?array $stepKeywordsCache = null;
+
+    /**
+     * @phpstan-param TDialectData $dialect
+     */
+    public function __construct(
+        private readonly string $language,
+        private readonly array $dialect,
+    ) {
+    }
+
+    public function getLanguage(): string
+    {
+        return $this->language;
+    }
+
+    /**
+     * @return non-empty-list<non-empty-string>
+     */
+    public function getFeatureKeywords(): array
+    {
+        return $this->dialect['feature'];
+    }
+
+    /**
+     * @return non-empty-list<non-empty-string>
+     */
+    public function getBackgroundKeywords(): array
+    {
+        return $this->dialect['background'];
+    }
+
+    /**
+     * @return non-empty-list<non-empty-string>
+     */
+    public function getScenarioKeywords(): array
+    {
+        return $this->dialect['scenario'];
+    }
+
+    /**
+     * @return non-empty-list<non-empty-string>
+     */
+    public function getScenarioOutlineKeywords(): array
+    {
+        return $this->dialect['scenarioOutline'];
+    }
+
+    /**
+     * @return non-empty-list<non-empty-string>
+     */
+    public function getRuleKeywords(): array
+    {
+        return $this->dialect['rule'];
+    }
+
+    /**
+     * @return non-empty-list<non-empty-string>
+     */
+    public function getGivenKeywords(): array
+    {
+        return $this->dialect['given'];
+    }
+
+    /**
+     * @return non-empty-list<non-empty-string>
+     */
+    public function getWhenKeywords(): array
+    {
+        return $this->dialect['when'];
+    }
+
+    /**
+     * @return non-empty-list<non-empty-string>
+     */
+    public function getThenKeywords(): array
+    {
+        return $this->dialect['then'];
+    }
+
+    /**
+     * @return non-empty-list<non-empty-string>
+     */
+    public function getAndKeywords(): array
+    {
+        return $this->dialect['and'];
+    }
+
+    /**
+     * @return non-empty-list<non-empty-string>
+     */
+    public function getButKeywords(): array
+    {
+        return $this->dialect['but'];
+    }
+
+    /**
+     * @return non-empty-list<non-empty-string>
+     */
+    public function getStepKeywords(): array
+    {
+        if ($this->stepKeywordsCache !== null) {
+            return $this->stepKeywordsCache;
+        }
+
+        $stepKeywords = [
+            ...$this->getGivenKeywords(),
+            ...$this->getWhenKeywords(),
+            ...$this->getThenKeywords(),
+            ...$this->getAndKeywords(),
+            ...$this->getButKeywords(),
+        ];
+
+        // Sort longer keywords before shorter keywords being their prefix
+        rsort($stepKeywords);
+
+        return $this->stepKeywordsCache = $stepKeywords;
+    }
+
+    /**
+     * @return non-empty-list<non-empty-string>
+     */
+    public function getExamplesKeywords(): array
+    {
+        return $this->dialect['examples'];
+    }
+}

--- a/src/Dialect/KeywordsDialectProvider.php
+++ b/src/Dialect/KeywordsDialectProvider.php
@@ -1,0 +1,100 @@
+<?php
+
+/*
+ * This file is part of the Behat Gherkin Parser.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Gherkin\Dialect;
+
+use Behat\Gherkin\Exception\NoSuchLanguageException;
+use Behat\Gherkin\Keywords\ArrayKeywords;
+use Behat\Gherkin\Keywords\KeywordsInterface;
+
+/**
+ * Adapter for the legacy keywords interface.
+ *
+ * @internal
+ */
+final class KeywordsDialectProvider implements DialectProviderInterface
+{
+    public function __construct(
+        private readonly KeywordsInterface $keywords,
+    ) {
+    }
+
+    public function getDialect(string $language): GherkinDialect
+    {
+        // The legacy keywords interface doesn't support detecting whether changing the language worked or no.
+        $this->keywords->setLanguage($language);
+
+        if ($this->keywords instanceof ArrayKeywords && $this->keywords->getLanguage() !== $language) {
+            throw new NoSuchLanguageException($language);
+        }
+
+        return $this->buildDialect($language);
+    }
+
+    public function getDefaultDialect(): GherkinDialect
+    {
+        // Assume a default dialect of `en` as the KeywordsInterface does not allow reading its language but returns the current data
+        $language = $this->keywords instanceof ArrayKeywords ? $this->keywords->getLanguage() : 'en';
+
+        return $this->buildDialect($language);
+    }
+
+    private function buildDialect(string $language): GherkinDialect
+    {
+        return new GherkinDialect($language, [
+            'feature' => self::parseKeywords($this->keywords->getFeatureKeywords()),
+            'background' => self::parseKeywords($this->keywords->getBackgroundKeywords()),
+            'scenario' => self::parseKeywords($this->keywords->getScenarioKeywords()),
+            'scenarioOutline' => self::parseKeywords($this->keywords->getOutlineKeywords()),
+            'examples' => self::parseKeywords($this->keywords->getExamplesKeywords()),
+            'rule' => ['Rule'], // Hardcoded value as our old keywords interface doesn't support rules.
+            'given' => self::parseStepKeywords($this->keywords->getGivenKeywords()),
+            'when' => self::parseStepKeywords($this->keywords->getWhenKeywords()),
+            'then' => self::parseStepKeywords($this->keywords->getThenKeywords()),
+            'and' => self::parseStepKeywords($this->keywords->getAndKeywords()),
+            'but' => self::parseStepKeywords($this->keywords->getButKeywords()),
+        ]);
+    }
+
+    /**
+     * @return non-empty-list<non-empty-string>
+     */
+    private static function parseKeywords(string $keywordString): array
+    {
+        $keywords = array_values(array_filter(explode('|', $keywordString)));
+
+        if ($keywords === []) {
+            throw new \LogicException('A keyword string must contain at least one keyword.');
+        }
+
+        return $keywords;
+    }
+
+    /**
+     * @return non-empty-list<non-empty-string>
+     */
+    private static function parseStepKeywords(string $keywordString): array
+    {
+        $legacyKeywords = explode('|', $keywordString);
+        $keywords = [];
+
+        foreach ($legacyKeywords as $legacyKeyword) {
+            if (\strlen($legacyKeyword) >= 2 && str_ends_with($legacyKeyword, '<')) {
+                $keyword = substr($legacyKeyword, 0, -1);
+                \assert($keyword !== ''); // phpstan is not smart enough to detect that the length check above guarantees this invariant
+                $keywords[] = $keyword;
+            } else {
+                $keywords[] = $legacyKeyword . ' ';
+            }
+        }
+
+        return $keywords;
+    }
+}

--- a/src/Exception/NoSuchLanguageException.php
+++ b/src/Exception/NoSuchLanguageException.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Behat Gherkin Parser.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Gherkin\Exception;
+
+final class NoSuchLanguageException extends ParserException
+{
+    public function __construct(public readonly string $language)
+    {
+        parent::__construct('Language not supported: ' . $language);
+    }
+}

--- a/src/Keywords/ArrayKeywords.php
+++ b/src/Keywords/ArrayKeywords.php
@@ -77,6 +77,14 @@ class ArrayKeywords implements KeywordsInterface
     }
 
     /**
+     * @internal
+     */
+    public function getLanguage(): string
+    {
+        return $this->language;
+    }
+
+    /**
      * Returns Feature keywords (separated by "|").
      *
      * @return string

--- a/src/Keywords/DialectKeywords.php
+++ b/src/Keywords/DialectKeywords.php
@@ -1,0 +1,121 @@
+<?php
+
+/*
+ * This file is part of the Behat Gherkin Parser.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Gherkin\Keywords;
+
+use Behat\Gherkin\Dialect\DialectProviderInterface;
+use Behat\Gherkin\Dialect\GherkinDialect;
+
+/**
+ * An adapter around a DialectProviderInterface to be able to use it with the KeywordsDumper.
+ *
+ * TODO add support for dumping an example feature for a dialect directly instead.
+ *
+ * @internal
+ */
+final class DialectKeywords implements KeywordsInterface
+{
+    private GherkinDialect $currentDialect;
+
+    public function __construct(
+        private readonly DialectProviderInterface $dialectProvider,
+    ) {
+        $this->currentDialect = $this->dialectProvider->getDefaultDialect();
+    }
+
+    public function setLanguage(string $language): void
+    {
+        if ($language === '') {
+            throw new \InvalidArgumentException('Language cannot be empty');
+        }
+
+        $this->currentDialect = $this->dialectProvider->getDialect($language);
+    }
+
+    public function getFeatureKeywords(): string
+    {
+        return $this->getKeywordString($this->currentDialect->getFeatureKeywords());
+    }
+
+    public function getBackgroundKeywords(): string
+    {
+        return $this->getKeywordString($this->currentDialect->getBackgroundKeywords());
+    }
+
+    public function getScenarioKeywords(): string
+    {
+        return $this->getKeywordString($this->currentDialect->getScenarioKeywords());
+    }
+
+    public function getOutlineKeywords(): string
+    {
+        return $this->getKeywordString($this->currentDialect->getScenarioOutlineKeywords());
+    }
+
+    public function getExamplesKeywords(): string
+    {
+        return $this->getKeywordString($this->currentDialect->getExamplesKeywords());
+    }
+
+    public function getGivenKeywords(): string
+    {
+        return $this->getStepKeywordString($this->currentDialect->getGivenKeywords());
+    }
+
+    public function getWhenKeywords(): string
+    {
+        return $this->getStepKeywordString($this->currentDialect->getWhenKeywords());
+    }
+
+    public function getThenKeywords(): string
+    {
+        return $this->getStepKeywordString($this->currentDialect->getThenKeywords());
+    }
+
+    public function getAndKeywords(): string
+    {
+        return $this->getStepKeywordString($this->currentDialect->getAndKeywords());
+    }
+
+    public function getButKeywords(): string
+    {
+        return $this->getStepKeywordString($this->currentDialect->getButKeywords());
+    }
+
+    public function getStepKeywords(): string
+    {
+        return $this->getStepKeywordString($this->currentDialect->getStepKeywords());
+    }
+
+    /**
+     * @param list<string> $keywords
+     */
+    private function getKeywordString(array $keywords): string
+    {
+        return implode('|', $keywords);
+    }
+
+    /**
+     * @param list<string> $keywords
+     */
+    private function getStepKeywordString(array $keywords): string
+    {
+        $legacyKeywords = [];
+        foreach ($keywords as $keyword) {
+            if (str_ends_with($keyword, ' ')) {
+                $legacyKeywords[] = substr($keyword, 0, -1);
+            } else {
+                $legacyKeywords[] = $keyword . '<';
+            }
+        }
+
+        return implode('|', $legacyKeywords);
+    }
+}

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -75,7 +75,7 @@ class Parser
         $this->tags = [];
 
         try {
-            $this->lexer->analyse($this->input, 'en');
+            $this->lexer->analyse($this->input);
         } catch (LexerException $e) {
             throw new ParserException(
                 sprintf('Lexer exception "%s" thrown for file %s', $e->getMessage(), $file),

--- a/tests/Cucumber/CompatibilityTest.php
+++ b/tests/Cucumber/CompatibilityTest.php
@@ -10,9 +10,9 @@
 
 namespace Tests\Behat\Gherkin\Cucumber;
 
+use Behat\Gherkin\Dialect\CucumberDialectProvider;
 use Behat\Gherkin\Exception\ParserException;
 use Behat\Gherkin\GherkinCompatibilityMode;
-use Behat\Gherkin\Keywords;
 use Behat\Gherkin\Lexer;
 use Behat\Gherkin\Loader\CucumberNDJsonAstLoader;
 use Behat\Gherkin\Parser;
@@ -129,8 +129,7 @@ class CompatibilityTest extends TestCase
 
     protected function setUp(): void
     {
-        $arrKeywords = include __DIR__ . '/../../i18n.php';
-        $lexer = new Lexer(new Keywords\ArrayKeywords($arrKeywords));
+        $lexer = new Lexer(new CucumberDialectProvider());
         $this->parser = new Parser($lexer);
         $this->loader = new CucumberNDJsonAstLoader();
     }

--- a/tests/Dialect/KeywordsDialectProviderTest.php
+++ b/tests/Dialect/KeywordsDialectProviderTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Behat Gherkin Parser.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Behat\Gherkin\Dialect;
+
+use Behat\Gherkin\Dialect\KeywordsDialectProvider;
+use Behat\Gherkin\Keywords\ArrayKeywords;
+use PHPUnit\Framework\TestCase;
+
+class KeywordsDialectProviderTest extends TestCase
+{
+    public function testFailsForEmptyKeywordString(): void
+    {
+        $keywords = new ArrayKeywords(['en' => [
+            'and' => 'And|*',
+            'background' => '',
+            'but' => 'But|*',
+            'examples' => 'Scenarios|Examples',
+            'feature' => 'Business Need|Ability|Feature',
+            'given' => 'Given|*',
+            'name' => 'English',
+            'native' => 'English',
+            'rule' => 'Rule',
+            'scenario' => 'Scenario|Example',
+            'scenario_outline' => 'Scenario Template|Scenario Outline',
+            'then' => 'Then|*',
+            'when' => 'When|*',
+        ]]);
+
+        $dialectProvider = new KeywordsDialectProvider($keywords);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('A keyword string must contain at least one keyword.');
+        $dialectProvider->getDialect('en');
+    }
+}

--- a/tests/Filter/FilterTestCase.php
+++ b/tests/Filter/FilterTestCase.php
@@ -10,7 +10,7 @@
 
 namespace Tests\Behat\Gherkin\Filter;
 
-use Behat\Gherkin\Keywords\ArrayKeywords;
+use Behat\Gherkin\Dialect\CucumberDialectProvider;
 use Behat\Gherkin\Lexer;
 use Behat\Gherkin\Node\FeatureNode;
 use Behat\Gherkin\Parser;
@@ -22,20 +22,7 @@ abstract class FilterTestCase extends TestCase
     {
         return new Parser(
             new Lexer(
-                new ArrayKeywords([
-                    'en' => [
-                        'feature' => 'Feature',
-                        'background' => 'Background',
-                        'scenario' => 'Scenario',
-                        'scenario_outline' => 'Scenario Outline|Scenario Template',
-                        'examples' => 'Examples|Scenarios',
-                        'given' => 'Given',
-                        'when' => 'When',
-                        'then' => 'Then',
-                        'and' => 'And',
-                        'but' => 'But',
-                    ],
-                ])
+                new CucumberDialectProvider()
             )
         );
     }
@@ -64,7 +51,7 @@ abstract class FilterTestCase extends TestCase
               | action | outcome |
               | act#1  | out#1   |
               | act#2  | out#2   |
-              
+
             @etag2
             Examples:
               | action | outcome |

--- a/tests/Keywords/ArrayKeywordsTest.php
+++ b/tests/Keywords/ArrayKeywordsTest.php
@@ -18,7 +18,24 @@ class ArrayKeywordsTest extends KeywordsTestCase
 {
     protected static function getKeywords(): KeywordsInterface
     {
-        return new ArrayKeywords(static::getKeywordsArray());
+        return new ArrayKeywords(static::getKeywordsArray() + [
+            // ArrayKeywords assumes internally that `en` is always a supported language
+            'en' => [
+                'and' => 'And|*',
+                'background' => 'Background',
+                'but' => 'But|*',
+                'examples' => 'Scenarios|Examples',
+                'feature' => 'Business Need|Ability|Feature',
+                'given' => 'Given|*',
+                'name' => 'English',
+                'native' => 'English',
+                'rule' => 'Rule',
+                'scenario' => 'Scenario|Example',
+                'scenario_outline' => 'Scenario Template|Scenario Outline',
+                'then' => 'Then|*',
+                'when' => 'When|*',
+            ],
+        ]);
     }
 
     protected static function getKeywordsArray(): array

--- a/tests/Keywords/DialectKeywordsTest.php
+++ b/tests/Keywords/DialectKeywordsTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the Behat Gherkin Parser.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Behat\Gherkin\Keywords;
+
+use Behat\Gherkin\Dialect\CucumberDialectProvider;
+use Behat\Gherkin\Keywords\DialectKeywords;
+use Behat\Gherkin\Keywords\KeywordsInterface;
+use Behat\Gherkin\Node\StepNode;
+use Tests\Behat\Gherkin\Filesystem;
+
+class DialectKeywordsTest extends KeywordsTestCase
+{
+    public function testFailsForEmptyLanguage(): void
+    {
+        $keywords = new DialectKeywords(new CucumberDialectProvider());
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Language cannot be empty');
+
+        $keywords->setLanguage('');
+    }
+
+    protected static function getKeywords(): KeywordsInterface
+    {
+        return new DialectKeywords(new CucumberDialectProvider());
+    }
+
+    protected static function getKeywordsArray(): array
+    {
+        $data = json_decode(Filesystem::readFile(__DIR__ . '/../../resources/gherkin-languages.json'), true, flags: \JSON_THROW_ON_ERROR);
+
+        $keywordsArray = [];
+
+        foreach ($data as $lang => $dialect) {
+            $keywordsArray[$lang] = [
+                'feature' => implode('|', $dialect['feature']),
+                'background' => implode('|', $dialect['background']),
+                'scenario' => implode('|', $dialect['scenario']),
+                'scenario_outline' => implode('|', $dialect['scenarioOutline']),
+                'examples' => implode('|', $dialect['examples']),
+                'given' => implode('|', $dialect['given']),
+                'when' => implode('|', $dialect['when']),
+                'then' => implode('|', $dialect['then']),
+                'and' => implode('|', $dialect['and']),
+                'but' => implode('|', $dialect['but']),
+            ];
+        }
+
+        return $keywordsArray;
+    }
+
+    protected static function getSteps(string $keywords, string $text, int &$line, ?string $keywordType): array
+    {
+        $steps = [];
+        foreach (explode('|', $keywords) as $keyword) {
+            if ($keyword === '* ') {
+                continue;
+            }
+
+            $steps[] = new StepNode(trim($keyword), $text, [], $line++, $keywordType);
+        }
+
+        return $steps;
+    }
+}

--- a/tests/Loader/GherkinFileLoaderTest.php
+++ b/tests/Loader/GherkinFileLoaderTest.php
@@ -11,7 +11,7 @@
 namespace Tests\Behat\Gherkin\Loader;
 
 use Behat\Gherkin\Cache\CacheInterface;
-use Behat\Gherkin\Keywords\CucumberKeywords;
+use Behat\Gherkin\Dialect\CucumberDialectProvider;
 use Behat\Gherkin\Lexer;
 use Behat\Gherkin\Loader\GherkinFileLoader;
 use Behat\Gherkin\Parser;
@@ -24,8 +24,7 @@ class GherkinFileLoaderTest extends TestCase
 
     protected function setUp(): void
     {
-        $keywords = new CucumberKeywords(__DIR__ . '/../Fixtures/i18n.yml');
-        $parser = new Parser(new Lexer($keywords));
+        $parser = new Parser(new Lexer(new CucumberDialectProvider()));
         $this->loader = new GherkinFileLoader($parser);
 
         $this->featuresPath = (string) realpath(__DIR__ . '/../Fixtures/features');

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -10,6 +10,7 @@
 
 namespace Tests\Behat\Gherkin;
 
+use Behat\Gherkin\Dialect\CucumberDialectProvider;
 use Behat\Gherkin\Exception\ParserException;
 use Behat\Gherkin\Keywords\ArrayKeywords;
 use Behat\Gherkin\Keywords\KeywordsInterface;
@@ -72,6 +73,42 @@ final class ParserTest extends TestCase
 
         $this->assertInstanceOf(FeatureNode::class, $feature2);
         $this->assertSame([], $feature2->getTags());
+    }
+
+    public function testParserIgnoresInvalidLanguage(): void
+    {
+        // TODO skip this test for the compatibility mode with cucumber/gherkin
+        $feature = $this->createGherkinParser()->parse(
+            <<<'FEATURE'
+            #language:no-such
+
+            Feature: Minimal
+
+              Scenario: minimalistic
+                Given the minimalism
+            FEATURE,
+        );
+
+        $this->assertInstanceOf(FeatureNode::class, $feature);
+        $this->assertCount(1, $feature->getScenarios());
+    }
+
+    public function testParserIgnoresInvalidLanguageWithDialectProvider(): void
+    {
+        // TODO skip this test for the compatibility mode with cucumber/gherkin
+        $feature = $this->createGherkinParser(new Lexer(new CucumberDialectProvider()))->parse(
+            <<<'FEATURE'
+            #language:no-such
+
+            Feature: Minimal
+
+              Scenario: minimalistic
+                Given the minimalism
+            FEATURE,
+        );
+
+        $this->assertInstanceOf(FeatureNode::class, $feature);
+        $this->assertCount(1, $feature->getScenarios());
     }
 
     public function testSingleCharacterStepSupport(): void

--- a/tests/TranslationTest.php
+++ b/tests/TranslationTest.php
@@ -1,0 +1,167 @@
+<?php
+
+/*
+ * This file is part of the Behat Gherkin Parser.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Behat\Gherkin;
+
+use Behat\Gherkin\Dialect\CucumberDialectProvider;
+use Behat\Gherkin\Dialect\GherkinDialect;
+use Behat\Gherkin\Keywords\DialectKeywords;
+use Behat\Gherkin\Keywords\KeywordsDumper;
+use Behat\Gherkin\Lexer;
+use Behat\Gherkin\Node\BackgroundNode;
+use Behat\Gherkin\Node\ExampleTableNode;
+use Behat\Gherkin\Node\FeatureNode;
+use Behat\Gherkin\Node\OutlineNode;
+use Behat\Gherkin\Node\ScenarioNode;
+use Behat\Gherkin\Node\StepNode;
+use Behat\Gherkin\Parser;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @phpstan-import-type TDialectData from GherkinDialect
+ */
+class TranslationTest extends TestCase
+{
+    /**
+     * @param list<string> $keywords
+     *
+     * @return list<StepNode>
+     */
+    private static function getSteps(array $keywords, string $text, int &$line, ?string $keywordType): array
+    {
+        $steps = [];
+        foreach ($keywords as $keyword) {
+            if ($keyword === '* ') {
+                continue;
+            }
+
+            $steps[] = new StepNode(trim($keyword), $text, [], $line++, $keywordType);
+        }
+
+        return $steps;
+    }
+
+    /**
+     * @return iterable<string, array{language: string, num: int, etalon: FeatureNode, source: string}>
+     */
+    public static function translationTestDataProvider(): iterable
+    {
+        $dumper = new KeywordsDumper(new DialectKeywords(new CucumberDialectProvider()));
+        /** @var non-empty-array<non-empty-string, TDialectData> $keywordsArray */
+        $keywordsArray = json_decode(Filesystem::readFile(__DIR__ . '/../resources/gherkin-languages.json'), true, flags: \JSON_THROW_ON_ERROR);
+
+        foreach ($keywordsArray as $lang => $i18nKeywords) {
+            $features = [];
+            foreach ($i18nKeywords['feature'] as $transNum => $featureKeyword) {
+                $line = 1;
+                if ($lang !== 'en') {
+                    $line = 2;
+                }
+
+                $featureLine = $line;
+                $line += 5;
+
+                $keywords = $i18nKeywords['background'];
+                $backgroundLine = $line;
+                ++$line;
+                $background = new BackgroundNode(null, array_merge(
+                    self::getSteps($i18nKeywords['given'], 'there is agent A', $line, 'Given'),
+                    self::getSteps($i18nKeywords['and'], 'there is agent B', $line, 'Given')
+                ), $keywords[0], $backgroundLine);
+
+                ++$line;
+
+                $scenarios = [];
+
+                foreach ($i18nKeywords['scenario'] as $scenarioKeyword) {
+                    $scenarioLine = $line;
+                    ++$line;
+
+                    $steps = array_merge(
+                        self::getSteps($i18nKeywords['given'], 'there is agent J', $line, 'Given'),
+                        self::getSteps($i18nKeywords['and'], 'there is agent K', $line, 'Given'),
+                        self::getSteps($i18nKeywords['when'], 'I erase agent K\'s memory', $line, 'When'),
+                        self::getSteps($i18nKeywords['then'], 'there should be agent J', $line, 'Then'),
+                        self::getSteps($i18nKeywords['but'], 'there should not be agent K', $line, 'Then')
+                    );
+
+                    $scenarios[] = new ScenarioNode('Erasing agent memory', [], $steps, $scenarioKeyword, $scenarioLine);
+                    ++$line;
+                }
+                foreach ($i18nKeywords['scenarioOutline'] as $outlineKeyword) {
+                    $outlineLine = $line;
+                    ++$line;
+
+                    $steps = array_merge(
+                        self::getSteps($i18nKeywords['given'], 'there is agent <agent1>', $line, 'Given'),
+                        self::getSteps($i18nKeywords['and'], 'there is agent <agent2>', $line, 'Given'),
+                        self::getSteps($i18nKeywords['when'], 'I erase agent <agent2>\'s memory', $line, 'When'),
+                        self::getSteps($i18nKeywords['then'], 'there should be agent <agent1>', $line, 'Then'),
+                        self::getSteps($i18nKeywords['but'], 'there should not be agent <agent2>', $line, 'Then')
+                    );
+                    ++$line;
+
+                    $keywords = $i18nKeywords['examples'];
+                    $table = new ExampleTableNode([
+                        ++$line => ['agent1', 'agent2'],
+                        ++$line => ['D', 'M'],
+                    ], $keywords[0]);
+                    ++$line;
+
+                    $scenarios[] = new OutlineNode('Erasing other agents\' memory', [], $steps, $table, $outlineKeyword, $outlineLine);
+                    ++$line;
+                }
+
+                $features[] = new FeatureNode(
+                    'Internal operations',
+                    <<<'DESC'
+                    In order to stay secret
+                    As a secret organization
+                    We need to be able to erase past agents' memory
+                    DESC,
+                    [],
+                    $background,
+                    $scenarios,
+                    $featureKeyword,
+                    $lang,
+                    __DIR__ . DIRECTORY_SEPARATOR . $lang . '_' . ($transNum + 1) . '.feature',
+                    $featureLine
+                );
+            }
+
+            $dumped = $dumper->dump($lang, false, true);
+
+            foreach ($dumped as $num => $dumpedFeature) {
+                yield $lang . '_' . $num => [
+                    'language' => $lang,
+                    'num' => $num,
+                    'etalon' => $features[$num],
+                    'source' => $dumpedFeature,
+                ];
+            }
+        }
+    }
+
+    #[DataProvider('translationTestDataProvider')]
+    public function testTranslation(string $language, int $num, FeatureNode $etalon, string $source): void
+    {
+        $lexer = new Lexer(new CucumberDialectProvider());
+        $parser = new Parser($lexer);
+
+        try {
+            $parsed = $parser->parse($source, __DIR__ . DIRECTORY_SEPARATOR . $language . '_' . ($num + 1) . '.feature');
+        } catch (\Throwable $e) {
+            throw new \RuntimeException($e->getMessage() . ":\n" . $source, 0, $e);
+        }
+
+        $this->assertEquals($etalon, $parsed, $source);
+    }
+}


### PR DESCRIPTION
~~When configuring the Lexer with a dialect provider, invalid language tags in the parsed files will fail instead of silently uswing English keywords, matching the cucumber behavior. Refs #156~~
~~When configuring the Lexer with a KeywordsInterface, the existing silent usage of English will still be done (as the Keywords implementation does that internally).~~
Failing for invalid languages during parsing will be implemented in a follow-up PR based on the compatiblity mode.

An implementation is provided based on the cucumber gherkin-languages.json file, which is now shipped in the package
unmodified (but is considered an internal implementation detail of the new class as we don't expose the path).
No configurable implementation is provided in the core. The DialectProviderInterface is simple enough to implement it fully based on your needs (I expect that the need to read translations from a file having the same structure than the cucumber gherkin-languages.json is not the use case for custom dialect providers, and even in such case, it is dead simple to implement it).

Closes #203

This PR does not provide a replacement for the KeywordsDumper feature for now (which is more a dumper for an example feature). This will be handled in a separate PR.
This PR also does not mark the KeywordsInterface as deprecated yet, but this is expected to happen once the replacement for the KeywordsDumper is available.