### PR TITLE
fix: Phpstan errors in current master build

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -40,5 +40,8 @@ return (new PhpCsFixer\Config())
         'single_line_throw' => false,
         'ternary_to_null_coalescing' => true,
         'global_namespace_import' => false,
+        'phpdoc_to_comment' => [ // Keep as a phpdoc if it contains the `@var` annotation
+            'ignored_tags' => ['var'],
+        ],
     ])
     ->setFinder($finder);

--- a/bin/update_i18n
+++ b/bin/update_i18n
@@ -24,6 +24,17 @@ foreach ($gherkinLanguages as $lang => $keywords) {
             $words = [$words];
         }
 
+        assert(array_find($words, fn ($word) => is_string($word)) === null, 'Expected $words to be an array of strings');
+        /**
+         * Here we force phpstan to recognise that we have narrowed the type of $words to a list of strings with the
+         * assertion above. Otherwise it will report an error from the later `implode()` call that $words must be a
+         * list<string>.
+         *
+         * There does not currently seem to be a way to force phpstan to detect this type narrowing at runtime
+         * https://github.com/phpstan/phpstan/issues/14360
+         *
+         * @var array<string> $words
+         */
         if ($type === 'scenarioOutline') {
             $type = 'scenario_outline';
         }
@@ -32,7 +43,6 @@ foreach ($gherkinLanguages as $lang => $keywords) {
             $formattedKeywords = [];
 
             foreach ($words as $word) {
-                assert(is_string($word));
                 $formattedWord = trim($word);
 
                 if ($formattedWord === $word) {
@@ -45,12 +55,14 @@ foreach ($gherkinLanguages as $lang => $keywords) {
             $words = $formattedKeywords;
         }
 
-        usort($words, static function ($type1, $type2) {
-            assert(is_string($type1));
-            assert(is_string($type2));
+        foreach ($words as $word) {
+            assert(is_string($word));
+        }
 
-            return [mb_strlen($type2, 'utf8'), $type1] <=> [mb_strlen($type1, 'utf8'), $type2];
-        });
+        usort(
+            $words,
+            static fn (string $type1, string $type2) => [mb_strlen($type2, 'utf8'), $type1] <=> [mb_strlen($type1, 'utf8'), $type2]
+        );
 
         $langMessages[$type] = implode('|', $words);
     }

--- a/bin/update_i18n
+++ b/bin/update_i18n
@@ -24,7 +24,7 @@ foreach ($gherkinLanguages as $lang => $keywords) {
             $words = [$words];
         }
 
-        assert(array_find($words, fn ($word) => is_string($word)) === null, 'Expected $words to be an array of strings');
+        assert(array_find($words, fn ($word) => !is_string($word)) === null, 'Expected $words to be an array of strings');
         /**
          * Here we force phpstan to recognise that we have narrowed the type of $words to a list of strings with the
          * assertion above. Otherwise it will report an error from the later `implode()` call that $words must be a

--- a/src/Gherkin.php
+++ b/src/Gherkin.php
@@ -151,6 +151,12 @@ class Gherkin
     {
         foreach ($this->loaders as $loader) {
             if ($loader->supports($resource)) {
+                /**
+                 * If the loader supports the provided resource, then it can safely be typed as
+                 * LoaderInterface<ResourceType>.
+                 *
+                 * @var LoaderInterface<TResourceType> $loader
+                 */
                 return $loader;
             }
         }

--- a/src/Loader/LoaderInterface.php
+++ b/src/Loader/LoaderInterface.php
@@ -24,11 +24,9 @@ interface LoaderInterface
     /**
      * Checks if current loader supports provided resource.
      *
-     * @template TSupportedResourceType
+     * @param mixed $resource Resource to load
      *
-     * @param TSupportedResourceType $resource Resource to load
-     *
-     * @phpstan-assert-if-true =LoaderInterface<TSupportedResourceType> $this
+     * @phpstan-assert-if-true =TResourceType $resource
      *
      * @return bool
      */

--- a/tests/Loader/GherkinFileLoaderTest.php
+++ b/tests/Loader/GherkinFileLoaderTest.php
@@ -15,6 +15,7 @@ use Behat\Gherkin\Dialect\CucumberDialectProvider;
 use Behat\Gherkin\Lexer;
 use Behat\Gherkin\Loader\GherkinFileLoader;
 use Behat\Gherkin\Parser;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class GherkinFileLoaderTest extends TestCase
@@ -22,12 +23,17 @@ class GherkinFileLoaderTest extends TestCase
     private GherkinFileLoader $loader;
     private string $featuresPath;
 
