### PR TITLE
Simplify FS operations

### DIFF
--- a/bin/update_cucumber
+++ b/bin/update_cucumber
@@ -27,9 +27,8 @@ class {
     public function update(string $composerFile, string $outputVarsFile): void
     {
         assert(is_file($composerFile), "'$composerFile' should be a file");
-        $composerConfigStr = $this->getContents($composerFile);
 
-        $currentVersion = $this->findComposerGherkinVersion($composerConfigStr);
+        $currentVersion = $this->findComposerGherkinVersion($composerFile);
         echo "Current local version is {$currentVersion['hash']} (tagged {$currentVersion['tag_name']})\n";
 
         $releases = $this->listGitHubReleases('cucumber/gherkin');
@@ -45,7 +44,7 @@ class {
         }
 
         echo "Next upstream version is {$nextVersion['hash']} (tagged {$nextVersion['tag_name']})\n";
-        $this->updateComposerJsonFile($composerFile, $composerConfigStr, $currentVersion, $nextVersion);
+        $this->updateComposerJsonFile($composerFile, $currentVersion, $nextVersion);
         $this->writeGitHubOutputs($outputVarsFile, [
             'cucumber_updated' => 'yes',
             'cucumber_version' => $nextVersion['tag_name'],
@@ -54,7 +53,7 @@ class {
         echo "Updated composer.json\n";
 
         // Sanity check that the update has applied correctly and the composer.json still parses as expected
-        $updatedVersion = $this->findComposerGherkinVersion($this->getContents($composerFile));
+        $updatedVersion = $this->findComposerGherkinVersion($composerFile);
         assert(
             ($updatedVersion['hash'] === $nextVersion['hash'])
             && ($updatedVersion['tag_name'] === $nextVersion['tag_name']),
@@ -65,11 +64,12 @@ class {
     /**
      * @phpstan-return TCurrentVersionArray
      */
-    private function findComposerGherkinVersion(string $composerConfigStr): array
+    private function findComposerGherkinVersion(string $composerFile): array
     {
-        $composerConfig = $this->jsonDecodeArray($composerConfigStr);
+        $composerConfig = Behat\Gherkin\Filesystem::readJsonFile($composerFile);
         assert(
-            is_array($composerConfig['repositories'] ?? null)
+            is_array($composerConfig)
+            && is_array($composerConfig['repositories'] ?? null)
             && is_array($composerConfig['repositories'][0] ?? null),
             'composer.json should contain custom repository configuration',
         );
@@ -106,24 +106,14 @@ class {
     }
 
     /**
-     * @return array<array-key, mixed>
-     */
-    private function jsonDecodeArray(string $json): array
-    {
-        $result = json_decode($json, true, flags: JSON_THROW_ON_ERROR);
-        assert(is_array($result), "'$json' should be a JSON array");
-
-        return $result;
-    }
-
-    /**
      * @phpstan-return non-empty-list<TGitHubReleaseArray>
      */
     private function listGitHubReleases(string $repo): array
     {
         // GitHub requires API requests to send a user_agent header for tracing
         ini_set('user_agent', 'https://github.com/Behat/Gherkin updater');
-        $releases = $this->jsonDecodeArray($this->getContents("https://api.github.com/repos/$repo/releases"));
+        $releases = Behat\Gherkin\Filesystem::readJsonFile("https://api.github.com/repos/$repo/releases", true);
+        assert(is_array($releases), 'Releases should be a JSON array');
 
         assert($releases !== [], 'github should have returned at least one release');
 
@@ -246,13 +236,16 @@ class {
      * @phpstan-param TCurrentVersionArray $currentVersion
      * @phpstan-param TGitHubReleaseArray $nextVersion
      */
-    private function updateComposerJsonFile(string $composerFile, string $composerConfigStr, array $currentVersion, array $nextVersion): void
+    private function updateComposerJsonFile(string $composerFile, array $currentVersion, array $nextVersion): void
     {
         // Use string replacement rather than json_encode so that we preserve the existing composer.json format
-        $newJSON = strtr($composerConfigStr, [
-            $currentVersion['composer_version'] => 'dev-gherkin-' . $nextVersion['tag_name'],
-            $currentVersion['hash'] => $nextVersion['hash'],
-        ]);
+        $newJSON = strtr(
+            Behat\Gherkin\Filesystem::readFile($composerFile),
+            [
+                $currentVersion['composer_version'] => 'dev-gherkin-' . $nextVersion['tag_name'],
+                $currentVersion['hash'] => $nextVersion['hash'],
+            ],
+        );
 
         assert((bool) file_put_contents($composerFile, $newJSON), 'Updated composer.json');
     }
@@ -273,14 +266,6 @@ class {
 
             assert((bool) file_put_contents($outputVarsFile, $var, FILE_APPEND), "Wrote output var $name");
         }
-    }
-
-    private function getContents(string $filenameOrUrl): string
-    {
-        $content = file_get_contents($filenameOrUrl);
-        assert($content !== false, 'Should be able to read ' . $filenameOrUrl);
-
-        return $content;
     }
 };
 

--- a/bin/update_i18n
+++ b/bin/update_i18n
@@ -10,7 +10,7 @@
  */
 
 $gherkinFile = __DIR__ . '/../vendor/cucumber/gherkin-monorepo/gherkin-languages.json';
-$gherkinLanguages = json_decode(file_get_contents($gherkinFile) ?: '', true, 512, JSON_THROW_ON_ERROR);
+$gherkinLanguages = Behat\Gherkin\Filesystem::readJsonFile($gherkinFile, true);
 assert(is_array($gherkinLanguages));
 $array = [];
 

--- a/src/Cache/FileCache.php
+++ b/src/Cache/FileCache.php
@@ -11,8 +11,10 @@
 namespace Behat\Gherkin\Cache;
 
 use Behat\Gherkin\Exception\CacheException;
+use Behat\Gherkin\Filesystem;
 use Behat\Gherkin\Node\FeatureNode;
 use Composer\InstalledVersions;
+use RuntimeException;
 
 /**
  * File cache.
@@ -86,7 +88,11 @@ class FileCache implements CacheInterface
     public function read(string $path)
     {
         $cachePath = $this->getCachePathFor($path);
-        $feature = unserialize(file_get_contents($cachePath));
+        try {
+            $feature = unserialize(Filesystem::readFile($cachePath));
+        } catch (RuntimeException $ex) {
+            throw new CacheException("Can not load cache: {$ex->getMessage()}", previous: $ex);
+        }
 
         if (!$feature instanceof FeatureNode) {
             throw new CacheException(sprintf('Can not load cache for a feature "%s" from "%s".', $path, $cachePath));

--- a/src/Dialect/CucumberDialectProvider.php
+++ b/src/Dialect/CucumberDialectProvider.php
@@ -11,6 +11,7 @@
 namespace Behat\Gherkin\Dialect;
 
 use Behat\Gherkin\Exception\NoSuchLanguageException;
+use Behat\Gherkin\Filesystem;
 
 /**
  * A dialect provider that loads the dialects based on the gherkin-languages.json file copied from the Cucumber project.
@@ -26,15 +27,13 @@ final class CucumberDialectProvider implements DialectProviderInterface
 
     public function __construct()
     {
-        $json = file_get_contents(__DIR__ . '/../../resources/gherkin-languages.json');
-        \assert($json !== false);
         /**
          * Here we force the type checker to assume the decoded JSON has the correct
          * structure, rather than validating it. This is safe because it's not dynamic.
          *
          * @var non-empty-array<non-empty-string, TDialectData> $data
          */
-        $data = json_decode($json, true, flags: JSON_THROW_ON_ERROR);
+        $data = Filesystem::readJsonFile(__DIR__ . '/../../resources/gherkin-languages.json', true);
         $this->dialects = $data;
     }
 

--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -8,15 +8,21 @@
  * file that was distributed with this source code.
  */
 
-namespace Tests\Behat\Gherkin;
+namespace Behat\Gherkin;
 
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use RuntimeException;
 use SplFileInfo;
 
-class Filesystem
+/**
+ * @internal
+ */
+final class Filesystem
 {
+    /**
+     * @throws RuntimeException
+     */
     public static function readFile(string $fileName): string
     {
         $data = @file_get_contents($fileName);
@@ -25,6 +31,14 @@ class Filesystem
         }
 
         return $data;
+    }
+
+    /**
+     * @throws \JsonException
+     */
+    public static function readJsonFile(string $fileName, bool $assoc = false): mixed
+    {
+        return json_decode(self::readFile($fileName), $assoc, flags: JSON_THROW_ON_ERROR);
     }
 
     /**

--- a/src/Loader/GherkinFileLoader.php
+++ b/src/Loader/GherkinFileLoader.php
@@ -93,8 +93,6 @@ class GherkinFileLoader extends AbstractFileLoader
      */
     protected function parseFeature(string $path)
     {
-        $content = file_get_contents($path);
-
-        return $this->parser->parse($content, $path);
+        return $this->parser->parseFile($path);
     }
 }

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -24,6 +24,7 @@ use Behat\Gherkin\Node\ScenarioInterface;
 use Behat\Gherkin\Node\ScenarioNode;
 use Behat\Gherkin\Node\StepNode;
 use Behat\Gherkin\Node\TableNode;
+use RuntimeException;
 
 /**
  * Gherkin parser.
@@ -104,6 +105,15 @@ class Parser implements ParserInterface
         }
 
         return $feature;
+    }
+
+    public function parseFile(string $file): ?FeatureNode
+    {
+        try {
+            return $this->parse(Filesystem::readFile($file), $file);
+        } catch (RuntimeException $ex) {
+            throw new ParserException("Cannot parse file: {$ex->getMessage()}", previous: $ex);
+        }
     }
 
     /**

--- a/src/ParserInterface.php
+++ b/src/ParserInterface.php
@@ -26,4 +26,11 @@ interface ParserInterface
      * @throws ParserException
      */
     public function parse(string $input, ?string $file = null);
+
+    /**
+     * Parses a Gherkin file and returns features array.
+     *
+     * @throws ParserException
+     */
+    public function parseFile(string $file): ?FeatureNode;
 }

--- a/tests/Cache/FileCacheTest.php
+++ b/tests/Cache/FileCacheTest.php
@@ -12,12 +12,12 @@ namespace Tests\Behat\Gherkin\Cache;
 
 use Behat\Gherkin\Cache\FileCache;
 use Behat\Gherkin\Exception\CacheException;
+use Behat\Gherkin\Filesystem;
 use Behat\Gherkin\Node\FeatureNode;
 use Behat\Gherkin\Node\ScenarioNode;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
 use PHPUnit\Framework\TestCase;
-use Tests\Behat\Gherkin\Filesystem;
 
 class FileCacheTest extends TestCase
 {

--- a/tests/Cucumber/CompatibilityTest.php
+++ b/tests/Cucumber/CompatibilityTest.php
@@ -12,6 +12,7 @@ namespace Tests\Behat\Gherkin\Cucumber;
 
 use Behat\Gherkin\Dialect\CucumberDialectProvider;
 use Behat\Gherkin\Exception\ParserException;
+use Behat\Gherkin\Filesystem;
 use Behat\Gherkin\GherkinCompatibilityMode;
 use Behat\Gherkin\Lexer;
 use Behat\Gherkin\Parser;
@@ -21,7 +22,6 @@ use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use SebastianBergmann\Comparator\Factory;
 use SplFileInfo;
-use Tests\Behat\Gherkin\Filesystem;
 
 /**
  * Tests the parser against the upstream cucumber/gherkin test data.

--- a/tests/Keywords/DialectKeywordsTest.php
+++ b/tests/Keywords/DialectKeywordsTest.php
@@ -11,10 +11,10 @@
 namespace Tests\Behat\Gherkin\Keywords;
 
 use Behat\Gherkin\Dialect\CucumberDialectProvider;
+use Behat\Gherkin\Filesystem;
 use Behat\Gherkin\Keywords\DialectKeywords;
 use Behat\Gherkin\Keywords\KeywordsInterface;
 use Behat\Gherkin\Node\StepNode;
-use Tests\Behat\Gherkin\Filesystem;
 
 class DialectKeywordsTest extends KeywordsTestCase
 {
@@ -35,7 +35,7 @@ class DialectKeywordsTest extends KeywordsTestCase
 
     protected static function getKeywordsArray(): array
     {
-        $data = json_decode(Filesystem::readFile(__DIR__ . '/../../resources/gherkin-languages.json'), true, flags: \JSON_THROW_ON_ERROR);
+        $data = Filesystem::readJsonFile(__DIR__ . '/../../resources/gherkin-languages.json', true);
 
         $keywordsArray = [];
 

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -12,6 +12,7 @@ namespace Tests\Behat\Gherkin;
 
 use Behat\Gherkin\Dialect\CucumberDialectProvider;
 use Behat\Gherkin\Exception\ParserException;
+use Behat\Gherkin\Filesystem;
 use Behat\Gherkin\Keywords\ArrayKeywords;
 use Behat\Gherkin\Keywords\KeywordsInterface;
 use Behat\Gherkin\Lexer;

--- a/tests/TranslationTest.php
+++ b/tests/TranslationTest.php
@@ -12,6 +12,7 @@ namespace Tests\Behat\Gherkin;
 
 use Behat\Gherkin\Dialect\CucumberDialectProvider;
 use Behat\Gherkin\Dialect\GherkinDialect;
+use Behat\Gherkin\Filesystem;
 use Behat\Gherkin\Keywords\DialectKeywords;
 use Behat\Gherkin\Keywords\KeywordsDumper;
 use Behat\Gherkin\Lexer;
@@ -56,7 +57,7 @@ class TranslationTest extends TestCase
     {
         $dumper = new KeywordsDumper(new DialectKeywords(new CucumberDialectProvider()));
         /** @var non-empty-array<non-empty-string, TDialectData> $keywordsArray */
-        $keywordsArray = json_decode(Filesystem::readFile(__DIR__ . '/../resources/gherkin-languages.json'), true, flags: \JSON_THROW_ON_ERROR);
+        $keywordsArray = Filesystem::readJsonFile(__DIR__ . '/../resources/gherkin-languages.json', true);
 
         foreach ($keywordsArray as $lang => $i18nKeywords) {
             $features = [];


### PR DESCRIPTION
What changed:
- moved `tests/Filesystem.php` to `src/` and made it `@internal`
- added `readJsonFile()` helper to `Filesystem`
- replaced/updated all usages of `file_get_contents(...)` or `json_decode(file_get_contents(...))`
- added `parseFile()` to the parser and parser interface
  - (which although technically a breaking change, we introduced the interface recently)

This is to:
- reduce duplicate code and checks
- less PHPStan warnings