### PR TITLE
fix: Use default file cache key if `behat/gherkin` version is unknown

### DIFF
--- a/src/Cache/FileCache.php
+++ b/src/Cache/FileCache.php
@@ -31,7 +31,7 @@ class FileCache implements CacheInterface
      */
     private static function getGherkinVersionHash(): string
     {
-        $version = InstalledVersions::getVersion('behat/gherkin');
+        $version = InstalledVersions::getVersion('behat/gherkin') ?? 'unknown';
 
         // Composer version strings can contain arbitrary content so hash for filesystem safety
         return md5($version);


### PR DESCRIPTION
As per PHPStan, it is possible that the version of the `behat/gherkin` package, (which we use as cache key), cannot be retrieved. This PR makes it default to `'unknown'` in that case.

This change was extracted from #364.