### PR TITLE
ci: Fix error in cucumber update job due to non-autoloadable classes

### DIFF
--- a/bin/update_cucumber
+++ b/bin/update_cucumber
@@ -18,6 +18,9 @@ if (ini_get('zend.assertions') !== '1') {
     exit(1);
 }
 
+// This script runs before composer install (because it updates composer.json) therefore cannot autoload our files.
+require_once __DIR__ . '/../src/Filesystem.php';
+
 $updater = new
 /**
  * @phpstan-type TCurrentVersionArray array{tag_name: string, hash: string, composer_version: string}

--- a/bin/update_i18n
+++ b/bin/update_i18n
@@ -9,6 +9,8 @@
  * file that was distributed with this source code.
  */
 
+require_once __DIR__ . '/../vendor/autoload.php';
+
 $gherkinFile = __DIR__ . '/../vendor/cucumber/gherkin-monorepo/gherkin-languages.json';
 $gherkinLanguages = Behat\Gherkin\Filesystem::readJsonFileArray($gherkinFile);
 $array = [];


### PR DESCRIPTION
#365 extracted some filesystem logic from these scripts to the new Filesystem helper class. This broke the job, because the scripts are unable to locate the class. This is because there is no autoloader registered in this environment (and, in the case of the main update_cucumber script, we have not yet run composer install).

Fixed by manually requiring the class for update_cucumber, and registering the autoloader for the update_i18n (which runs after the composer install).