### PR TITLE
test: Fix cucumber variant assertions to include inherited properties

### DIFF
--- a/tests/Cucumber/ParserResultDumper.php
+++ b/tests/Cucumber/ParserResultDumper.php
@@ -70,12 +70,14 @@ class ParserResultDumper
         // we know that the FeatureNode and the objects it contains do not contain any recursive references.
         $values = [];
         $reflection = new ReflectionClass($value);
-        foreach ($reflection->getProperties() as $property) {
-            $values[$property->getName()] = match ($property->isInitialized($value)) {
-                true => $this->recursiveDump($property->getValue($value)),
-                false => '**NOT INITIALIZED**',
-            };
-        }
+        do {
+            foreach ($reflection->getProperties() as $property) {
+                $values[$property->getName()] = match ($property->isInitialized($value)) {
+                    true => $this->recursiveDump($property->getValue($value)),
+                    false => '**NOT INITIALIZED**',
+                };
+            }
+        } while ($reflection = $reflection->getParentClass());
 
         return [$value::class => $values];
     }

--- a/tests/Cucumber/expected_variants/gherkin-32/padded_example.feature.expected.yaml
+++ b/tests/Cucumber/expected_variants/gherkin-32/padded_example.feature.expected.yaml
@@ -11,6 +11,13 @@ Behat\Gherkin\Node\FeatureNode:
                         Behat\Gherkin\Node\ExampleTableNode:
                             keyword: Examples
                             tags: []
+                            maxLineLength:
+                                - 9
+                            table:
+                                17:
+                                    - color
+                                18:
+                                    - "\_ \tred\_ \t"
                 examples: '**NOT INITIALIZED**'
                 title: test
                 tags: []

--- a/tests/Cucumber/expected_variants/legacy/padded_example.feature.expected.yaml
+++ b/tests/Cucumber/expected_variants/legacy/padded_example.feature.expected.yaml
@@ -11,6 +11,13 @@ Behat\Gherkin\Node\FeatureNode:
                         Behat\Gherkin\Node\ExampleTableNode:
                             keyword: Examples
                             tags: []
+                            maxLineLength:
+                                - 7
+                            table:
+                                17:
+                                    - color
+                                18:
+                                    - "\_ \tred\_"
                 examples: '**NOT INITIALIZED**'
                 title: test
                 tags: []


### PR DESCRIPTION
Most of our nodes are standalone classes, but ExampleTableNode inherits from TableNode and the actual `table` content is a private property in the parent class. This meant that our dumped YAML data for assertions did not capture the example table content.

I built this commit off the original (based on 4.14.0) and then patched it onto the current version - only one original feature was affected.