### PR TITLE
fix: Add `Stringable` to classes implementing __toString()

### DIFF
--- a/src/Node/PyStringNode.php
+++ b/src/Node/PyStringNode.php
@@ -10,6 +10,8 @@
 
 namespace Behat\Gherkin\Node;
 
+use Stringable;
+
 /**
  * Represents Gherkin PyString argument.
  *
@@ -17,7 +19,7 @@ namespace Behat\Gherkin\Node;
  *
  * @final since 4.15.0
  */
-class PyStringNode implements ArgumentInterface
+class PyStringNode implements Stringable, ArgumentInterface
 {
     /**
      * @param list<string> $strings String in form of [$stringLine]

--- a/src/Node/TableNode.php
+++ b/src/Node/TableNode.php
@@ -15,6 +15,7 @@ use Behat\Gherkin\Exception\NodeException;
 use Iterator;
 use IteratorAggregate;
 use ReturnTypeWillChange;
+use Stringable;
 
 /**
  * Represents Gherkin Table argument.
@@ -23,7 +24,7 @@ use ReturnTypeWillChange;
  *
  * @template-implements IteratorAggregate<int, array<string, string>>
  */
-class TableNode implements ArgumentInterface, IteratorAggregate
+class TableNode implements Stringable, ArgumentInterface, IteratorAggregate
 {
     /**
      * @var array<array-key, int>
@@ -135,7 +136,7 @@ class TableNode implements ArgumentInterface, IteratorAggregate
 
         $hash = [];
         foreach ($rows as $row) {
-            \assert($keys !== null); // If there is no first row due to an empty table, we won't enter this loop either.
+            assert($keys !== null); // If there is no first row due to an empty table, we won't enter this loop either.
             $hash[] = array_combine($keys, $row);
         }
 


### PR DESCRIPTION
php-cs-fixer 3.91.0 added a new rule to the `@Symfony` set that adds the `Stringable` interface to classes implementing a `__toString()` method.

This commit applies that rule to our codebase to resolve the current build failure.