### PR TITLE
style: Fix comma position after heredoc call argument

### DIFF
--- a/tests/Keywords/KeywordsDumperTest.php
+++ b/tests/Keywords/KeywordsDumperTest.php
@@ -220,8 +220,8 @@ class KeywordsDumperTest extends TestCase
                 Примеры:
                   | agent1 | agent2 |
                   | D      | M      |
-            GHERKIN
-            , <<<'GHERKIN'
+            GHERKIN,
+            <<<'GHERKIN'
             # language: ru
             Фича: Internal operations
               In order to stay secret


### PR DESCRIPTION
The previous version (with the comma on the following line) dates back to PHP < 7.3.0 when the heredoc terminator had to be the only thing on the line.

php-cs-fixer 3.86.0 updates the symfony ruleset to require that the comma be on the same line as the heredoc terminator (which we already do in most places), meaning this line is now reported as a violation.