### PR TITLE
Fix the implementation of the default dialect for the keywords provider

### DIFF
--- a/src/Dialect/KeywordsDialectProvider.php
+++ b/src/Dialect/KeywordsDialectProvider.php
@@ -21,9 +21,13 @@ use Behat\Gherkin\Keywords\KeywordsInterface;
  */
 final class KeywordsDialectProvider implements DialectProviderInterface
 {
+    private readonly string $defaultLanguage;
+
     public function __construct(
         private readonly KeywordsInterface $keywords,
     ) {
+        // Assume a default dialect of `en` as the KeywordsInterface does not allow reading its language but returns the current data
+        $this->defaultLanguage = $this->keywords instanceof ArrayKeywords ? $this->keywords->getLanguage() : 'en';
     }
 
     public function getDialect(string $language): GherkinDialect
@@ -40,10 +44,9 @@ final class KeywordsDialectProvider implements DialectProviderInterface
 
     public function getDefaultDialect(): GherkinDialect
     {
-        // Assume a default dialect of `en` as the KeywordsInterface does not allow reading its language but returns the current data
-        $language = $this->keywords instanceof ArrayKeywords ? $this->keywords->getLanguage() : 'en';
+        $this->keywords->setLanguage($this->defaultLanguage);
 
-        return $this->buildDialect($language);
+        return $this->buildDialect($this->defaultLanguage);
     }
 
     private function buildDialect(string $language): GherkinDialect

--- a/tests/Dialect/KeywordsDialectProviderTest.php
+++ b/tests/Dialect/KeywordsDialectProviderTest.php
@@ -12,6 +12,7 @@ namespace Tests\Behat\Gherkin\Dialect;
 
 use Behat\Gherkin\Dialect\KeywordsDialectProvider;
 use Behat\Gherkin\Keywords\ArrayKeywords;
+use Behat\Gherkin\Keywords\CachedArrayKeywords;
 use PHPUnit\Framework\TestCase;
 
 class KeywordsDialectProviderTest extends TestCase
@@ -39,5 +40,16 @@ class KeywordsDialectProviderTest extends TestCase
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('A keyword string must contain at least one keyword.');
         $dialectProvider->getDialect('en');
+    }
+
+    public function testDefaultDialectAfterExplicitDialect(): void
+    {
+        $dialectProvider = new KeywordsDialectProvider(CachedArrayKeywords::withDefaultKeywords());
+
+        $ruDialect = $dialectProvider->getDialect('ru');
+        $defaultDialect = $dialectProvider->getDefaultDialect();
+
+        $this->assertSame('ru', $ruDialect->getLanguage());
+        $this->assertSame('en', $defaultDialect->getLanguage());
     }
 }


### PR DESCRIPTION
The legacy KeywordsInterface was stateful, so we cannot assume that the _current_ language is the default one. We need to read the _initial_ language instead.

Closes #403