### PR TITLE
ci: Fix incorrect assumption about github releases in update_cucumber

### DIFF
--- a/bin/update_cucumber
+++ b/bin/update_cucumber
@@ -116,7 +116,7 @@ class {
     {
         // GitHub requires API requests to send a user_agent header for tracing
         ini_set('user_agent', 'https://github.com/Behat/Gherkin updater');
-        $releases = Behat\Gherkin\Filesystem::readJsonFileHash('https://api.github.com/repos/' . $repo . '/releases');
+        $releases = Behat\Gherkin\Filesystem::readJsonFileArray('https://api.github.com/repos/' . $repo . '/releases');
 
         assert($releases !== [], 'github should have returned at least one release');
 

--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -44,15 +44,27 @@ final class Filesystem
     }
 
     /**
+     * @return array<mixed>
+     *
+     * @throws JsonException|FilesystemException
+     */
+    public static function readJsonFileArray(string $fileName): array
+    {
+        $result = json_decode(self::readFile($fileName), true, flags: JSON_THROW_ON_ERROR);
+
+        assert(is_array($result), 'File must contain JSON with an array or object at its root');
+
+        return $result;
+    }
+
+    /**
      * @return array<string, mixed>
      *
      * @throws JsonException|FilesystemException
      */
     public static function readJsonFileHash(string $fileName): array
     {
-        $result = json_decode(self::readFile($fileName), true, flags: JSON_THROW_ON_ERROR);
-
-        assert(is_array($result), 'File must contain JSON with an array or object at its root');
+        $result = self::readJsonFileArray($fileName);
         assert(
             $result === array_filter($result, is_string(...), ARRAY_FILTER_USE_KEY),
             'File must contain a JSON object at its root',


### PR DESCRIPTION
#368 converted the previous `readJsonFileArray` utility method to a stricter `readJsonFileHash` to improve phpstan checking. This was based on the belief that we were always currently using that method to parse JSON data with an object structure at the root.

However, in the case of the update_cucumber script, the github releases API returns a JSON array of objects. The strict check was therefore causing that job to fail.

I have introduced the looser `readJsonFileArray` for this purpose and confirmed that the task now works locally.