### PR TITLE
Deprecate the CucumberNDJsonAstLoader

### DIFF
--- a/tests/Cucumber/CompatibilityTest.php
+++ b/tests/Cucumber/CompatibilityTest.php
@@ -14,7 +14,6 @@ use Behat\Gherkin\Exception\ParserException;
 use Behat\Gherkin\GherkinCompatibilityMode;
 use Behat\Gherkin\Keywords;
 use Behat\Gherkin\Lexer;
-use Behat\Gherkin\Loader\CucumberNDJsonAstLoader;
 use Behat\Gherkin\Parser;
 use FilesystemIterator;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -101,7 +100,7 @@ class CompatibilityTest extends TestCase
 
     private Parser $parser;
 
-    private CucumberNDJsonAstLoader $loader;
+    private NDJsonAstParser $ndJsonAstParser;
 
     private static ?StepNodeComparator $stepNodeComparator = null;
 
@@ -132,7 +131,7 @@ class CompatibilityTest extends TestCase
         $arrKeywords = include __DIR__ . '/../../i18n.php';
         $lexer = new Lexer(new Keywords\ArrayKeywords($arrKeywords));
         $this->parser = new Parser($lexer);
-        $this->loader = new CucumberNDJsonAstLoader();
+        $this->ndJsonAstParser = new NDJsonAstParser();
     }
 
     #[DataProvider('goodCucumberFeatures')]
@@ -148,7 +147,7 @@ class CompatibilityTest extends TestCase
 
         $gherkinFile = $file->getPathname();
         $actual = $this->parser->parse(Filesystem::readFile($gherkinFile), $gherkinFile);
-        $cucumberFeatures = $this->loader->load($gherkinFile . '.ast.ndjson');
+        $cucumberFeatures = $this->ndJsonAstParser->load($gherkinFile . '.ast.ndjson');
 
         $expected = $cucumberFeatures ? $cucumberFeatures[0] : null;
 

--- a/tests/Cucumber/NDJsonAstParser.php
+++ b/tests/Cucumber/NDJsonAstParser.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Behat\Gherkin\Loader;
+namespace Tests\Behat\Gherkin\Cucumber;
 
 use Behat\Gherkin\Exception\NodeException;
 use Behat\Gherkin\Node\ArgumentInterface;
@@ -26,8 +26,6 @@ use Behat\Gherkin\Node\TableNode;
  * Loads a feature from cucumber's messages JSON format.
  *
  * Lines in the ndjson file are expected to match the Cucumber Messages JSON schema defined at https://github.com/cucumber/messages/tree/main/jsonschema
- *
- * @deprecated This loader is deprecated and will be removed in 5.0
  *
  * @phpstan-type TLocation array{line: int, column?: int}
  * @phpstan-type TBackground array{location: TLocation, keyword: string, name: string, description: string, steps: list<TStep>, id: string}
@@ -48,14 +46,12 @@ use Behat\Gherkin\Node\TableNode;
  * // We only care about the gherkinDocument messages for our use case, so this does not describe the envelope fully
  * @phpstan-type TEnvelope array{gherkinDocument?: TGherkinDocument, ...}
  */
-class CucumberNDJsonAstLoader implements LoaderInterface
+class NDJsonAstParser
 {
-    public function supports(mixed $resource)
-    {
-        return is_string($resource);
-    }
-
-    public function load(mixed $resource)
+    /**
+     * @return list<FeatureNode>
+     */
+    public function load(string $resource): array
     {
         return array_values(
             array_filter(

--- a/tests/Loader/CucumberNDJsonAstLoaderTest.php
+++ b/tests/Loader/CucumberNDJsonAstLoaderTest.php
@@ -16,7 +16,10 @@ use Behat\Gherkin\Node\BackgroundNode;
 use Behat\Gherkin\Node\ExampleTableNode;
 use Behat\Gherkin\Node\FeatureNode;
 use Behat\Gherkin\Node\OutlineNode;
+use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\ScenarioNode;
+use Behat\Gherkin\Node\StepNode;
+use Behat\Gherkin\Node\TableNode;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -76,7 +79,40 @@ final class CucumberNDJsonAstLoaderTest extends TestCase
                                 'name' => 'Examples Scenario',
                                 'description' => '',
                                 'tags' => [],
-                                'steps' => [],
+                                'steps' => [
+                                    [
+                                        'location' => ['line' => 500],
+                                        'keyword' => 'Given ',
+                                        'keywordType' => 'Context',
+                                        'text' => 'some step',
+                                        'docString' => [
+                                            'location' => ['line' => 501],
+                                            'delimiter' => '"""',
+                                            'content' => 'some text',
+                                        ],
+                                        'id' => '',
+                                    ],
+                                    [
+                                        'location' => ['line' => 510],
+                                        'keyword' => 'When ',
+                                        'keywordType' => 'Action',
+                                        'text' => 'some other step',
+                                        'dataTable' => [
+                                            'location' => ['line' => 511],
+                                            'rows' => [
+                                                [
+                                                    'location' => ['line' => 511],
+                                                    'cells' => [
+                                                        ['location' => ['line' => 511], 'value' => 'A'],
+                                                        ['location' => ['line' => 511], 'value' => 'B'],
+                                                    ],
+                                                    'id' => '',
+                                                ],
+                                            ],
+                                        ],
+                                        'id' => '',
+                                    ],
+                                ],
                                 'id' => '',
                                 'keyword' => 'out',
                                 'examples' => [
@@ -134,7 +170,10 @@ final class CucumberNDJsonAstLoaderTest extends TestCase
                     new BackgroundNode('Empty Background', [], 'bac', 222),
                     [
                         new ScenarioNode('Empty Scenario', [], [], 'sce', 333),
-                        new OutlineNode('Examples Scenario', [], [], [
+                        new OutlineNode('Examples Scenario', [], [
+                            new StepNode('Given', 'some step', [new PyStringNode(['some text'], 501)], 500, 'Given'),
+                            new StepNode('When', 'some other step', [new TableNode([511 => ['A', 'B']])], 510, 'When'),
+                        ], [
                             new ExampleTableNode([
                                 666 => ['A', 'B'],
                                 777 => ['A1', 'B1'],
@@ -281,6 +320,20 @@ final class CucumberNDJsonAstLoaderTest extends TestCase
             ],
             $features,
         );
+    }
+
+    public function testLoadingEmptyDocument(): void
+    {
+        $file = $this->serializeCucumberMessagesToFile([
+            'gherkinDocument' => [
+                'comments' => [],
+                'uri' => '../testdata/good/empty.feature',
+            ],
+        ]);
+
+        $features = $this->loader->load($file);
+
+        $this->assertCount(0, $features);
     }
 
     /**


### PR DESCRIPTION
This loader was implemented for internal usage in the testsuite, but was not expected to be released in the public package. Closes #351 


The NDJsonAstParser class in the testsuite is a copy of the deprecated loader, except for its public API that does not implement LoaderInterface.
This test-only parser is expected to be updated in the future to remove any custom normalization being done, so that our compatibility tests are ensuring full compatibility (either by relying on compatibility mode in this parser or by relying on the object comparators)