+    private static function featuresPath(): string
+    {
+        return dirname(__DIR__) . DIRECTORY_SEPARATOR . 'Fixtures' . DIRECTORY_SEPARATOR . 'features';
+    }
+
     protected function setUp(): void
     {
         $parser = new Parser(new Lexer(new CucumberDialectProvider()));
         $this->loader = new GherkinFileLoader($parser);
 
-        $this->featuresPath = dirname(__DIR__) . DIRECTORY_SEPARATOR . 'Fixtures' . DIRECTORY_SEPARATOR . 'features';
+        $this->featuresPath = self::featuresPath();
     }
 
     public function testSupports(): void
@@ -93,26 +99,76 @@ class GherkinFileLoaderTest extends TestCase
         $this->assertEquals('cache', $features[0]);
     }
 
-    public function testBasePath(): void
+    /**
+     * @return array<string, array{?string, array<string, bool>}>
+     */
+    public static function providerSupportsWithBasePath(): array
     {
-        $this->assertFalse($this->loader->supports('features'));
-        $this->assertFalse($this->loader->supports('tables.feature'));
+        return [
+            'with no base path set' => [
+                null,
+                [
+                    // The default is the current working directory, and there are no files there
+                    'features' => false,
+                    'tables.feature' => false,
+                    'features/tables.feature' => false,
+                    'features/pystring.feature' => false,
+                    'features/multiline_name.feature' => false,
+                ],
+            ],
+            'with base path set to features directory' => [
+                self::featuresPath(),
+                [
+                    'features' => false,
+                    'tables.feature' => true,
+                    'pystring.feature' => true,
+                    'features/tables.feature' => false,
+                    'features/pystring.feature' => false,
+                ],
+            ],
+            'with base path set to parent of features directory' => [
+                self::featuresPath() . '/../',
+                [
+                    'features' => false,
+                    'tables.feature' => false,
+                    'pystring.feature' => false,
+                    'features/tables.feature' => true,
+                    'features/pystring.feature' => true,
+                ],
+            ],
+        ];
+    }
 
-        $this->loader->setBasePath($this->featuresPath . '/../');
-        $this->assertFalse($this->loader->supports('features'));
-        $this->assertFalse($this->loader->supports('tables.feature'));
-        $this->assertTrue($this->loader->supports('features/tables.feature'));
+    /**
+     * @param array<string,bool> $expected
+     */
+    #[DataProvider('providerSupportsWithBasePath')]
+    public function testSupportsWithBasePath(?string $basePath, array $expected): void
+    {
+        if ($basePath !== null) {
+            $this->loader->setBasePath($basePath);
+        }
 
-        $this->assertTrue($this->loader->supports('features/pystring.feature'));
+        $actual = [];
+        foreach (array_keys($expected) as $resource) {
+            $actual[$resource] = $this->loader->supports($resource);
+        }
+
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testLoadWithBasePath(): void
+    {
+        $this->loader->setBasePath(self::featuresPath() . '/../');
         $features = $this->loader->load('features/pystring.feature');
         $this->assertCount(1, $features);
         $this->assertEquals('A py string feature', $features[0]->getTitle());
-        $this->assertEquals($this->featuresPath . DIRECTORY_SEPARATOR . 'pystring.feature', $features[0]->getFile());
+        $this->assertEquals(self::featuresPath() . DIRECTORY_SEPARATOR . 'pystring.feature', $features[0]->getFile());
 
-        $this->loader->setBasePath($this->featuresPath);
+        $this->loader->setBasePath(self::featuresPath());
         $features = $this->loader->load('multiline_name.feature');
         $this->assertCount(1, $features);
         $this->assertEquals('multiline', $features[0]->getTitle());
-        $this->assertEquals($this->featuresPath . DIRECTORY_SEPARATOR . 'multiline_name.feature', $features[0]->getFile());
+        $this->assertEquals(self::featuresPath() . DIRECTORY_SEPARATOR . 'multiline_name.feature', $features[0]->getFile());
     }
 }

--- a/tests/Loader/GherkinFileLoaderTest.php
+++ b/tests/Loader/GherkinFileLoaderTest.php
@@ -15,7 +15,6 @@ use Behat\Gherkin\Dialect\CucumberDialectProvider;
 use Behat\Gherkin\Lexer;
 use Behat\Gherkin\Loader\GherkinFileLoader;
 use Behat\Gherkin\Parser;
-use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class GherkinFileLoaderTest extends TestCase
@@ -23,17 +22,12 @@ class GherkinFileLoaderTest extends TestCase
     private GherkinFileLoader $loader;
     private string $featuresPath;
 
