### PR TITLE
ci: Fix string interpolation in update_cucumber job

### DIFF
--- a/bin/update_cucumber
+++ b/bin/update_cucumber
@@ -116,7 +116,7 @@ class {
     {
         // GitHub requires API requests to send a user_agent header for tracing
         ini_set('user_agent', 'https://github.com/Behat/Gherkin updater');
-        $releases = Behat\Gherkin\Filesystem::readJsonFileHash('https://api.github.com/repos/$repo/releases');
+        $releases = Behat\Gherkin\Filesystem::readJsonFileHash('https://api.github.com/repos/' . $repo . '/releases');
 
         assert($releases !== [], 'github should have returned at least one release');
 


### PR DESCRIPTION
#368 accidentally converted this variable to a single quoted string, breaking variable interpolation and causing it to generate an incorrect URL for the github API request.

This previously happened in #365 (which had been picked out of #368) and was fixed in #375, however I didn't spot that the patch had then been reapplied in the final PR.

Change from interpolation to concatenation to minimise the risk of recurrence.