### PR TITLE
feat: Deprecate FilterInterface, SimpleFilter and friends

### DIFF
--- a/src/Filter/FilterInterface.php
+++ b/src/Filter/FilterInterface.php
@@ -16,6 +16,10 @@ use Behat\Gherkin\Node\ScenarioInterface;
  * Filter interface.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @deprecated see either:
+ *   * FeatureFilterInterface for finding all matching Scenarios within a Feature
+ *   * ComplexFilterInterface to expose a method for checking if a single Scenario matches a filter
  */
 interface FilterInterface extends FeatureFilterInterface
 {
@@ -25,6 +29,8 @@ interface FilterInterface extends FeatureFilterInterface
      * @param ScenarioInterface $scenario Scenario or Outline node instance
      *
      * @return bool
+     *
+     * @deprecated see the interface PHPDoc for more details
      */
     public function isScenarioMatch(ScenarioInterface $scenario);
 }

--- a/src/Filter/LineFilter.php
+++ b/src/Filter/LineFilter.php
@@ -54,6 +54,8 @@ class LineFilter implements FilterInterface
      * @param ScenarioInterface $scenario Scenario or Outline node instance
      *
      * @return bool
+     *
+     * @deprecated see FilterInterface for further information
      */
     public function isScenarioMatch(ScenarioInterface $scenario)
     {

--- a/src/Filter/LineRangeFilter.php
+++ b/src/Filter/LineRangeFilter.php
@@ -61,6 +61,8 @@ class LineRangeFilter implements FilterInterface
      * @param ScenarioInterface $scenario Scenario or Outline node instance
      *
      * @return bool
+     *
+     * @deprecated see FilterInterface for further information
      */
     public function isScenarioMatch(ScenarioInterface $scenario)
     {

--- a/src/Filter/NameFilter.php
+++ b/src/Filter/NameFilter.php
@@ -57,6 +57,8 @@ class NameFilter extends SimpleFilter
      * @param ScenarioInterface $scenario Scenario or Outline node instance
      *
      * @return bool
+     *
+     * @deprecated see FilterInterface for further information
      */
     public function isScenarioMatch(ScenarioInterface $scenario)
     {

--- a/src/Filter/NarrativeFilter.php
+++ b/src/Filter/NarrativeFilter.php
@@ -30,6 +30,9 @@ class NarrativeFilter extends SimpleFilter
         return (bool) preg_match($this->regex, $feature->getDescription() ?? '');
     }
 
+    /**
+     * @deprecated see FilterInterface for further information
+     */
     public function isScenarioMatch(ScenarioInterface $scenario)
     {
         // This filter does not apply to scenarios.

--- a/src/Filter/PathsFilter.php
+++ b/src/Filter/PathsFilter.php
@@ -63,6 +63,9 @@ class PathsFilter extends SimpleFilter
         return false;
     }
 
+    /**
+     * @deprecated see FilterInterface for further information
+     */
     public function isScenarioMatch(ScenarioInterface $scenario)
     {
         // This filter does not apply to scenarios.

--- a/src/Filter/RoleFilter.php
+++ b/src/Filter/RoleFilter.php
@@ -51,6 +51,9 @@ class RoleFilter extends SimpleFilter
         return (bool) preg_match($this->pattern, $feature->getDescription() ?? '');
     }
 
+    /**
+     * @deprecated see FilterInterface for further information
+     */
     public function isScenarioMatch(ScenarioInterface $scenario)
     {
         // This filter does not apply to scenarios.

--- a/src/Filter/SimpleFilter.php
+++ b/src/Filter/SimpleFilter.php
@@ -16,6 +16,8 @@ use Behat\Gherkin\Node\FeatureNode;
  * Abstract filter class.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @deprecated see FilterInterface for further information
  */
 abstract class SimpleFilter implements FilterInterface
 {


### PR DESCRIPTION
Neither Gherkin nor Behat directly use FilterInterface or SimpleFilter.

Behat has one direct call to `NameFilter::isScenarioMatch`, which is used to check whether a Scenario hook should be called by matching against the scenario name and description. This could easily be refactored.

The problem with this API is that it assumes a filter can always check whether a scenario matches based on only the ScenarioNode. This initial assumption proved incorrect back in 2013 when tag filtering was added, because checking tag matches also needs the FeatureNode.

As a result, the FeatureFilterInterface was extracted and a new ComplexFilterInterface added. The old interface was kept for other filters for BC.

The interface means that there is already some inconsistent behaviour in filter implementations:

* Some filters - e.g. `LineFilter` and `TagFilter` - will always return true from `isScenarioMatch` for any Scenario that would be included in the current filtered Features.
* Some filters - e.g. `RoleFilter` and `PathsFilter` - will include a Scenario when filtering the Feature, but are hardcoded to return `false` if a user later calls `isScenarioMatch` for the Scenario.
* `NameFilter` considers the Feature name **and** the Scenario name during `filterFeature`, but only considers the Scenario name during `isScenarioMatch`.

The interface also makes tests more complex. Currently, they have to cover the behaviour of `filterFeature`, `isFeatureMatch`, and `isScenarioMatch` (or assume the relationship between their behaviour). In almost every case, we only actually need `filterFeature`.

More importantly, introducing Rule support (and potentially any future Gherkin changes), changes the fundamental assumptions about which filters need context to match a Scenario. For example, LineFilter and LineRangeFilter will need to check if the Scenario is part of a Rule that matches.

This means they ideally need to become `ComplexFilterInterface` - but it is not possible to implement both interfaces on the same filter because they share the `isScenarioMatch` method name with different signatures.

It is possible to work around this, but it is ugly.

There are very few usecases where an external caller needs to check if a single Scenario matches a filter. In most cases, callers will just use the result of `filterFeature`.

The `isScenarioMatch` is mostly a convenience to support the shared `filterFeature` implementation in `SimpleFilter` but that could easily be an internal abstract method for classes that choose to implement the `FeatureFilterInterface` in that way.

Therefore, I think we should deprecate this interface and its usage, and remove it in the next major.