### PR TITLE
feat: Add a `getFullText()` method to a StepNode

### DIFF
--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -34,7 +34,7 @@ use function assert;
  * @phpstan-type TStringValueToken array{type: TTokenType, value: string, line: int, deferred: bool}
  * @phpstan-type TNullValueToken array{type: TTokenType, value: null, line: int, deferred: bool}
  * @phpstan-type TTitleToken array{type: TTitleKeyword, value: null|non-empty-string, line: int, deferred: bool, keyword: string, indent: int}
- * @phpstan-type TStepToken array{type: 'Step', value: string, line: int, deferred: bool, keyword_type: string, text: string}
+ * @phpstan-type TStepToken array{type: 'Step', value: string, line: int, deferred: bool, keyword_type: string, text: string, fullText: string}
  * @phpstan-type TTagToken array{type: 'Tag', value: null, line: int, deferred: bool, tags: list<string>}
  * @phpstan-type TTableRowToken array{type: 'TableRow', value: null, line: int, deferred: bool, columns: list<string>}
  * @phpstan-type TDocStringSeparator '"""'|'```'
@@ -671,6 +671,7 @@ class Lexer
         $token = $this->takeToken('Step', $nodeKeyword);
         $token['keyword_type'] = $this->getStepKeywordType($matchedKeyword);
         $token['text'] = $text;
+        $token['fullText'] = $matchedKeyword . $text;
 
         $this->consumeLine();
         $this->allowMultilineArguments = true;

--- a/src/Loader/ArrayLoader.php
+++ b/src/Loader/ArrayLoader.php
@@ -229,7 +229,7 @@ class ArrayLoader extends AbstractLoader
             }
         }
 
-        return new StepNode($hash['type'], $hash['text'], $arguments, $hash['line'], $hash['keyword_type']);
+        return new StepNode($hash['type'], $hash['text'], $arguments, $hash['line'], $hash['keyword_type'], $hash['full_text'] ?? null);
     }
 
     /**

--- a/src/Node/ExampleNode.php
+++ b/src/Node/ExampleNode.php
@@ -168,10 +168,13 @@ class ExampleNode implements ScenarioInterface, NamedScenarioInterface
             $keyword = $outlineStep->getKeyword();
             $keywordType = $outlineStep->getKeywordType();
             $text = $this->replaceTextTokens($outlineStep->getText());
+            // Only replace tokens within the step part of the fullText. Avoids risk of accidentally replacing tokens
+            // in the keyword portion even in unexpected / custom languages.
+            $fullText = $keyword . $this->replaceTextTokens(mb_substr($outlineStep->getFullText(), mb_strlen($keyword)));
             $args = $this->replaceArgumentsTokens($outlineStep->getArguments());
             $line = $outlineStep->getLine();
 
-            $steps[] = new StepNode($keyword, $text, $args, $line, $keywordType);
+            $steps[] = new StepNode($keyword, $text, $args, $line, $keywordType, $fullText);
         }
 
         return $steps;

--- a/src/Node/StepNode.php
+++ b/src/Node/StepNode.php
@@ -23,6 +23,8 @@ class StepNode implements NodeInterface
 {
     private readonly string $keywordType;
 
+    private readonly string $fullText;
+
     /**
      * @param ArgumentInterface[] $arguments
      */
@@ -32,6 +34,7 @@ class StepNode implements NodeInterface
         private readonly array $arguments,
         private readonly int $line,
         ?string $keywordType = null,
