### PR TITLE
ci: Further fixes to cucumber_update job following #365 and #374

### DIFF
--- a/bin/update_cucumber
+++ b/bin/update_cucumber
@@ -20,6 +20,8 @@ if (ini_get('zend.assertions') !== '1') {
 
 // This script runs before composer install (because it updates composer.json) therefore cannot autoload our files.
 require_once __DIR__ . '/../src/Filesystem.php';
+require_once __DIR__ . '/../src/Exception/Exception.php';
+require_once __DIR__ . '/../src/Exception/FilesystemException.php';
 
 $updater = new
 /**
@@ -114,7 +116,7 @@ class {
     {
         // GitHub requires API requests to send a user_agent header for tracing
         ini_set('user_agent', 'https://github.com/Behat/Gherkin updater');
-        $releases = Behat\Gherkin\Filesystem::readJsonFileArray('https://api.github.com/repos/$repo/releases');
+        $releases = Behat\Gherkin\Filesystem::readJsonFileArray("https://api.github.com/repos/$repo/releases");
 
         assert($releases !== [], 'github should have returned at least one release');
 


### PR DESCRIPTION
Further to the previous fix, we also need to manually require the FilesystemException class and the interface it uses in case we encounter filesystem errors during execution.

#365 also accidentally converted the github API url from a double-quoted to single-quoted string, breaking the interpolation of the repository name and causing it to 404.