### PR TITLE
feat: Support language tags with whitespace in `gherkin-32` mode

### DIFF
--- a/src/GherkinCompatibilityMode.php
+++ b/src/GherkinCompatibilityMode.php
@@ -42,4 +42,15 @@ enum GherkinCompatibilityMode: string
             default => false,
         };
     }
+
+    /**
+     * @internal
+     */
+    public function allowWhitespaceInLanguageTag(): bool
+    {
+        return match ($this) {
+            self::LEGACY => false,
+            default => true,
+        };
+    }
 }

--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -789,7 +789,11 @@ class Lexer
             return null;
         }
 
-        $token = $this->scanInput('/^\s*#\s*language:\s*([\w_\-]+)\s*$/', 'Language');
+        $pattern = $this->compatibilityMode->allowWhitespaceInLanguageTag()
+            ? '/^\s*#\s*language\s*:\s*([\w_\-]+)\s*$/u'
+            : '/^\s*#\s*language:\s*([\w_\-]+)\s*$/';
+
+        $token = $this->scanInput($pattern, 'Language');
 
         if ($token) {
             \assert(\is_string($token['value']));

--- a/tests/Cucumber/CompatibilityTest.php
+++ b/tests/Cucumber/CompatibilityTest.php
@@ -68,7 +68,6 @@ class CompatibilityTest extends TestCase
             'descriptions_with_comments.feature' => 'Examples table descriptions not supported',
             'feature_keyword_in_scenario_description.feature' => 'Scenario descriptions not supported',
             'padded_example.feature' => 'Table padding is not trimmed as aggressively',
-            'spaces_in_language.feature' => 'Whitespace not supported around language selector',
             'rule_without_name_and_description.feature' => 'Rule is wrongly parsed as Description',
             'incomplete_background_2.feature' => 'Background descriptions not supported',
         ],


### PR DESCRIPTION
Matches cucumber/gherkin behaviour by allowing language tags with additional whitespace either side of the keyword e.g.

```
 #  language  :   en-lol
```

Fixes #206