+        ?string $fullText = null,
     ) {
         if (count($arguments) > 1) {
             throw new NodeException(sprintf(
@@ -43,6 +46,7 @@ class StepNode implements NodeInterface
         }
 
         $this->keywordType = $keywordType ?: 'Given';
+        $this->fullText = $fullText ?? $keyword . ' ' . $text;
     }
 
     /**
@@ -95,6 +99,18 @@ class StepNode implements NodeInterface
     public function getText()
     {
         return $this->text;
+    }
+
+    /**
+     * Returns the full gherkin text including the keyword.
+     *
+     * Can be used to print a representation of the gherkin for this step, without
+     * needing to know whether the language / keyword requires a space between the
+     * keyword and the following text.
+     */
+    public function getFullText(): string
+    {
+        return $this->fullText;
     }
 
     /**

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -491,7 +491,7 @@ class Parser implements ParserInterface
             }
         }
 
-        return new StepNode($token['value'], trim($token['text']), $arguments, $token['line'], $token['keyword_type']);
+        return new StepNode($token['value'], trim($token['text']), $arguments, $token['line'], $token['keyword_type'], $token['fullText']);
     }
 
     /**
@@ -754,7 +754,8 @@ class Parser implements ParserInterface
             $node->getText(),
             $node->getArguments(),
             $node->getLine(),
-            $keywordType
+            $keywordType,
+            $node->getFullText(),
         );
     }
 

--- a/tests/Cucumber/NDJsonAstParser.php
+++ b/tests/Cucumber/NDJsonAstParser.php
@@ -201,7 +201,8 @@ class NDJsonAstParser
                 $item['text'],
                 $this->getStepArguments($item),
                 $item['location']['line'],
-                trim($item['keyword'])
+                trim($item['keyword']),
+                $item['keyword'] . $item['text'],
             ),
             $items
         );

--- a/tests/Cucumber/expected_variants/gherkin-32/rule_without_name_and_description.feature.expected.yaml
+++ b/tests/Cucumber/expected_variants/gherkin-32/rule_without_name_and_description.feature.expected.yaml
@@ -12,6 +12,7 @@ Behat\Gherkin\Node\FeatureNode:
                     -
                         Behat\Gherkin\Node\StepNode:
                             keywordType: Given
+                            fullText: 'Given text'
                             keyword: 'Given '
                             text: text
                             arguments: []

--- a/tests/Cucumber/expected_variants/legacy/datatables_with_new_lines.feature.expected.yaml
+++ b/tests/Cucumber/expected_variants/legacy/datatables_with_new_lines.feature.expected.yaml
@@ -12,6 +12,7 @@ Behat\Gherkin\Node\FeatureNode:
                     -
                         Behat\Gherkin\Node\StepNode:
                             keywordType: Given
+                            fullText: 'Given 3 lines of poetry on 5 lines'
                             keyword: Given
                             text: '3 lines of poetry on 5 lines'
                             arguments:
@@ -26,6 +27,7 @@ Behat\Gherkin\Node\FeatureNode:
                     -
                         Behat\Gherkin\Node\StepNode:
                             keywordType: Given
+                            fullText: 'Given an example of negative space'
                             keyword: Given
                             text: 'an example of negative space'
                             arguments:

--- a/tests/Cucumber/expected_variants/legacy/descriptions.feature.expected.yaml
+++ b/tests/Cucumber/expected_variants/legacy/descriptions.feature.expected.yaml
@@ -15,6 +15,7 @@ Behat\Gherkin\Node\FeatureNode:
                     -
                         Behat\Gherkin\Node\StepNode:
                             keywordType: Given
+                            fullText: 'Given the minimalism'
                             keyword: Given
                             text: 'the minimalism'
                             arguments: []
@@ -32,6 +33,7 @@ Behat\Gherkin\Node\FeatureNode:
                     -
                         Behat\Gherkin\Node\StepNode:
                             keywordType: Given
+                            fullText: 'Given the minimalism'
                             keyword: Given
                             text: 'the minimalism'
                             arguments: []
@@ -51,6 +53,7 @@ Behat\Gherkin\Node\FeatureNode:
                     -
                         Behat\Gherkin\Node\StepNode:
                             keywordType: Given
+                            fullText: 'Given the minimalism'
                             keyword: Given
                             text: 'the minimalism'
                             arguments: []
@@ -70,6 +73,7 @@ Behat\Gherkin\Node\FeatureNode:
                     -
                         Behat\Gherkin\Node\StepNode:
                             keywordType: Given
+                            fullText: 'Given the minimalism'
                             keyword: Given
                             text: 'the minimalism'
                             arguments: []
@@ -88,6 +92,7 @@ Behat\Gherkin\Node\FeatureNode:
                     -
                         Behat\Gherkin\Node\StepNode:
                             keywordType: Given
+                            fullText: 'Given the minimalism'
                             keyword: Given
                             text: 'the minimalism'
                             arguments: []
@@ -106,6 +111,7 @@ Behat\Gherkin\Node\FeatureNode:
                     -
                         Behat\Gherkin\Node\StepNode:
                             keywordType: Given
+                            fullText: 'Given the minimalism'
                             keyword: Given
                             text: 'the minimalism'
                             arguments: []
@@ -123,6 +129,7 @@ Behat\Gherkin\Node\FeatureNode:
                     -
                         Behat\Gherkin\Node\StepNode:
                             keywordType: Given
+                            fullText: 'Given the minimalism'
                             keyword: Given
                             text: 'the minimalism'
                             arguments: []
@@ -157,6 +164,7 @@ Behat\Gherkin\Node\FeatureNode:
                     -
                         Behat\Gherkin\Node\StepNode:
                             keywordType: Given
+                            fullText: 'Given the minimalism'
                             keyword: Given
                             text: 'the minimalism'
                             arguments: []

--- a/tests/Cucumber/expected_variants/legacy/descriptions_with_comments.feature.expected.yaml
+++ b/tests/Cucumber/expected_variants/legacy/descriptions_with_comments.feature.expected.yaml
@@ -17,6 +17,7 @@ Behat\Gherkin\Node\FeatureNode:
                     -
                         Behat\Gherkin\Node\StepNode:
                             keywordType: Given
+                            fullText: 'Given the minimalism'
                             keyword: Given
                             text: 'the minimalism'
                             arguments: []
@@ -35,6 +36,7 @@ Behat\Gherkin\Node\FeatureNode:
                     -
                         Behat\Gherkin\Node\StepNode:
                             keywordType: Given
+                            fullText: 'Given the minimalism'
                             keyword: Given
                             text: 'the minimalism'
                             arguments: []
@@ -54,6 +56,7 @@ Behat\Gherkin\Node\FeatureNode:
                     -
                         Behat\Gherkin\Node\StepNode:
                             keywordType: Given
+                            fullText: 'Given the minimalism'
                             keyword: Given
                             text: 'the minimalism'
                             arguments: []
@@ -73,6 +76,7 @@ Behat\Gherkin\Node\FeatureNode:
                     -
                         Behat\Gherkin\Node\StepNode:
                             keywordType: Given
+                            fullText: 'Given the minimalism'
                             keyword: Given
                             text: 'the minimalism'
                             arguments: []
@@ -109,6 +113,7 @@ Behat\Gherkin\Node\FeatureNode:
                     -
                         Behat\Gherkin\Node\StepNode:
                             keywordType: Given
+                            fullText: 'Given the minimalism'
                             keyword: Given
                             text: 'the minimalism'
                             arguments: []
@@ -124,6 +129,7 @@ Behat\Gherkin\Node\FeatureNode:
                     -
                         Behat\Gherkin\Node\StepNode:
                             keywordType: Given
+                            fullText: 'Given the minimalism'
                             keyword: Given
                             text: 'the minimalism'
                             arguments: []
@@ -139,6 +145,7 @@ Behat\Gherkin\Node\FeatureNode:
                     -
                         Behat\Gherkin\Node\StepNode:
                             keywordType: Given
+                            fullText: 'Given the minimalism'
                             keyword: Given
                             text: 'the minimalism'
                             arguments: []

--- a/tests/Cucumber/expected_variants/legacy/docstrings.feature.expected.yaml
+++ b/tests/Cucumber/expected_variants/legacy/docstrings.feature.expected.yaml
@@ -12,6 +12,7 @@ Behat\Gherkin\Node\FeatureNode:
                     -
                         Behat\Gherkin\Node\StepNode:
                             keywordType: Given
+                            fullText: 'Given a simple DocString'
                             keyword: Given
                             text: 'a simple DocString'
                             arguments:
@@ -27,6 +28,7 @@ Behat\Gherkin\Node\FeatureNode:
                     -
                         Behat\Gherkin\Node\StepNode:
                             keywordType: Given
+                            fullText: 'Given a DocString with content type'
                             keyword: Given
                             text: 'a DocString with content type'
                             arguments:
@@ -41,6 +43,7 @@ Behat\Gherkin\Node\FeatureNode:
                     -
                         Behat\Gherkin\Node\StepNode:
                             keywordType: Given
+                            fullText: 'And a DocString with wrong indentation'
                             keyword: And
                             text: 'a DocString with wrong indentation'
                             arguments:
@@ -53,6 +56,7 @@ Behat\Gherkin\Node\FeatureNode:
                     -
                         Behat\Gherkin\Node\StepNode:
                             keywordType: Given
+                            fullText: 'And a DocString with alternative separator'
                             keyword: And
                             text: 'a DocString with alternative separator'
                             arguments:
@@ -66,6 +70,7 @@ Behat\Gherkin\Node\FeatureNode:
                     -
                         Behat\Gherkin\Node\StepNode:
                             keywordType: Given
+                            fullText: 'And a DocString with normal separator inside'
                             keyword: And
                             text: 'a DocString with normal separator inside'
                             arguments:
@@ -80,6 +85,7 @@ Behat\Gherkin\Node\FeatureNode:
                     -
                         Behat\Gherkin\Node\StepNode:
                             keywordType: Given
+                            fullText: 'And a DocString with alternative separator inside'
                             keyword: And
                             text: 'a DocString with alternative separator inside'
                             arguments:
@@ -94,6 +100,7 @@ Behat\Gherkin\Node\FeatureNode:
                     -
                         Behat\Gherkin\Node\StepNode:
                             keywordType: Given
+                            fullText: 'And a DocString with escaped separator inside'
                             keyword: And
                             text: 'a DocString with escaped separator inside'
                             arguments:
@@ -108,6 +115,7 @@ Behat\Gherkin\Node\FeatureNode:
                     -
                         Behat\Gherkin\Node\StepNode:
                             keywordType: Given
+                            fullText: 'And a DocString with an escaped alternative separator inside'
                             keyword: And
                             text: 'a DocString with an escaped alternative separator inside'
                             arguments:

--- a/tests/Cucumber/expected_variants/legacy/escaped_pipes.feature.expected.yaml
+++ b/tests/Cucumber/expected_variants/legacy/escaped_pipes.feature.expected.yaml
@@ -14,6 +14,7 @@ Behat\Gherkin\Node\FeatureNode:
                     -
                         Behat\Gherkin\Node\StepNode:
                             keywordType: Given
+                            fullText: 'Given they have arrived'
                             keyword: Given
                             text: 'they have arrived'
                             arguments:
@@ -33,6 +34,7 @@ Behat\Gherkin\Node\FeatureNode:
                     -
                         Behat\Gherkin\Node\StepNode:
                             keywordType: Given
+                            fullText: 'Given they have arrived'
                             keyword: Given
                             text: 'they have arrived'
                             arguments:

--- a/tests/Cucumber/expected_variants/legacy/extra_blank_lines_everywhere.feature.expected.yaml
+++ b/tests/Cucumber/expected_variants/legacy/extra_blank_lines_everywhere.feature.expected.yaml
@@ -19,6 +19,7 @@ Behat\Gherkin\Node\FeatureNode:
                 -
                     Behat\Gherkin\Node\StepNode:
                         keywordType: Given
+                        fullText: 'Given something'
                         keyword: Given
                         text: something
                         arguments: []
@@ -26,6 +27,7 @@ Behat\Gherkin\Node\FeatureNode:
                 -
                     Behat\Gherkin\Node\StepNode:
                         keywordType: Given
+                        fullText: 'And something else'
                         keyword: And
                         text: 'something else'
                         arguments: []
@@ -71,6 +73,7 @@ Behat\Gherkin\Node\FeatureNode:
                     -
                         Behat\Gherkin\Node\StepNode:
                             keywordType: When
+                            fullText: 'When <precondition>'
                             keyword: When
                             text: '<precondition>'
                             arguments: []
@@ -78,6 +81,7 @@ Behat\Gherkin\Node\FeatureNode:
                     -
                         Behat\Gherkin\Node\StepNode:
                             keywordType: Then
+                            fullText: 'Then profit'
                             keyword: Then
                             text: profit
                             arguments: []

--- a/tests/Cucumber/expected_variants/legacy/incomplete_background_2.feature.expected.yaml
+++ b/tests/Cucumber/expected_variants/legacy/incomplete_background_2.feature.expected.yaml
@@ -20,6 +20,7 @@ Behat\Gherkin\Node\FeatureNode:
                     -
                         Behat\Gherkin\Node\StepNode:
                             keywordType: Given
+                            fullText: '* a step'
                             keyword: '*'
                             text: 'a step'
                             arguments: []

--- a/tests/Cucumber/expected_variants/legacy/invalid_language.feature.expected.yaml
+++ b/tests/Cucumber/expected_variants/legacy/invalid_language.feature.expected.yaml
@@ -12,6 +12,7 @@ Behat\Gherkin\Node\FeatureNode:
                     -
                         Behat\Gherkin\Node\StepNode:
                             keywordType: Given
+                            fullText: 'Given the minimalism'
                             keyword: Given
                             text: 'the minimalism'
                             arguments: []

--- a/tests/Cucumber/expected_variants/legacy/padded_example.feature.expected.yaml
+++ b/tests/Cucumber/expected_variants/legacy/padded_example.feature.expected.yaml
@@ -27,6 +27,7 @@ Behat\Gherkin\Node\FeatureNode:
                     -
                         Behat\Gherkin\Node\StepNode:
                             keywordType: Given
+                            fullText: 'Given a <color> ball with:'
                             keyword: Given
                             text: 'a <color> ball with:'
                             arguments:

--- a/tests/Cucumber/expected_variants/legacy/rule_without_name_and_description.feature.expected.yaml
+++ b/tests/Cucumber/expected_variants/legacy/rule_without_name_and_description.feature.expected.yaml
@@ -14,6 +14,7 @@ Behat\Gherkin\Node\FeatureNode:
                     -
                         Behat\Gherkin\Node\StepNode:
                             keywordType: Given
+                            fullText: 'Given text'
                             keyword: Given
                             text: text
                             arguments: []

--- a/tests/Fixtures/etalons/ja_addition.yml
+++ b/tests/Fixtures/etalons/ja_addition.yml
@@ -15,7 +15,7 @@ feature:
       title:    '2つの数の加算について'
       line:     7
       steps:
-        - { keyword_type: 'Given', type: '前提',  text: '50 を入力',         line: 8 }
-        - { keyword_type: 'Given', type: 'かつ',  text: '70 を入力',         line: 9 }
-        - { keyword_type: 'When',  type: 'もし',  text: 'add ボタンを押した',  line: 10 }
-        - { keyword_type: 'Then',  type: 'ならば', text: '結果は 120 を表示',  line: 11 }
+        - { keyword_type: 'Given', type: '前提',  text: '50 を入力',         line: 8, full_text: '前提50 を入力' }
+        - { keyword_type: 'Given', type: 'かつ',  text: '70 を入力',         line: 9, full_text: 'かつ70 を入力' }
+        - { keyword_type: 'When',  type: 'もし',  text: 'add ボタンを押した',  line: 10, full_text: 'もしadd ボタンを押した' }
+        - { keyword_type: 'Then',  type: 'ならば', text: '結果は 120 を表示',  line: 11, full_text: 'ならば結果は 120 を表示' }

--- a/tests/Keywords/CachedArrayKeywordsTest.php
+++ b/tests/Keywords/CachedArrayKeywordsTest.php
@@ -38,9 +38,12 @@ class CachedArrayKeywordsTest extends KeywordsTestCase
 
             if (str_contains($keyword, '<')) {
                 $keyword = mb_substr($keyword, 0, -1);
+                $fullText = $keyword . $text;
+            } else {
+                $fullText = $keyword . ' ' . $text;
             }
 
-            $steps[] = new StepNode($keyword, $text, [], $line++, $keywordType);
+            $steps[] = new StepNode($keyword, $text, [], $line++, $keywordType, $fullText);
         }
 
         return $steps;

--- a/tests/Keywords/CucumberKeywordsTest.php
+++ b/tests/Keywords/CucumberKeywordsTest.php
@@ -36,9 +36,12 @@ class CucumberKeywordsTest extends KeywordsTestCase
         foreach (explode('|', mb_substr($keywords, 2)) as $keyword) {
             if (str_contains($keyword, '<')) {
                 $keyword = mb_substr($keyword, 0, -1);
+                $fullText = $keyword . $text;
+            } else {
+                $fullText = $keyword . ' ' . $text;
             }
 
-            $steps[] = new StepNode($keyword, $text, [], $line++, $keywordType);
+            $steps[] = new StepNode($keyword, $text, [], $line++, $keywordType, $fullText);
         }
 
         return $steps;

--- a/tests/Keywords/DialectKeywordsTest.php
+++ b/tests/Keywords/DialectKeywordsTest.php
@@ -71,7 +71,7 @@ class DialectKeywordsTest extends KeywordsTestCase
                 continue;
             }
 
-            $steps[] = new StepNode(trim($keyword), $text, [], $line++, $keywordType);
+            $steps[] = new StepNode(trim($keyword), $text, [], $line++, $keywordType, $keyword . $text);
         }
 
         return $steps;

--- a/tests/Node/ExampleNodeTest.php
+++ b/tests/Node/ExampleNodeTest.php
@@ -112,4 +112,44 @@ class ExampleNodeTest extends TestCase
         $this->assertInstanceOf(TableNode::class, $args[0]);
         $this->assertEquals('| page | homepage |', $args[0]->getTableAsString());
     }
+
+    public function testCreateExampleStepsInLanguageWithoutSpaceAfterKeyword(): void
+    {
+        // Proves that the fullText is correctly copied to the new steps, with the parameters replaced.
+        $steps = [
+            new StepNode('前提', '<番号> を入力', [], 8, 'Given', '前提<番号> を入力'),
+        ];
+        $table = new ExampleTableNode(
+            [
+                ['番号'],
+                ['30'],
+                ['50'],
+            ],
+            '例',
+        );
+        $outline = new OutlineNode(null, [], $steps, $table, '', 1);
+        $examples = $outline->getExamples();
+
+        $this->assertEquals(
+            [
+                'text' => '30 を入力',
+                'fullText' => '前提30 を入力',
+            ],
+            [
+                'text' => $examples[0]->getSteps()[0]->getText(),
+                'fullText' => $examples[0]->getSteps()[0]->getFullText(),
+            ],
+        );
+
+        $this->assertEquals(
+            [
+                'text' => '50 を入力',
+                'fullText' => '前提50 を入力',
+            ],
+            [
+                'text' => $examples[1]->getSteps()[0]->getText(),
+                'fullText' => $examples[1]->getSteps()[0]->getFullText(),
+            ],
+        );
+    }
 }

--- a/tests/TranslationTest.php
+++ b/tests/TranslationTest.php
@@ -44,7 +44,7 @@ class TranslationTest extends TestCase
                 continue;
             }
 
-            $steps[] = new StepNode(trim($keyword), $text, [], $line++, $keywordType);
+            $steps[] = new StepNode(trim($keyword), $text, [], $line++, $keywordType, $keyword . $text);
         }
 
         return $steps;


### PR DESCRIPTION
This provides a gherkin representation of the step text, including the keyword. This can for example be used by formatters that need to render the step, without them needing to take account of whether the keyword should be followed by a space character in the current language.

The result will be consistent in all gherkin parsing modes.