-    private static function featuresPath(): string
-    {
-        return dirname(__DIR__) . DIRECTORY_SEPARATOR . 'Fixtures' . DIRECTORY_SEPARATOR . 'features';
-    }
-
     protected function setUp(): void
     {
         $parser = new Parser(new Lexer(new CucumberDialectProvider()));
         $this->loader = new GherkinFileLoader($parser);
 
-        $this->featuresPath = self::featuresPath();
+        $this->featuresPath = dirname(__DIR__) . DIRECTORY_SEPARATOR . 'Fixtures' . DIRECTORY_SEPARATOR . 'features';
     }
 
     public function testSupports(): void
@@ -99,76 +93,26 @@ class GherkinFileLoaderTest extends TestCase
         $this->assertEquals('cache', $features[0]);
     }
 
-    /**
-     * @return array<string, array{?string, array<string, bool>}>
-     */
-    public static function providerSupportsWithBasePath(): array
+    public function testBasePath(): void
     {
-        return [
-            'with no base path set' => [
-                null,
-                [
-                    // The default is the current working directory, and there are no files there
-                    'features' => false,
-                    'tables.feature' => false,
-                    'features/tables.feature' => false,
-                    'features/pystring.feature' => false,
-                    'features/multiline_name.feature' => false,
-                ],
-            ],
-            'with base path set to features directory' => [
-                self::featuresPath(),
-                [
-                    'features' => false,
-                    'tables.feature' => true,
-                    'pystring.feature' => true,
-                    'features/tables.feature' => false,
-                    'features/pystring.feature' => false,
-                ],
-            ],
-            'with base path set to parent of features directory' => [
-                self::featuresPath() . '/../',
-                [
-                    'features' => false,
-                    'tables.feature' => false,
-                    'pystring.feature' => false,
-                    'features/tables.feature' => true,
-                    'features/pystring.feature' => true,
-                ],
-            ],
-        ];
-    }
+        $this->assertFalse($this->loader->supports('features'));
+        $this->assertFalse($this->loader->supports('tables.feature'));
 
-    /**
-     * @param array<string,bool> $expected
-     */
-    #[DataProvider('providerSupportsWithBasePath')]
-    public function testSupportsWithBasePath(?string $basePath, array $expected): void
-    {
-        if ($basePath !== null) {
-            $this->loader->setBasePath($basePath);
-        }
+        $this->loader->setBasePath($this->featuresPath . '/../');
+        $this->assertFalse($this->loader->supports('features'));
+        $this->assertFalse($this->loader->supports('tables.feature'));
+        $this->assertTrue($this->loader->supports('features/tables.feature'));
 
-        $actual = [];
-        foreach (array_keys($expected) as $resource) {
-            $actual[$resource] = $this->loader->supports($resource);
-        }
-
-        $this->assertSame($expected, $actual);
-    }
-
-    public function testLoadWithBasePath(): void
-    {
-        $this->loader->setBasePath(self::featuresPath() . '/../');
+        $this->assertTrue($this->loader->supports('features/pystring.feature'));
         $features = $this->loader->load('features/pystring.feature');
         $this->assertCount(1, $features);
         $this->assertEquals('A py string feature', $features[0]->getTitle());
-        $this->assertEquals(self::featuresPath() . DIRECTORY_SEPARATOR . 'pystring.feature', $features[0]->getFile());
+        $this->assertEquals($this->featuresPath . DIRECTORY_SEPARATOR . 'pystring.feature', $features[0]->getFile());
 
-        $this->loader->setBasePath(self::featuresPath());
+        $this->loader->setBasePath($this->featuresPath);
         $features = $this->loader->load('multiline_name.feature');
         $this->assertCount(1, $features);
         $this->assertEquals('multiline', $features[0]->getTitle());
-        $this->assertEquals(self::featuresPath() . DIRECTORY_SEPARATOR . 'multiline_name.feature', $features[0]->getFile());
+        $this->assertEquals($this->featuresPath . DIRECTORY_SEPARATOR . 'multiline_name.feature', $features[0]->getFile());
     }
 }


### PR DESCRIPTION
The master branch is failing static analysis due to changes in recent phpstan versions.

One of these I think is a valid issue that had not been detected previously, though fixing it involved working around a limitation in narrowing the types of arrays that I've reported to phpstan in https://github.com/phpstan/phpstan/issues/14360

The other is to do with type narrowing / confusion in how our LoaderInterface and the GherkinFileLoader are tagged as generics. We were previously making an assumption that wasn't guaranteed to be correct. I've updated the generics tagging to fix this.