### PR TITLE
refactor: Refactor filter implementations and tests, cover missed test cases

### DIFF
--- a/src/Filter/TagFilter.php
+++ b/src/Filter/TagFilter.php
@@ -26,16 +26,11 @@ class TagFilter extends ComplexFilter
      */
     protected $filterString;
 
-    /**
-     * @var array{all?: list<array{any: list<array{tag: string, hasTag: bool}>}>, filterString: string}
-     */
-    private array $parsedFilter;
+    private TagFilterMatcher $filterMatcher;
 
     public function __construct(string $filterString)
     {
-        $this->filterString = trim($filterString);
-        $this->parseFilterString();
-
+        $this->filterMatcher = new TagFilterMatcher($filterString);
         // Because `filterString` is protected (and therefore could in theory be modified by a child class at runtime),
         // we need to check if the parsed filter is up to date every time isTagsMatchCondition is called.
         //
@@ -45,83 +40,7 @@ class TagFilter extends ComplexFilter
         //
         // This can all be removed in the next major if we make `filterString` private and/or readonly and remove the
         // normalisation of deprecated syntax.
-        $this->filterString = $this->parsedFilter['filterString'] = implode(
-            '&&',
-            array_map(
-                static fn (array $filterClause) => implode(',',
-                    array_map(
-                        static fn (array $tag) => sprintf(
-                            '%s%s',
-                            $tag['hasTag'] ? '' : '~',
-                            $tag['tag']
-                        ),
-                        $filterClause['any']
-                    )),
-                $this->parsedFilter['all'] ?? [],
-            ),
-        );
-    }
-
-    private function parseFilterString(): void
-    {
-        $this->parsedFilter = [
-            'filterString' => $this->filterString,
-        ];
-
-        if ($this->filterString === '') {
-            return;
-        }
-
-        $hadTagWithWhitespace = false;
-        $hadTagWithoutPrefix = false;
-
-        $this->parsedFilter['all'] = [];
-        foreach (explode('&&', $this->filterString) as $andTags) {
-            $orParts = [];
-            foreach (explode(',', $andTags) as $tag) {
-                $tag = trim($tag);
-
-                // Fix tag expressions where the filter string does not include the `@` prefixes.
-                // e.g. `new TagFilter('wip&&~slow')` rather than `new TagFilter('@wip&&~@slow')`. These were
-                // historically supported, although not officially, and have been reinstated to solve a BC issue.
-                // This syntax is deprecated and will be removed in future.
-                $fixedTag = match (true) {
-                    // Valid - tag filter contains the `@` prefix
-                    str_starts_with($tag, '@'),
-                    str_starts_with($tag, '~@'),
-                    // Valid historical edge case - tag filter contains the `@` prefix, but there is whitespace after the `~`
-                    (bool) preg_match('/^~\s+@/', $tag) => $tag,
-                    // Invalid / legacy cases - insert the missing `@` prefix in the right place
-                    str_starts_with($tag, '~') => '~@' . substr($tag, 1),
-                    default => '@' . $tag,
-                };
-
-                if (str_starts_with($fixedTag, '~')) {
-                    $orParts[] = ['tag' => substr($fixedTag, 1), 'hasTag' => false];
-                } else {
-                    $orParts[] = ['tag' => $fixedTag, 'hasTag' => true];
-                }
-
-                $hadTagWithoutPrefix = $hadTagWithoutPrefix || ($tag !== $fixedTag);
-                $hadTagWithWhitespace = $hadTagWithWhitespace || str_contains($tag, ' ');
-            }
-
-            $this->parsedFilter['all'][] = ['any' => $orParts];
-        }
-
-        if ($hadTagWithWhitespace) {
-            trigger_error(
-                'Tags with whitespace are deprecated and may be removed in a future version',
-                E_USER_DEPRECATED
-            );
-        }
-
-        if ($hadTagWithoutPrefix) {
-            trigger_error(
-                'Filter strings should contain `@` prefixes for tags, e.g. `@wip` rather than `wip`.',
-                E_USER_DEPRECATED
-            );
-        }
+        $this->filterString = $this->filterMatcher->getNormalisedFilterString();
     }
 
     /**
@@ -199,38 +118,12 @@ class TagFilter extends ComplexFilter
      */
     protected function isTagsMatchCondition(array $tags)
     {
-        if ($this->parsedFilter['filterString'] !== $this->filterString) {
+        if ($this->filterMatcher->getNormalisedFilterString() !== $this->filterString) {
             // A child class has modified the filter string since the last call.
-            $this->parseFilterString();
+            $this->filterMatcher = new TagFilterMatcher($this->filterString);
+            $this->filterString = $this->filterMatcher->getNormalisedFilterString();
         }
 
-        if (!isset($this->parsedFilter['all'])) {
-            return true;
-        }
-
-        // If the file was parsed in legacy mode, the `@` prefix will have been removed from the individual tags on the
-        // parsed node. The tags in the filter expression still have their @ so we add the prefix back here if required.
-        // This can be removed once legacy parsing mode is removed.
-        $tags = array_map(
-            static fn (string $tag) => str_starts_with($tag, '@') ? $tag : '@' . $tag,
-            $tags
-        );
-
-        foreach ($this->parsedFilter['all'] as $filterPart) {
-            $satisfiesComma = false;
-
-            foreach ($filterPart['any'] as $tag) {
-                if (in_array($tag['tag'], $tags, true) === $tag['hasTag']) {
-                    $satisfiesComma = true;
-                    break;
-                }
-            }
-
-            if (!$satisfiesComma) {
-                return false;
-            }
-        }
-
-        return true;
+        return $this->filterMatcher->isMatch($tags);
     }
 }

--- a/src/Filter/TagFilterMatcher.php
+++ b/src/Filter/TagFilterMatcher.php
@@ -1,0 +1,154 @@
+<?php
+
+/*
+ * This file is part of the Behat Gherkin Parser.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Gherkin\Filter;
+
+/**
+ * @internal
+ *
+ * @phpstan-type TParsedFilterArray array{all?: list<array{any: list<array{tag: string, hasTag: bool}>}>}
+ */
+final class TagFilterMatcher
+{
+    /**
+     * @var TParsedFilterArray
+     */
+    private readonly array $parsedFilter;
+
+    private readonly string $normalisedFilterString;
+
+    public function __construct(string $filterString)
+    {
+        $this->parsedFilter = $this->parseFilterString(trim($filterString));
+        $this->normalisedFilterString = $this->normaliseFilterString();
+    }
+
+    /**
+     * @return TParsedFilterArray
+     */
+    private function parseFilterString(string $filterString): array
+    {
+        if ($filterString === '') {
+            return [];
+        }
+
+        $hadTagWithWhitespace = false;
+        $hadTagWithoutPrefix = false;
+
+        $filter['all'] = [];
+        foreach (explode('&&', $filterString) as $andTags) {
+            $orParts = [];
+            foreach (explode(',', $andTags) as $tag) {
+                $tag = trim($tag);
+
+                // Fix tag expressions where the filter string does not include the `@` prefixes.
+                // e.g. `new TagFilter('wip&&~slow')` rather than `new TagFilter('@wip&&~@slow')`. These were
+                // historically supported, although not officially, and have been reinstated to solve a BC issue.
+                // This syntax is deprecated and will be removed in future.
+                $fixedTag = match (true) {
+                    // Valid - tag filter contains the `@` prefix
+                    str_starts_with($tag, '@'),
+                    str_starts_with($tag, '~@'),
+                    // Valid historical edge case - tag filter contains the `@` prefix, but there is whitespace after the `~`
+                    (bool) preg_match('/^~\s+@/', $tag) => $tag,
+                    // Invalid / legacy cases - insert the missing `@` prefix in the right place
+                    str_starts_with($tag, '~') => '~@' . substr($tag, 1),
+                    default => '@' . $tag,
+                };
+
+                if (str_starts_with($fixedTag, '~')) {
+                    $orParts[] = ['tag' => substr($fixedTag, 1), 'hasTag' => false];
+                } else {
+                    $orParts[] = ['tag' => $fixedTag, 'hasTag' => true];
+                }
+
+                $hadTagWithoutPrefix = $hadTagWithoutPrefix || ($tag !== $fixedTag);
+                $hadTagWithWhitespace = $hadTagWithWhitespace || str_contains($tag, ' ');
+            }
+
+            $filter['all'][] = ['any' => $orParts];
+        }
+
+        if ($hadTagWithWhitespace) {
+            trigger_error(
+                'Tags with whitespace are deprecated and may be removed in a future version',
+                E_USER_DEPRECATED,
+            );
+        }
+
+        if ($hadTagWithoutPrefix) {
+            trigger_error(
+                'Filter strings should contain `@` prefixes for tags, e.g. `@wip` rather than `wip`.',
+                E_USER_DEPRECATED,
+            );
+        }
+
+        return $filter;
+    }
+
+    private function normaliseFilterString(): string
+    {
+        return implode(
+            '&&',
+            array_map(
+                static fn (array $filterClause) => implode(',',
+                    array_map(
+                        static fn (array $tag) => sprintf(
+                            '%s%s',
+                            $tag['hasTag'] ? '' : '~',
+                            $tag['tag']
+                        ),
+                        $filterClause['any']
+                    )),
+                $this->parsedFilter['all'] ?? [],
+            ),
+        );
+    }
+
+    public function getNormalisedFilterString(): string
+    {
+        return $this->normalisedFilterString;
+    }
+
+    /**
+     * @param array<array-key, string> $tags
+     */
+    public function isMatch(array $tags): bool
+    {
+        if (!isset($this->parsedFilter['all'])) {
+            return true;
+        }
+
+        // If the file was parsed in legacy mode, the `@` prefix will have been removed from the individual tags on the
+        // parsed node. The tags in the filter expression still have their @ so we add the prefix back here if required.
+        // This can be removed once legacy parsing mode is removed.
+        $tags = array_map(
+            static fn (string $tag) => str_starts_with($tag, '@') ? $tag : '@' . $tag,
+            $tags
+        );
+
+        foreach ($this->parsedFilter['all'] as $filterPart) {
+            $satisfiesComma = false;
+
+            foreach ($filterPart['any'] as $tag) {
+                if (in_array($tag['tag'], $tags, true) === $tag['hasTag']) {
+                    $satisfiesComma = true;
+                    break;
+                }
+            }
+
+            if (!$satisfiesComma) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/tests/Filter/ComplexFilterTest.php
+++ b/tests/Filter/ComplexFilterTest.php
@@ -13,49 +13,82 @@ namespace Tests\Behat\Gherkin\Filter;
 use Behat\Gherkin\Filter\ComplexFilter;
 use Behat\Gherkin\Node\FeatureNode;
 use Behat\Gherkin\Node\ScenarioInterface;
-use Behat\Gherkin\Node\ScenarioNode;
 use Closure;
+use PHPUnit\Framework\Attributes\DataProvider;
 use RuntimeException;
 
 class ComplexFilterTest extends FilterTestCase
 {
     public function testFilterFeatureShouldReturnSameInstanceWhenNotFiltering(): void
     {
-        $scenarios = [new ScenarioNode('A scenario', [], [], '', 1)];
-        $originalFeature = new FeatureNode('A feature', null, [], null, $scenarios, '', '', null, 1);
+        $originalFeature = $this->parseFeature(
+            <<<'GHERKIN'
+            Feature: A feature
+              
+              Scenario: A scenario 
+            GHERKIN
+        );
+
         $nonFilteringFilter = $this->createComplexFilter(static fn () => true);
 
-        $filteredFeature = $nonFilteringFilter->filterFeature($originalFeature);
-
-        $this->assertSame($originalFeature, $filteredFeature);
+        $this->assertSame($originalFeature, $nonFilteringFilter->filterFeature($originalFeature));
     }
 
-    public function testFilterFeatureShouldReturnDifferentInstanceWhenFilteringOutAllScenarios(): void
+    /**
+     * @phpstan-return iterable<string, array{FeatureFilterTestFixture, Closure(FeatureNode, ScenarioInterface): bool}>
+     */
+    public static function providerFilterFeatureWhenFiltering(): iterable
     {
-        $scenarios = [new ScenarioNode('A scenario', [], [], '', 1)];
-        $originalFeature = new FeatureNode('A feature', null, [], null, $scenarios, '', '', null, 1);
-        $nonFilteringFilter = $this->createComplexFilter(static fn () => false);
+        yield 'filters out all scenarios' => [
+            FeatureFilterTestFixture::fromCommentedExpectation(
+                <<<'GHERKIN'
+                Feature: A feature
+                  
+                #  Scenario: Scenario 1
+                #    Given something
+                #  
+                #  Scenario: Scenario 2
+                #    Given something  
 
-        $filteredFeature = $nonFilteringFilter->filterFeature($originalFeature);
-
-        $this->assertNotSame($originalFeature, $filteredFeature);
-        $this->assertFalse($filteredFeature->hasScenarios());
-    }
-
-    public function testFilterFeatureShouldReturnDifferentInstanceWhenFilteringScenarios(): void
-    {
-        $scenarios = [
-            $scenario1 = new ScenarioNode('Scenario#1', [], [], '', 1),
-            $scenario2 = new ScenarioNode('Scenario#2', [], [], '', 2),
-            $scenario3 = new ScenarioNode('Scenario#3', [], [], '', 3),
+                GHERKIN, [
+                    'Scenario 1' => false,
+                    'Scenario 2' => false,
+                ]
+            ),
+            static fn () => false,
         ];
-        $originalFeature = new FeatureNode('Feature#1', null, [], null, $scenarios, '', '', null, 1);
-        $nonFilteringFilter = $this->createComplexFilter(static fn ($feature, $scenario) => $scenario !== $scenario2);
 
-        $filteredFeature = $nonFilteringFilter->filterFeature($originalFeature);
+        yield 'partially filters scenarios' => [
+            FeatureFilterTestFixture::fromCommentedExpectation(
+                <<<'GHERKIN'
+                Feature: A feature
+                  With a description
 
-        $this->assertNotSame($originalFeature, $filteredFeature);
-        $this->assertSame([$scenario1, $scenario3], $filteredFeature->getScenarios());
+                #  Scenario: Scenario 1
+                #    Given something
+
+                   Scenario: Scenario 2
+                     Given something  
+                  
+                #  Scenario: Scenario 3
+                #    Given other
+                GHERKIN, [
+                    'Scenario 1' => false,
+                    'Scenario 2' => true,
+                    'Scenario 3' => false,
+                ]
+            ),
+            static fn (FeatureNode $f, ScenarioInterface $s): bool => $s->getTitle() === 'Scenario 2',
+        ];
+    }
+
+    /**
+     * @phpstan-param Closure(FeatureNode, ScenarioInterface): bool $filterFunc
+     */
+    #[DataProvider('providerFilterFeatureWhenFiltering')]
+    public function testFilterFeatureShouldReturnDifferentInstanceWhenFilteringOutAllScenarios(FeatureFilterTestFixture $testCase, callable $filterFunc): void
+    {
+        $this->assertFiltersFeatureAsExpected($testCase, $this->createComplexFilter($filterFunc));
     }
 
     /**

--- a/tests/Filter/FeatureFilterTestFixture.php
+++ b/tests/Filter/FeatureFilterTestFixture.php
@@ -1,0 +1,108 @@
+<?php
+
+/*
+ * This file is part of the Behat Gherkin Parser.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Behat\Gherkin\Filter;
+
+/**
+ * Represents an original Gherkin feature with the expectations of what it should look like after filtering.
+ *
+ * If filters are working correctly, the result of every `filterFeature` operation should be identical to what
+ * we would have parsed if the nodes that don't match the filter had never been present.
+ *
+ * This means that we can express the expected behaviour of a filter as:
+ *
+ *  - A Gherkin feature string to parse as the input to the filter.
+ *  - A Gherkin feature string that, when parsed, should be equivalent to the filtered feature.
+ *
+ * Building assertions in this way avoids us being coupled to the details of how the Parser creates nodes and the
+ * properties they have. It also ensures that filters do not unexpectedly modify the structure or content of nodes
+ * during filtering.
+ *
+ * @phpstan-type TExpectedScenarioMatches array<string, bool>
+ */
+final class FeatureFilterTestFixture
+{
+    /**
+     * The filter is expected to match everything - the filtered result should be identical to re-parsing the original.
+     *
+     * @phpstan-param TExpectedScenarioMatches $expectScenarioMatches
+     */
+    public static function expectingNoFiltering(
+        string $feature,
+        array $expectScenarioMatches,
+    ): self {
+        return new self(
+            originalFeature: $feature,
+            expectedEquivalentFeature: $feature,
+            expectScenarioMatches: $expectScenarioMatches,
+        );
+    }
+
+    /**
+     * The filter is expected to remove some nodes.
+     *
+     * The filtered feature should be identical to what would be parsed if the nodes that don't match were commented out.
+     *
+     * Therefore, we can keep tests clear and concise by providing the expected, commented, result. This method then
+     * un-comments all lines to produce the input feature.
+     *
+     * For example:
+     *
+     *    <<<'GHERKIN'
+     *      Feature: Something
+     *
+     *      #  Scenario: First
+     *      #    Given something
+     *    GHERKIN;
+     *
+     * Will produce a test fixture where the "original feature" is:
+     *
+     *    <<<'GHERKIN'
+     *       Feature: Something
+     *
+     *         Scenario: First
+     *           Given something
+     *     GHERKIN;
+     *
+     * The test parses this as a feature with a single scenario, then asserts that all scenarios were filtered out of
+     * the filtered feature.
+     *
+     * Some filters are based on line numbers. To make the tests clear, you can include line numbering in your feature
+     * string and then pass `stripLineNumbers` to remove those before the feature is parsed. See the LineFilterTest
+     * for examples.
+     *
+     * @phpstan-param TExpectedScenarioMatches $expectScenarioMatches
+     */
+    public static function fromCommentedExpectation(
+        string $expectEquivalentFeature,
+        array $expectScenarioMatches,
+        bool $stripLineNumbers = false,
+    ): self {
+        if ($stripLineNumbers) {
+            $expectEquivalentFeature = (string) preg_replace('/^\d+\s*:/m', '', $expectEquivalentFeature);
+        }
+
+        return new self(
+            originalFeature: (string) preg_replace('/^(\s*)#/m', '$1 ', $expectEquivalentFeature),
+            expectedEquivalentFeature: $expectEquivalentFeature,
+            expectScenarioMatches: $expectScenarioMatches,
+        );
+    }
+
+    /**
+     * @phpstan-param TExpectedScenarioMatches $expectScenarioMatches
+     */
+    public function __construct(
+        public readonly string $originalFeature,
+        public readonly string $expectedEquivalentFeature,
+        public readonly array $expectScenarioMatches,
+    ) {
+    }
+}

--- a/tests/Filter/FeatureFilterTestFixtureTest.php
+++ b/tests/Filter/FeatureFilterTestFixtureTest.php
@@ -1,0 +1,132 @@
+<?php
+
+/*
+ * This file is part of the Behat Gherkin Parser.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Behat\Gherkin\Filter;
+
+use PHPUnit\Framework\TestCase;
+
+class FeatureFilterTestFixtureTest extends TestCase
+{
+    public function testFromCommentedExpectationGeneratesOriginalByUncommenting(): void
+    {
+        $expectedEquivalentFeature = <<<'GHERKIN'
+        Feature: Some feature that has comments to show what should be filtered out
+          As a user
+          
+          
+          Scenario: Assume this matches
+            Given something
+            
+        # Scenario: But this one should not match
+        #   Given other things
+        #   Then OK?
+        
+          Scenario Outline: This should match
+            Examples:
+              | ok           | 
+              | yes          |
+        #     | not matching |
+        GHERKIN;
+
+        $case = FeatureFilterTestFixture::fromCommentedExpectation($expectedEquivalentFeature, []);
+
+        $this->assertSame($expectedEquivalentFeature, $case->expectedEquivalentFeature);
+        $this->assertSame(
+            <<<'GHERKIN'
+            Feature: Some feature that has comments to show what should be filtered out
+              As a user
+              
+              
+              Scenario: Assume this matches
+                Given something
+                
+              Scenario: But this one should not match
+                Given other things
+                Then OK?
+            
+              Scenario Outline: This should match
+                Examples:
+                  | ok           | 
+                  | yes          |
+                  | not matching |
+            GHERKIN,
+            $case->originalFeature,
+        );
+    }
+
+    public function testFromCommentedOriginalOptionallyStripsLineNumbers(): void
+    {
+        $case = FeatureFilterTestFixture::fromCommentedExpectation(
+            <<<'GHERKIN'
+            1 : Feature: Some feature that has comments to show what should be filtered out
+            2 :  As a user
+            4 :  
+            5 :  Scenario: Assume this matches
+            6 :    Given something
+            7 :    
+            8 : # Scenario: But this one should not match
+            9 : #   Given other things
+            10: #   Then OK?
+            GHERKIN,
+            [],
+            stripLineNumbers: true,
+        );
+
+        $this->assertSame(
+            <<<'GHERKIN'
+             Feature: Some feature that has comments to show what should be filtered out
+              As a user
+              
+              Scenario: Assume this matches
+                Given something
+                
+             # Scenario: But this one should not match
+             #   Given other things
+             #   Then OK?
+            GHERKIN,
+            $case->expectedEquivalentFeature,
+        );
+
+        $this->assertSame(
+            <<<'GHERKIN'
+             Feature: Some feature that has comments to show what should be filtered out
+              As a user
+              
+              Scenario: Assume this matches
+                Given something
+                
+               Scenario: But this one should not match
+                 Given other things
+                 Then OK?
+            GHERKIN,
+            $case->originalFeature,
+        );
+    }
+
+    public function testExpectingNoFilteringGivesSameFeatureForSourceAndOriginal(): void
+    {
+        $feature = <<<'GHERKIN'
+        Feature: Some feature that has comments to show what should be filtered out
+          As a user
+          
+          
+          Scenario: Assume this matches
+            Given something
+            
+        # Scenario: This should still be commented in the output
+        #   Not that that would be useful, but just to prove we don't change anything
+        GHERKIN;
+
+        $case = FeatureFilterTestFixture::expectingNoFiltering($feature, []);
+
+        $this->assertSame($feature, $case->expectedEquivalentFeature);
+        $this->assertSame($feature, $case->originalFeature);
+    }
+}

--- a/tests/Filter/FilterTestCase.php
+++ b/tests/Filter/FilterTestCase.php
@@ -11,58 +11,58 @@
 namespace Tests\Behat\Gherkin\Filter;
 
 use Behat\Gherkin\Dialect\CucumberDialectProvider;
+use Behat\Gherkin\Filter\ComplexFilterInterface;
+use Behat\Gherkin\Filter\FeatureFilterInterface;
+use Behat\Gherkin\Filter\FilterInterface;
+use Behat\Gherkin\GherkinCompatibilityMode;
 use Behat\Gherkin\Lexer;
 use Behat\Gherkin\Node\FeatureNode;
 use Behat\Gherkin\Parser;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 abstract class FilterTestCase extends TestCase
 {
-    protected function getParser(): Parser
+    protected function getParser(GherkinCompatibilityMode $mode): Parser
     {
         return new Parser(
             new Lexer(
-                new CucumberDialectProvider()
-            )
+                new CucumberDialectProvider(),
+            ),
+            $mode,
         );
     }
 
-    protected function getGherkinFeature(): string
+    final protected function parseFeature(string $feature): FeatureNode
     {
-        return <<<'GHERKIN'
-        Feature: Long feature with outline
-          Scenario: Scenario#1
-            Given initial step
-            When action occurs
-            Then outcomes should be visible
-
-          Scenario: Scenario#2
-            Given initial step
-            And another initial step
-            When action occurs
-            Then outcomes should be visible
-
-          Scenario Outline: Scenario#3
-            When <action> occurs
-            Then <outcome> should be visible
-
-            @etag1
-            Examples:
-              | action | outcome |
-              | act#1  | out#1   |
-              | act#2  | out#2   |
-
-            @etag2
-            Examples:
-              | action | outcome |
-              | act#3  | out#3   |
-
-        GHERKIN;
+        return $this->getParser(GherkinCompatibilityMode::GHERKIN_32)->parse($feature)
+            ?? throw new \InvalidArgumentException('Could not parse predefined test feature');
     }
 
-    protected function getParsedFeature(): FeatureNode
+    final protected function assertFiltersFeatureAsExpected(FeatureFilterTestFixture $testcase, FeatureFilterInterface $filter): void
     {
-        return $this->getParser()->parse($this->getGherkinFeature())
-            ?? throw new \LogicException('Could not parse predefined feature in getGherkinFeature()');
+        $originalFeature = $this->parseFeature($testcase->originalFeature);
+
+        // First, assert that `isScenarioMatch` matches all scenarios within the feature as expected.
+        // This also ensures that the original feature has been parsed to the expected list of scenarios (e.g. that
+        // anything that was commented in the expected feature has been properly uncommented).
+        $actualScenarioMatches = [];
+        foreach ($originalFeature->getScenarios() as $scenario) {
+            $actualScenarioMatches[$scenario->getTitle()] = match (true) {
+                $filter instanceof FilterInterface => $filter->isScenarioMatch($scenario),
+                $filter instanceof ComplexFilterInterface => $filter->isScenarioMatch($originalFeature, $scenario),
+                default => throw new RuntimeException('Unknown filter type'),
+            };
+        }
+        $this->assertSame($testcase->expectScenarioMatches, $actualScenarioMatches);
+
+        // Then, assert that the result of filtering the feature is identical to parsing an equivalent feature
+        $filteredFeature = $filter->filterFeature($originalFeature);
+
+        $this->assertEquals(
+            $this->parseFeature($testcase->expectedEquivalentFeature),
+            $filteredFeature,
+            'Filtered feature should match the expected equivalent feature'
+        );
     }
 }

--- a/tests/Filter/FilterTestCase.php
+++ b/tests/Filter/FilterTestCase.php
@@ -33,15 +33,15 @@ abstract class FilterTestCase extends TestCase
         );
     }
 
-    final protected function parseFeature(string $feature): FeatureNode
+    final protected function parseFeature(string $feature, ?string $featureFilePath = null): FeatureNode
     {
-        return $this->getParser(GherkinCompatibilityMode::GHERKIN_32)->parse($feature)
+        return $this->getParser(GherkinCompatibilityMode::GHERKIN_32)->parse($feature, $featureFilePath)
             ?? throw new \InvalidArgumentException('Could not parse predefined test feature');
     }
 
-    final protected function assertFiltersFeatureAsExpected(FeatureFilterTestFixture $testcase, FeatureFilterInterface $filter): void
+    final protected function assertFiltersFeatureAsExpected(FeatureFilterTestFixture $testcase, FeatureFilterInterface $filter, ?string $featureFilePath = null): void
     {
-        $originalFeature = $this->parseFeature($testcase->originalFeature);
+        $originalFeature = $this->parseFeature($testcase->originalFeature, $featureFilePath);
 
         // First, assert that `isScenarioMatch` matches all scenarios within the feature as expected.
         // This also ensures that the original feature has been parsed to the expected list of scenarios (e.g. that
@@ -60,7 +60,7 @@ abstract class FilterTestCase extends TestCase
         $filteredFeature = $filter->filterFeature($originalFeature);
 
         $this->assertEquals(
-            $this->parseFeature($testcase->expectedEquivalentFeature),
+            $this->parseFeature($testcase->expectedEquivalentFeature, $featureFilePath),
             $filteredFeature,
             'Filtered feature should match the expected equivalent feature'
         );

--- a/tests/Filter/FilterTestCase.php
+++ b/tests/Filter/FilterTestCase.php
@@ -20,6 +20,7 @@ use Behat\Gherkin\Node\FeatureNode;
 use Behat\Gherkin\Parser;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
+use UnexpectedValueException;
 
 abstract class FilterTestCase extends TestCase
 {
@@ -48,7 +49,13 @@ abstract class FilterTestCase extends TestCase
         // anything that was commented in the expected feature has been properly uncommented).
         $actualScenarioMatches = [];
         foreach ($originalFeature->getScenarios() as $scenario) {
-            $actualScenarioMatches[$scenario->getTitle()] = match (true) {
+            $title = $scenario->getTitle() ?? '';
+
+            if (isset($actualScenarioMatches[$title])) {
+                throw new UnexpectedValueException('Duplicate scenario title in test data: ' . $title);
+            }
+
+            $actualScenarioMatches[$scenario->getTitle() ?? ''] = match (true) {
                 $filter instanceof FilterInterface => $filter->isScenarioMatch($scenario),
                 $filter instanceof ComplexFilterInterface => $filter->isScenarioMatch($originalFeature, $scenario),
                 default => throw new RuntimeException('Unknown filter type'),

--- a/tests/Filter/LineFilterTest.php
+++ b/tests/Filter/LineFilterTest.php
@@ -11,10 +11,8 @@
 namespace Tests\Behat\Gherkin\Filter;
 
 use Behat\Gherkin\Filter\LineFilter;
-use Behat\Gherkin\Node\ExampleTableNode;
 use Behat\Gherkin\Node\FeatureNode;
-use Behat\Gherkin\Node\OutlineNode;
-use Behat\Gherkin\Node\ScenarioNode;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class LineFilterTest extends FilterTestCase
 {
@@ -32,88 +30,262 @@ class LineFilterTest extends FilterTestCase
         $this->assertFalse($filter->isFeatureMatch($feature));
     }
 
-    public function testIsScenarioMatchFilter(): void
+    /**
+     * @phpstan-return iterable<string,array{FeatureFilterTestFixture, int}>
+     */
+    public static function providerFilterFeature(): iterable
     {
-        $scenario = new ScenarioNode(null, [], [], '', 2);
-
-        $filter = new LineFilter(2);
-        $this->assertTrue($filter->isScenarioMatch($scenario));
-
-        $filter = new LineFilter(1);
-        $this->assertFalse($filter->isScenarioMatch($scenario));
-
-        $filter = new LineFilter(5);
-        $this->assertFalse($filter->isScenarioMatch($scenario));
-
-        $outline = new OutlineNode(null, [], [], new ExampleTableNode([], ''), '', 20);
-
-        $filter = new LineFilter(5);
-        $this->assertFalse($filter->isScenarioMatch($outline));
-
-        $filter = new LineFilter(20);
-        $this->assertTrue($filter->isScenarioMatch($outline));
+        yield from self::providerFilterFeatureScenarios();
+        yield from self::providerFilterFeatureOutlineExamples();
     }
 
-    public function testFilterFeatureScenario(): void
+    /**
+     * @phpstan-return iterable<string,array{FeatureFilterTestFixture, int}>
+     */
+    private static function providerFilterFeatureScenarios(): iterable
     {
-        $filter = new LineFilter(2);
-        $feature = $filter->filterFeature($this->getParsedFeature());
-        $this->assertCount(1, $scenarios = $feature->getScenarios());
-        $this->assertSame('Scenario#1', $scenarios[0]->getTitle());
+        yield 'simple feature, exact scenario line number' => [
+            FeatureFilterTestFixture::fromCommentedExpectation(
+                <<<'GHERKIN'
+                1 : Feature: Two scenarios                 
+                2 :   Scenario: Scenario#1                 
+                3 :     Given initial step                 
+                4 :     When action occurs                 
+                5 :     Then outcomes should be visible    
+                6 :                                        
+                7 : #   Scenario: Scenario#2                 
+                8 : #     Given initial step                 
+                9 : #     And another initial step           
+                10: #     When action occurs                 
+                11: #    Then outcomes should be visible     
+                GHERKIN,
+                expectScenarioMatches: [
+                    'Scenario#1' => true,
+                    'Scenario#2' => false,
+                ],
+                stripLineNumbers: true,
+            ),
+            2,
+        ];
 
-        $filter = new LineFilter(7);
-        $feature = $filter->filterFeature($this->getParsedFeature());
-        $this->assertCount(1, $scenarios = $feature->getScenarios());
-        $this->assertSame('Scenario#2', $scenarios[0]->getTitle());
+        yield 'simple feature, other matching line number' => [
+            FeatureFilterTestFixture::fromCommentedExpectation(
+                <<<'GHERKIN'
+                1 : Feature: Two scenarios                 
+                2 : #  Scenario: Scenario#1                 
+                3 : #    Given initial step                 
+                4 : #    When action occurs                 
+                5 : #    Then outcomes should be visible    
+                6 :                                        
+                7 :    Scenario: Scenario#2                 
+                8 :     Given initial step                 
+                9 :     And another initial step           
+                10:     When action occurs                 
+                11:     Then outcomes should be visible     
+                GHERKIN,
+                expectScenarioMatches: [
+                    'Scenario#1' => false,
+                    'Scenario#2' => true,
+                ],
+                stripLineNumbers: true,
+            ),
+            7,
+        ];
 
-        $filter = new LineFilter(5);
-        $feature = $filter->filterFeature($this->getParsedFeature());
-        $this->assertCount(0, $scenarios = $feature->getScenarios());
+        yield 'simple feature, within a scenario (matches nothing)' => [
+            FeatureFilterTestFixture::fromCommentedExpectation(
+                <<<'GHERKIN'
+                1 : Feature: Two scenarios                 
+                2 : #  Scenario: Scenario#1                 
+                3 : #    Given initial step                 
+                4 : #    When action occurs                 
+                5 : #    Then outcomes should be visible    
+                6 : #                                       
+                7 : #   Scenario: Scenario#2                 
+                8 : #    Given initial step                 
+                9 : #    And another initial step           
+                10: #    When action occurs                 
+                11: #    Then outcomes should be visible     
+                GHERKIN,
+                expectScenarioMatches: [
+                    'Scenario#1' => false,
+                    'Scenario#2' => false,
+                ],
+                stripLineNumbers: true,
+            ),
+            5,
+        ];
     }
 
-    public function testFilterFeatureOutline(): void
+    /**
+     * @phpstan-return iterable<string,array{FeatureFilterTestFixture, int}>
+     */
+    private static function providerFilterFeatureOutlineExamples(): iterable
     {
-        $filter = new LineFilter(13);
-        $feature = $filter->filterFeature($this->getParsedFeature());
-        $this->assertCount(1, $scenarios = $feature->getScenarios());
-        $this->assertSame('Scenario#3', $scenarios[0]->getTitle());
-        $this->assertInstanceOf(OutlineNode::class, $scenarios[0]);
-        $this->assertCount(4, $scenarios[0]->getExampleTable()->getRows());
+        yield 'feature with outline, matches line of the Outline' => [
+            FeatureFilterTestFixture::fromCommentedExpectation(
+                <<<'GHERKIN'
+                1 : Feature: Long feature with outline
+                2 : #  Scenario: Scenario#1
+                3 : #   Given initial step
+                4 : #   When action occurs
+                5 : #   Then outcomes should be visible
+                6 : #
+                7 : # Scenario: Scenario#2
+                8 : #   Given initial step
+                9 : #   And another initial step
+                10: #   When action occurs
+                11: #   Then outcomes should be visible
+                12:
+                13:   Scenario Outline: Scenario#3
+                14:     When <action> occurs
+                15:     Then <outcome> should be visible
+                16:
+                17:    @etag1
+                18:    Examples:
+                19:      | action | outcome |
+                20:      | act#1  | out#1   |
+                21:      | act#2  | out#2   |
+                22:
+                23:    @etag2
+                24:    Examples:
+                25:      | action | outcome |
+                26:      | act#3  | out#3   |
+                GHERKIN,
+                expectScenarioMatches: [
+                    'Scenario#1' => false,
+                    'Scenario#2' => false,
+                    'Scenario#3' => true,
+                ],
+                stripLineNumbers: true,
+            ),
+            13,
+        ];
 
-        $filter = new LineFilter(20);
-        $feature = $filter->filterFeature($this->getParsedFeature());
-        $this->assertCount(1, $scenarios = $feature->getScenarios());
-        $this->assertSame('Scenario#3', $scenarios[0]->getTitle());
-        $this->assertInstanceOf(OutlineNode::class, $scenarios[0]);
-        $exampleTableNodes = $scenarios[0]->getExampleTables();
-        $this->assertCount(1, $exampleTableNodes);
-        $this->assertCount(2, $exampleTableNodes[0]->getRows());
-        $this->assertSame([
-            ['action', 'outcome'],
-            ['act#1', 'out#1'],
-        ], $exampleTableNodes[0]->getRows());
-        $this->assertEquals(['etag1'], $exampleTableNodes[0]->getTags());
+        yield 'feature with outline, matches one line in Example table' => [
+            FeatureFilterTestFixture::fromCommentedExpectation(
+                <<<'GHERKIN'
+                1 : Feature: Long feature with outline
+                2 : #  Scenario: Scenario#1
+                3 : #   Given initial step
+                4 : #   When action occurs
+                5 : #   Then outcomes should be visible
+                6 : #
+                7 : # Scenario: Scenario#2
+                8 : #   Given initial step
+                9 : #   And another initial step
+                10: #   When action occurs
+                11: #   Then outcomes should be visible
+                12:
+                13:   Scenario Outline: Scenario#3
+                14:     When <action> occurs
+                15:     Then <outcome> should be visible
+                16:
+                17:    @etag1
+                18:    Examples:
+                19:      | action | outcome |
+                20:      | act#1  | out#1   |
+                21: #     | act#2  | out#2   |
+                22:
+                23: #   @etag2
+                24: #   Examples:
+                25: #     | action | outcome |
+                26: #     | act#3  | out#3   |
+                GHERKIN,
+                expectScenarioMatches: [
+                    'Scenario#1' => false,
+                    'Scenario#2' => false,
+                    'Scenario#3' => true,
+                ],
+                stripLineNumbers: true,
+            ),
+            20,
+        ];
 
-        $filter = new LineFilter(26);
-        $feature = $filter->filterFeature($this->getParsedFeature());
-        $this->assertCount(1, $scenarios = $feature->getScenarios());
-        $this->assertSame('Scenario#3', $scenarios[0]->getTitle());
-        $this->assertInstanceOf(OutlineNode::class, $scenarios[0]);
-        $exampleTableNodes = $scenarios[0]->getExampleTables();
-        $this->assertCount(1, $exampleTableNodes);
-        $this->assertCount(2, $exampleTableNodes[0]->getRows());
-        $this->assertSame([
-            ['action', 'outcome'],
-            ['act#3', 'out#3'],
-        ], $exampleTableNodes[0]->getRows());
-        $this->assertEquals(['etag2'], $exampleTableNodes[0]->getTags());
+        yield 'feature with outline, matches different line in Example table' => [
+            FeatureFilterTestFixture::fromCommentedExpectation(
+                <<<'GHERKIN'
+                1 : Feature: Long feature with outline
+                2 : #  Scenario: Scenario#1
+                3 : #   Given initial step
+                4 : #   When action occurs
+                5 : #   Then outcomes should be visible
+                6 : #
+                7 : # Scenario: Scenario#2
+                8 : #   Given initial step
+                9 : #   And another initial step
+                10: #   When action occurs
+                11: #   Then outcomes should be visible
+                12:
+                13:   Scenario Outline: Scenario#3
+                14:     When <action> occurs
+                15:     Then <outcome> should be visible
+                16:
+                17: #   @etag1
+                18: #   Examples:
+                19: #     | action | outcome |
+                20: #     | act#1  | out#1   |
+                21: #     | act#2  | out#2   |
+                22:
+                23:    @etag2
+                24:    Examples:
+                25:      | action | outcome |
+                26:      | act#3  | out#3   |
+                GHERKIN,
+                expectScenarioMatches: [
+                    'Scenario#1' => false,
+                    'Scenario#2' => false,
+                    'Scenario#3' => true,
+                ],
+                stripLineNumbers: true,
+            ),
+            26,
+        ];
 
-        $filter = new LineFilter(19);
-        $feature = $filter->filterFeature($this->getParsedFeature());
-        $this->assertCount(1, $scenarios = $feature->getScenarios());
-        $this->assertSame('Scenario#3', $scenarios[0]->getTitle());
-        $this->assertInstanceOf(OutlineNode::class, $scenarios[0]);
-        $this->assertCount(1, $scenarios[0]->getExampleTable()->getRows());
-        $this->assertSame([['action', 'outcome']], $scenarios[0]->getExampleTable()->getRows());
+        yield 'feature with outline, matches one Example table header (parses as empty table, matches Scenario)' => [
+            FeatureFilterTestFixture::fromCommentedExpectation(
+                <<<'GHERKIN'
+                1 : Feature: Long feature with outline
+                2 : #  Scenario: Scenario#1
+                3 : #   Given initial step
+                4 : #   When action occurs
+                5 : #   Then outcomes should be visible
+                6 : #
+                7 : # Scenario: Scenario#2
+                8 : #   Given initial step
+                9 : #   And another initial step
+                10: #   When action occurs
+                11: #   Then outcomes should be visible
+                12:
+                13:   Scenario Outline: Scenario#3
+                14:     When <action> occurs
+                15:     Then <outcome> should be visible
+                16:
+                17:    @etag1
+                18:    Examples:
+                19:      | action | outcome |
+                20: #     | act#1  | out#1   |
+                21: #     | act#2  | out#2   |
+                22: #
+                23: #   @etag2
+                24: #   Examples:
+                25: #     | action | outcome |
+                26: #     | act#3  | out#3   |
+                GHERKIN,
+                expectScenarioMatches: [
+                    'Scenario#1' => false,
+                    'Scenario#2' => false,
+                    'Scenario#3' => true,
+                ],
+                stripLineNumbers: true,
+            ),
+            19,
+        ];
+    }
+
+    #[DataProvider('providerFilterFeature')]
+    public function testFilterFeature(FeatureFilterTestFixture $testcase, int $filterLine): void
+    {
+        $this->assertFiltersFeatureAsExpected($testcase, new LineFilter($filterLine));
     }
 }

--- a/tests/Filter/LineFilterTest.php
+++ b/tests/Filter/LineFilterTest.php
@@ -128,38 +128,60 @@ class LineFilterTest extends FilterTestCase
                 1 : Feature: Long feature with outline
                 2 : #  Scenario: Scenario#1
                 3 : #   Given initial step
-                4 : #   When action occurs
-                5 : #   Then outcomes should be visible
-                6 : #
-                7 : # Scenario: Scenario#2
-                8 : #   Given initial step
-                9 : #   And another initial step
-                10: #   When action occurs
-                11: #   Then outcomes should be visible
-                12:
-                13:   Scenario Outline: Scenario#3
-                14:     When <action> occurs
-                15:     Then <outcome> should be visible
-                16:
-                17:    @etag1
-                18:    Examples:
-                19:      | action | outcome |
-                20:      | act#1  | out#1   |
-                21:      | act#2  | out#2   |
-                22:
-                23:    @etag2
-                24:    Examples:
-                25:      | action | outcome |
-                26:      | act#3  | out#3   |
+                4 :
+                5 :   Scenario Outline: Scenario#2
+                6 :     When <action> occurs
+                8 :
+                9 :     @etag1
+                10:     Examples:
+                11:       | action |
+                12:       | act#1  |
+                13:       | act#2  |
+                14:
+                15:    @etag2
+                16:    Examples:
+                17:      | action |
+                18:      | act#3  |
+                19:      | act#4  |
+                GHERKIN,
+                expectScenarioMatches: [
+                    'Scenario#1' => false,
+                    'Scenario#2' => true,
+                ],
+                stripLineNumbers: true,
+            ),
+            5,
+        ];
+
+        yield 'feature with outline, matches a step in the Outline (matches nothing)' => [
+            FeatureFilterTestFixture::fromCommentedExpectation(
+                <<<'GHERKIN'
+                1 : Feature: Long feature with outline
+                2 : #  Scenario: Scenario#1
+                3 : #   Given initial step
+                4 :
+                5 : #  Scenario Outline: Scenario#2
+                6 : #    When <action> occurs
+                7 : #
+                8 : #    @etag1
+                9 : #    Examples:
+                10: #      | action |
+                11: #      | act#1  |
+                12: #      | act#2  |
+                13: #
+                14: #   @etag2
+                15: #   Examples:
+                16: #     | action |
+                17: #     | act#3  |
+                18: #     | act#4  |
                 GHERKIN,
                 expectScenarioMatches: [
                     'Scenario#1' => false,
                     'Scenario#2' => false,
-                    'Scenario#3' => true,
                 ],
                 stripLineNumbers: true,
             ),
-            13,
+            6,
         ];
 
         yield 'feature with outline, matches one line in Example table' => [
@@ -168,38 +190,29 @@ class LineFilterTest extends FilterTestCase
                 1 : Feature: Long feature with outline
                 2 : #  Scenario: Scenario#1
                 3 : #   Given initial step
-                4 : #   When action occurs
-                5 : #   Then outcomes should be visible
-                6 : #
-                7 : # Scenario: Scenario#2
-                8 : #   Given initial step
-                9 : #   And another initial step
-                10: #   When action occurs
-                11: #   Then outcomes should be visible
-                12:
-                13:   Scenario Outline: Scenario#3
-                14:     When <action> occurs
-                15:     Then <outcome> should be visible
-                16:
-                17:    @etag1
-                18:    Examples:
-                19:      | action | outcome |
-                20:      | act#1  | out#1   |
-                21: #     | act#2  | out#2   |
-                22:
-                23: #   @etag2
-                24: #   Examples:
-                25: #     | action | outcome |
-                26: #     | act#3  | out#3   |
+                4 :
+                5 :   Scenario Outline: Scenario#2
+                6 :     When <action> occurs
+                7 :
+                8 :     @etag1
+                9 :     Examples:
+                10:       | action |
+                11: #     | act#1  |
+                12:       | act#2  |
+                13:
+                14: #  @etag2
+                15: #  Examples:
+                16: #    | action |
+                17: #    | act#3  |
+                18: #    | act#4  |
                 GHERKIN,
                 expectScenarioMatches: [
                     'Scenario#1' => false,
-                    'Scenario#2' => false,
-                    'Scenario#3' => true,
+                    'Scenario#2' => true,
                 ],
                 stripLineNumbers: true,
             ),
-            20,
+            12,
         ];
 
         yield 'feature with outline, matches different line in Example table' => [
@@ -208,38 +221,29 @@ class LineFilterTest extends FilterTestCase
                 1 : Feature: Long feature with outline
                 2 : #  Scenario: Scenario#1
                 3 : #   Given initial step
-                4 : #   When action occurs
-                5 : #   Then outcomes should be visible
-                6 : #
-                7 : # Scenario: Scenario#2
-                8 : #   Given initial step
-                9 : #   And another initial step
-                10: #   When action occurs
-                11: #   Then outcomes should be visible
-                12:
-                13:   Scenario Outline: Scenario#3
-                14:     When <action> occurs
-                15:     Then <outcome> should be visible
-                16:
-                17: #   @etag1
-                18: #   Examples:
-                19: #     | action | outcome |
-                20: #     | act#1  | out#1   |
-                21: #     | act#2  | out#2   |
-                22:
-                23:    @etag2
-                24:    Examples:
-                25:      | action | outcome |
-                26:      | act#3  | out#3   |
+                4 :
+                5 :   Scenario Outline: Scenario#2
+                6 :     When <action> occurs
+                7 :
+                8 : #   @etag1
+                9 : #   Examples:
+                10: #     | action |
+                11: #     | act#1  |
+                12: #     | act#2  |
+                13:
+                14:    @etag2
+                15:    Examples:
+                16:      | action |
+                17:      | act#3  |
+                18: #    | act#4  |
                 GHERKIN,
                 expectScenarioMatches: [
                     'Scenario#1' => false,
-                    'Scenario#2' => false,
-                    'Scenario#3' => true,
+                    'Scenario#2' => true,
                 ],
                 stripLineNumbers: true,
             ),
-            26,
+            17,
         ];
 
         yield 'feature with outline, matches one Example table header (parses as empty table, matches Scenario)' => [
@@ -248,38 +252,49 @@ class LineFilterTest extends FilterTestCase
                 1 : Feature: Long feature with outline
                 2 : #  Scenario: Scenario#1
                 3 : #   Given initial step
-                4 : #   When action occurs
-                5 : #   Then outcomes should be visible
-                6 : #
-                7 : # Scenario: Scenario#2
-                8 : #   Given initial step
-                9 : #   And another initial step
-                10: #   When action occurs
-                11: #   Then outcomes should be visible
-                12:
-                13:   Scenario Outline: Scenario#3
-                14:     When <action> occurs
-                15:     Then <outcome> should be visible
-                16:
-                17:    @etag1
-                18:    Examples:
-                19:      | action | outcome |
-                20: #     | act#1  | out#1   |
-                21: #     | act#2  | out#2   |
-                22: #
-                23: #   @etag2
-                24: #   Examples:
-                25: #     | action | outcome |
-                26: #     | act#3  | out#3   |
+                4 :
+                5 :   Scenario Outline: Scenario#2
+                6 :     When <action> occurs
+                7 :
+                8 :    @etag1
+                9 :    Examples:
+                10:       | action | 
+                11: #     | act#1  |
+                12: #
+                13: #   Examples:
+                14: #     | action |
+                15: #     | act#3  |
                 GHERKIN,
                 expectScenarioMatches: [
                     'Scenario#1' => false,
-                    'Scenario#2' => false,
-                    'Scenario#3' => true,
+                    'Scenario#2' => true,
                 ],
                 stripLineNumbers: true,
             ),
-            19,
+            10,
+        ];
+
+        yield 'feature with outline, Examples: line matches nothing' => [
+            // This is current behaviour, but it is slightly unexpected (and inconsistent with the behaviour of matching
+            // either the Outline, or the header of the table)
+            FeatureFilterTestFixture::fromCommentedExpectation(
+                <<<'GHERKIN'
+                1: Feature: Some feature
+                2: 
+                3: #  Scenario Outline: Some scenario
+                4: #    When <action> occurs
+                5: #
+                6: #   @etag1
+                7: #   Examples:
+                8: #     | action | outcome |
+                9: #     | act#1  | out#1   |
+                GHERKIN,
+                expectScenarioMatches: [
+                    'Some scenario' => false,
+                ],
+                stripLineNumbers: true,
+            ),
+            7,
         ];
     }
 

--- a/tests/Filter/LineRangeFilterTest.php
+++ b/tests/Filter/LineRangeFilterTest.php
@@ -331,39 +331,31 @@ class LineRangeFilterTest extends FilterTestCase
                 1 : Feature: Long feature with outline
                 2 : #  Scenario: Scenario#1
                 3 : #    Given initial step
-                4 : #    When action occurs
-                5 : #    Then outcomes should be visible
-                6 : # 
-                7 : #  Scenario: Scenario#2
-                8 : #    Given initial step
-                9 : #    And another initial step
-                10: #    When action occurs
-                11: #    Then outcomes should be visible
-                12:  
-                13:   Scenario Outline: Scenario#3
-                14:     When <action> occurs
-                15:     Then <outcome> should be visible
-                16:  
-                17:     @etag1
-                18:     Examples:
-                19:       | action | outcome |
-                20:       | act#1  | out#1   |
-                21:       | act#2  | out#2   |
-                22:  
-                23: #    @etag2
-                24: #    Examples:
-                25: #      | action | outcome |
-                26: #      | act#3  | out#3   |
+                4 : # 
+                5 :  
+                6 :   Scenario Outline: Outline#1
+                7 :     When <action> occurs
+                8 :     Then <outcome> should be visible
+                9 :  
+                10:     @etag1
+                11:     Examples:
+                12:       | action | outcome |
+                13:       | act#1  | out#1   |
+                14:       | act#2  | out#2   |
+                15:  
+                16: #    @etag2
+                17: #    Examples:
+                18: #      | action | outcome |
+                19: #      | act#3  | out#3   |
                 GHERKIN,
                 expectScenarioMatches: [
                     'Scenario#1' => false,
-                    'Scenario#2' => false,
-                    'Scenario#3' => true,
+                    'Outline#1' => true,
                 ],
                 stripLineNumbers: true,
             ),
+            10,
             16,
-            21,
         ];
 
         yield 'feature with outline, range includes both tables' => [
@@ -372,39 +364,31 @@ class LineRangeFilterTest extends FilterTestCase
                 1 : Feature: Long feature with outline
                 2 : #  Scenario: Scenario#1
                 3 : #    Given initial step
-                4 : #    When action occurs
-                5 : #    Then outcomes should be visible
-                6 : #
-                7 : #  Scenario: Scenario#2
-                8 : #    Given initial step
-                9 : #    And another initial step
-                10: #    When action occurs
-                11: #    Then outcomes should be visible
-                12: 
-                13:   Scenario Outline: Scenario#3
-                14:     When <action> occurs
-                15:     Then <outcome> should be visible
-                16: 
-                17:     @etag1
-                18:     Examples:
-                19:       | action | outcome |
-                20:       | act#1  | out#1   |
-                21:       | act#2  | out#2   |
-                22: 
-                23:     @etag2
-                24:     Examples:
-                25:       | action | outcome |
-                26:       | act#3  | out#3   |
+                4 : # 
+                5 :  
+                6 :   Scenario Outline: Outline#1
+                7 :     When <action> occurs
+                8 :     Then <outcome> should be visible
+                9 :  
+                10:     @etag1
+                11:     Examples:
+                12:       | action | outcome |
+                13:       | act#1  | out#1   |
+                14:       | act#2  | out#2   |
+                15:  
+                16:     @etag2
+                17:     Examples:
+                18:       | action | outcome |
+                19:       | act#3  | out#3   |
                 GHERKIN,
                 expectScenarioMatches: [
                     'Scenario#1' => false,
-                    'Scenario#2' => false,
-                    'Scenario#3' => true,
+                    'Outline#1' => true,
                 ],
                 stripLineNumbers: true,
             ),
-            16,
-            26,
+            9,
+            19,
         ];
 
         yield 'feature with outline, range includes one table' => [
@@ -413,39 +397,31 @@ class LineRangeFilterTest extends FilterTestCase
                 1 : Feature: Long feature with outline
                 2 : #  Scenario: Scenario#1
                 3 : #    Given initial step
-                4 : #    When action occurs
-                5 : #    Then outcomes should be visible
-                6 : #
-                7 : #  Scenario: Scenario#2
-                8 : #    Given initial step
-                9 : #    And another initial step
-                10: #    When action occurs
-                11: #    Then outcomes should be visible
-                12: 
-                13:   Scenario Outline: Scenario#3
-                14:     When <action> occurs
-                15:     Then <outcome> should be visible
-                16: 
-                17: #    @etag1
-                18: #    Examples:
-                19: #      | action | outcome |
-                20: #      | act#1  | out#1   |
-                21: #      | act#2  | out#2   |
-                22: 
-                23:     @etag2
-                24:     Examples:
-                25:       | action | outcome |
-                26:       | act#3  | out#3   |
+                4 : # 
+                5 :  
+                6 :   Scenario Outline: Outline#1
+                7 :     When <action> occurs
+                8 :     Then <outcome> should be visible
+                9 :  
+                10: #    @etag1
+                11: #    Examples:
+                12: #      | action | outcome |
+                13: #      | act#1  | out#1   |
+                14: #      | act#2  | out#2   |
+                15:  
+                16:     @etag2
+                17:     Examples:
+                18:       | action | outcome |
+                19:       | act#3  | out#3   |
                 GHERKIN,
                 expectScenarioMatches: [
                     'Scenario#1' => false,
-                    'Scenario#2' => false,
-                    'Scenario#3' => true,
+                    'Outline#1' => true,
                 ],
                 stripLineNumbers: true,
             ),
-            25,
-            26,
+            18,
+            19,
         ];
 
         yield 'feature with outline, range includes multiple partial tables' => [
@@ -454,39 +430,64 @@ class LineRangeFilterTest extends FilterTestCase
                 1 : Feature: Long feature with outline
                 2 : #  Scenario: Scenario#1
                 3 : #    Given initial step
-                4 : #    When action occurs
-                5 : #    Then outcomes should be visible
-                6 : #
-                7 : #  Scenario: Scenario#2
-                8 : #    Given initial step
-                9 : #    And another initial step
-                10: #    When action occurs
-                11: #    Then outcomes should be visible
-                12: 
-                13:   Scenario Outline: Scenario#3
-                14:     When <action> occurs
-                15:     Then <outcome> should be visible
-                16: 
-                17:     @etag1
-                18:     Examples:
-                19:       | action | outcome |
-                20: #      | act#1  | out#1   |
-                21:       | act#2  | out#2   |
-                22: 
-                23:     @etag2
-                24:     Examples:
-                25:       | action | outcome |
-                26:       | act#3  | out#3   |
+                4 : # 
+                5 :  
+                6 :   Scenario Outline: Outline#1
+                7 :     When <action> occurs
+                8 :     Then <outcome> should be visible
+                9 :  
+                10:     @etag1
+                11:     Examples:
+                12:       | action | outcome |
+                13: #     | act#1  | out#1   |
+                14:       | act#2  | out#2   |
+                15:  
+                16:     @etag2
+                17:     Examples:
+                18:       | action | outcome |
+                19:       | act#3  | out#3   |
                 GHERKIN,
                 expectScenarioMatches: [
                     'Scenario#1' => false,
-                    'Scenario#2' => false,
-                    'Scenario#3' => true,
+                    'Outline#1' => true,
                 ],
                 stripLineNumbers: true,
             ),
-            21,
+            14,
             '*',
+        ];
+
+        yield 'feature with outline, range is one table row' => [
+            FeatureFilterTestFixture::fromCommentedExpectation(
+                <<<'GHERKIN'
+                1 : Feature: Long feature with outline
+                2 : #  Scenario: Scenario#1
+                3 : #    Given initial step
+                4 : # 
+                5 :  
+                6 :   Scenario Outline: Outline#1
+                7 :     When <action> occurs
+                8 :     Then <outcome> should be visible
+                9 :   
+                10:      @etag1
+                11:      Examples:
+                12:        | action | outcome |
+                13:        | act#1  | out#1   |
+                14: #      | act#2  | out#2   |
+                15: # 
+                16: #    @etag2
+                17: #    Examples:
+                18: #      | action | outcome |
+                19: #      | act#3  | out#3   |
+                GHERKIN,
+                expectScenarioMatches: [
+                    'Scenario#1' => false,
+                    'Outline#1' => true,
+                ],
+                stripLineNumbers: true,
+            ),
+            13,
+            13,
         ];
     }
 
@@ -499,36 +500,73 @@ class LineRangeFilterTest extends FilterTestCase
         $this->assertFiltersFeatureAsExpected($testcase, new LineRangeFilter($filterMinLine, $filterMaxLine));
     }
 
-    public function testFilterFeatureLeavesEmptyOutlineIfOnlyOutlineInRange(): void
+    /**
+     * @return iterable<string, array{string, int, int}>
+     */
+    public static function providerFeaturesThatLeaveEmptyOutline(): iterable
     {
-        // Edge case: If the range includes the Outline: line but none of the Examples: tables, the filtered feature
-        // will have an empty Outline. We can't prove this with the normal test, because the parser converts an empty
-        // Outline to a Scenario node.
-        $feature = $this->parseFeature(
+        $fixture = FeatureFilterTestFixture::fromCommentedExpectation(
             <<<'GHERKIN'
-            Feature: Long feature with outline
-              Scenario: Scenario#1
-                Given initial step
-                When action occurs
-                Then outcomes should be visible
-                
-              Scenario: Scenario#2
-                Given initial step
-                And another initial step
-                When action occurs
-                Then outcomes should be visible
-
-              Scenario Outline: Scenario#3
-                When <action> occurs
-                Then <outcome> should be visible
-                
-                Examples: 
-                  | action | outcome  |
-                  | click  | something|
-            GHERKIN
+            1 : Feature: Long feature with outline
+            2 :   Scenario: Scenario#1
+            3 :     Given initial step
+            4 :  
+            5 :  
+            6 :   Scenario Outline: Outline#1
+            7 :     When <action> occurs
+            8 :     Then <outcome> should be visible
+            9 :   
+            10:      @etag1
+            11:      Examples: First set
+            12:        | action | outcome |
+            13:        | act#1  | out#1   |
+            14:        | act#2  | out#2   |
+            15:  
+            16:     @etag2
+            17:      Examples: Second set
+            18:        | action | outcome |
+            19:        | act#3  | out#3   |
+            GHERKIN,
+            expectScenarioMatches: [
+                'Scenario#1' => false,
+                'Outline#1' => true,
+            ],
+            stripLineNumbers: true,
         );
 
-        $filter = new LineRangeFilter(12, 14);
+        yield 'line range includes Outline: but no tables' => [
+            $fixture->originalFeature,
+            6,
+            9,
+        ];
+
+        yield 'line range includes Outline: and Examples: but no table rows' => [
+            $fixture->originalFeature,
+            6,
+            11,
+        ];
+
+        yield 'line range includes Outline: through to table header, but no table rows' => [
+            // This is inconsistent with LineFilter, where matching the table header row keeps the Outline
+            // with an empty table (containing only the header row).
+            $fixture->originalFeature,
+            6,
+            12,
+        ];
+    }
+
+    #[DataProvider('providerFeaturesThatLeaveEmptyOutline')]
+    public function testFilterFeatureLeavesEmptyOutlineIfNoTableRowsInRange(
+        string $originalFeature,
+        int $filterMinLine,
+        int $filterMaxLine,
+    ): void {
+        // Edge case: If the range includes the Outline: line but none of the Examples: table rows, the filtered feature
+        // will have an empty Outline. We can't prove this with the normal test, because the parser converts an empty
+        // Outline to a Scenario node.
+        $feature = $this->parseFeature($originalFeature);
+
+        $filter = new LineRangeFilter($filterMinLine, $filterMaxLine);
         $filtered = $filter->filterFeature($feature);
 
         $this->assertTrue($filtered->hasScenarios(), 'Feature still has scenarios');

--- a/tests/Filter/LineRangeFilterTest.php
+++ b/tests/Filter/LineRangeFilterTest.php
@@ -293,6 +293,31 @@ class LineRangeFilterTest extends FilterTestCase
             5,
             6,
         ];
+
+        yield 'simple feature, range ends with "*"' => [
+            FeatureFilterTestFixture::fromCommentedExpectation(
+                <<<'GHERKIN'
+                1 : Feature: Two scenarios
+                2 : #  Scenario: Scenario#1
+                3 : #    Given initial step
+                4 : #    When action occurs
+                5 : #    Then outcomes should be visible
+                6 : 
+                7 :   Scenario: Scenario#2
+                8 :     Given initial step
+                9 :     And another initial step
+                10:     When action occurs
+                11:     Then outcomes should be visible
+                GHERKIN,
+                expectScenarioMatches: [
+                    'Scenario#1' => false,
+                    'Scenario#2' => true,
+                ],
+                stripLineNumbers: true,
+            ),
+            5,
+            '*',
+        ];
     }
 
     /**
@@ -421,6 +446,47 @@ class LineRangeFilterTest extends FilterTestCase
             ),
             25,
             26,
+        ];
+
+        yield 'feature with outline, range includes multiple partial tables' => [
+            FeatureFilterTestFixture::fromCommentedExpectation(
+                <<<'GHERKIN'
+                1 : Feature: Long feature with outline
+                2 : #  Scenario: Scenario#1
+                3 : #    Given initial step
+                4 : #    When action occurs
+                5 : #    Then outcomes should be visible
+                6 : #
+                7 : #  Scenario: Scenario#2
+                8 : #    Given initial step
+                9 : #    And another initial step
+                10: #    When action occurs
+                11: #    Then outcomes should be visible
+                12: 
+                13:   Scenario Outline: Scenario#3
+                14:     When <action> occurs
+                15:     Then <outcome> should be visible
+                16: 
+                17:     @etag1
+                18:     Examples:
+                19:       | action | outcome |
+                20: #      | act#1  | out#1   |
+                21:       | act#2  | out#2   |
+                22: 
+                23:     @etag2
+                24:     Examples:
+                25:       | action | outcome |
+                26:       | act#3  | out#3   |
+                GHERKIN,
+                expectScenarioMatches: [
+                    'Scenario#1' => false,
+                    'Scenario#2' => false,
+                    'Scenario#3' => true,
+                ],
+                stripLineNumbers: true,
+            ),
+            21,
+            '*',
         ];
     }
 

--- a/tests/Filter/LineRangeFilterTest.php
+++ b/tests/Filter/LineRangeFilterTest.php
@@ -11,10 +11,8 @@
 namespace Tests\Behat\Gherkin\Filter;
 
 use Behat\Gherkin\Filter\LineRangeFilter;
-use Behat\Gherkin\Node\ExampleTableNode;
 use Behat\Gherkin\Node\FeatureNode;
 use Behat\Gherkin\Node\OutlineNode;
-use Behat\Gherkin\Node\ScenarioNode;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 class LineRangeFilterTest extends FilterTestCase
@@ -47,117 +45,433 @@ class LineRangeFilterTest extends FilterTestCase
     }
 
     /**
-     * @return iterable<array{numeric-string, numeric-string|'*', int}>
+     * @phpstan-return iterable<string,array{FeatureFilterTestFixture, int, int|"*"}>
      */
-    public static function scenarioLineRangeProvider(): iterable
+    public static function providerFilterFeature(): iterable
     {
-        return [
-            ['1', '2', 1],
-            ['1', '*', 2],
-            ['2', '2', 1],
-            ['2', '*', 2],
-            ['3', '3', 1],
-            ['3', '*', 1],
-            ['1', '1', 0],
-            ['4', '4', 0],
-            ['4', '*', 0],
+        yield from self::providerFilterFeatureScenarioLineRange();
+        yield from self::providerFilterFeatureScenarioExamples();
+        yield from self::providerFilterFeatureOutlineExamples();
+    }
+
+    /**
+     * @phpstan-return iterable<string,array{FeatureFilterTestFixture, int, int|"*"}>
+     */
+    private static function providerFilterFeatureScenarioLineRange(): iterable
+    {
+        yield 'scenario starts on last line of range' => [
+            FeatureFilterTestFixture::fromCommentedExpectation(
+                <<<'GHERKIN'
+                1:   Feature:
+                2:     Scenario: Sample Scenario
+                3: #   Scenario Outline: Sample Outline
+                GHERKIN,
+                expectScenarioMatches: [
+                    'Sample Scenario' => true,
+                    'Sample Outline' => false,
+                ],
+                stripLineNumbers: true,
+            ),
+            1,
+            2,
+        ];
+
+        yield 'range covers entire file (*)' => [
+            FeatureFilterTestFixture::fromCommentedExpectation(
+                <<<'GHERKIN'
+                1:   Feature:
+                2:     Scenario: Sample Scenario
+                3:     Scenario Outline: Sample Outline
+                GHERKIN,
+                expectScenarioMatches: [
+                    'Sample Scenario' => true,
+                    'Sample Outline' => true,
+                ],
+                stripLineNumbers: true,
+            ),
+            1,
+            '*',
+        ];
+
+        yield 'single-line range is Scenario line' => [
+            FeatureFilterTestFixture::fromCommentedExpectation(
+                <<<'GHERKIN'
+                1:   Feature:
+                2:     Scenario: Sample Scenario
+                3: #   Scenario Outline: Sample Outline
+                GHERKIN,
+                expectScenarioMatches: [
+                    'Sample Scenario' => true,
+                    'Sample Outline' => false,
+                ],
+                stripLineNumbers: true,
+            ),
+            2,
+            2,
+        ];
+
+        yield 'range runs from Scenario line to EOF' => [
+            FeatureFilterTestFixture::fromCommentedExpectation(
+                <<<'GHERKIN'
+                1:   Feature:
+                2:     Scenario: Sample Scenario
+                3:     Scenario Outline: Sample Outline
+                GHERKIN,
+                expectScenarioMatches: [
+                    'Sample Scenario' => true,
+                    'Sample Outline' => true,
+                ],
+                stripLineNumbers: true,
+            ),
+            2,
+            '*',
+        ];
+
+        yield 'single-line range is Outline line' => [
+            FeatureFilterTestFixture::fromCommentedExpectation(
+                <<<'GHERKIN'
+                1:   Feature:
+                2: #  Scenario: Sample Scenario
+                3:    Scenario Outline: Sample Outline
+                GHERKIN,
+                expectScenarioMatches: [
+                    'Sample Scenario' => false,
+                    'Sample Outline' => true,
+                ],
+                stripLineNumbers: true,
+            ),
+            3,
+            3,
+        ];
+
+        yield 'range runs from Outline to EOF' => [
+            FeatureFilterTestFixture::fromCommentedExpectation(
+                <<<'GHERKIN'
+                1:   Feature:
+                2: #  Scenario: Sample Scenario
+                3:    Scenario Outline: Sample Outline
+                GHERKIN,
+                expectScenarioMatches: [
+                    'Sample Scenario' => false,
+                    'Sample Outline' => true,
+                ],
+                stripLineNumbers: true,
+            ),
+            3,
+            '*',
+        ];
+
+        yield 'range only matches the Feature line' => [
+            // No scenarios match, even though the feature itself will pass isFeatureMatch.
+            FeatureFilterTestFixture::fromCommentedExpectation(
+                <<<'GHERKIN'
+                1:   Feature:
+                2: #  Scenario: Sample Scenario
+                3: #  Scenario Outline: Sample Outline
+                GHERKIN,
+                expectScenarioMatches: [
+                    'Sample Scenario' => false,
+                    'Sample Outline' => false,
+                ],
+                stripLineNumbers: true,
+            ),
+            1,
+            1,
+        ];
+
+        yield 'range is beyond EOF' => [
+            FeatureFilterTestFixture::fromCommentedExpectation(
+                <<<'GHERKIN'
+                1:   Feature:
+                2: #  Scenario: Sample Scenario
+                3: #  Scenario Outline: Sample Outline
+                GHERKIN,
+                expectScenarioMatches: [
+                    'Sample Scenario' => false,
+                    'Sample Outline' => false,
+                ],
+                stripLineNumbers: true,
+            ),
+            4,
+            4,
+        ];
+
+        yield 'range starts at EOF and runs to "*"' => [
+            FeatureFilterTestFixture::fromCommentedExpectation(
+                <<<'GHERKIN'
+                1:   Feature:
+                2: #  Scenario: Sample Scenario
+                3: #  Scenario Outline: Sample Outline
+                GHERKIN,
+                expectScenarioMatches: [
+                    'Sample Scenario' => false,
+                    'Sample Outline' => false,
+                ],
+                stripLineNumbers: true,
+            ),
+            4,
+            '*',
         ];
     }
 
     /**
-     * @param numeric-string $filterMinLine
-     * @param numeric-string|'*' $filterMaxLine
+     * @phpstan-return iterable<string,array{FeatureFilterTestFixture, int, int|"*"}>
      */
-    #[DataProvider('scenarioLineRangeProvider')]
-    public function testIsScenarioMatchFilter(string $filterMinLine, string $filterMaxLine, int $expectedNumberOfMatches): void
+    private static function providerFilterFeatureScenarioExamples(): iterable
     {
-        $scenario = new ScenarioNode(null, [], [], '', 2);
-        $outline = new OutlineNode(null, [], [], [new ExampleTableNode([], '')], '', 3);
+        yield 'simple feature, range includes scenario line number' => [
+            FeatureFilterTestFixture::fromCommentedExpectation(
+                <<<'GHERKIN'
+                1 : Feature: Two scenarios
+                2 :   Scenario: Scenario#1
+                3 :     Given initial step
+                4 :     When action occurs
+                5 :     Then outcomes should be visible
+                6 : 
+                7 : #  Scenario: Scenario#2
+                8 : #    Given initial step
+                9 : #    And another initial step
+                10: #    When action occurs
+                11: #    Then outcomes should be visible
+                GHERKIN,
+                expectScenarioMatches: [
+                    'Scenario#1' => true,
+                    'Scenario#2' => false,
+                ],
+                stripLineNumbers: true,
+            ),
+            1,
+            3,
+        ];
 
-        $filter = new LineRangeFilter($filterMinLine, $filterMaxLine);
-        $this->assertEquals(
-            $expectedNumberOfMatches,
-            (int) $filter->isScenarioMatch($scenario) + (int) $filter->isScenarioMatch($outline)
+        yield 'simple feature, range includes other scenario line number' => [
+            FeatureFilterTestFixture::fromCommentedExpectation(
+                <<<'GHERKIN'
+                1 : Feature: Two scenarios
+                2 : #  Scenario: Scenario#1
+                3 : #    Given initial step
+                4 : #    When action occurs
+                5 : #    Then outcomes should be visible
+                6 : 
+                7 :   Scenario: Scenario#2
+                8 :     Given initial step
+                9 :     And another initial step
+                10:     When action occurs
+                11:     Then outcomes should be visible
+                GHERKIN,
+                expectScenarioMatches: [
+                    'Scenario#1' => false,
+                    'Scenario#2' => true,
+                ],
+                stripLineNumbers: true,
+            ),
+            5,
+            9,
+        ];
+
+        yield 'simple feature, range does not include any Scenario: line' => [
+            FeatureFilterTestFixture::fromCommentedExpectation(
+                <<<'GHERKIN'
+                1 : Feature: Two scenarios
+                2 : #  Scenario: Scenario#1
+                3 : #    Given initial step
+                4 : #    When action occurs
+                5 : #    Then outcomes should be visible
+                6 : #
+                7 : #  Scenario: Scenario#2
+                8 : #    Given initial step
+                9 : #    And another initial step
+                10: #    When action occurs
+                11: #    Then outcomes should be visible
+                GHERKIN,
+                expectScenarioMatches: [
+                    'Scenario#1' => false,
+                    'Scenario#2' => false,
+                ],
+                stripLineNumbers: true,
+            ),
+            5,
+            6,
+        ];
+    }
+
+    /**
+     * @phpstan-return iterable<string,array{FeatureFilterTestFixture, int, int|"*"}>
+     */
+    private static function providerFilterFeatureOutlineExamples(): iterable
+    {
+        yield 'feature with outline, range includes one complete table' => [
+            FeatureFilterTestFixture::fromCommentedExpectation(
+                <<<'GHERKIN'
+                1 : Feature: Long feature with outline
+                2 : #  Scenario: Scenario#1
+                3 : #    Given initial step
+                4 : #    When action occurs
+                5 : #    Then outcomes should be visible
+                6 : # 
+                7 : #  Scenario: Scenario#2
+                8 : #    Given initial step
+                9 : #    And another initial step
+                10: #    When action occurs
+                11: #    Then outcomes should be visible
+                12:  
+                13:   Scenario Outline: Scenario#3
+                14:     When <action> occurs
+                15:     Then <outcome> should be visible
+                16:  
+                17:     @etag1
+                18:     Examples:
+                19:       | action | outcome |
+                20:       | act#1  | out#1   |
+                21:       | act#2  | out#2   |
+                22:  
+                23: #    @etag2
+                24: #    Examples:
+                25: #      | action | outcome |
+                26: #      | act#3  | out#3   |
+                GHERKIN,
+                expectScenarioMatches: [
+                    'Scenario#1' => false,
+                    'Scenario#2' => false,
+                    'Scenario#3' => true,
+                ],
+                stripLineNumbers: true,
+            ),
+            16,
+            21,
+        ];
+
+        yield 'feature with outline, range includes both tables' => [
+            FeatureFilterTestFixture::fromCommentedExpectation(
+                <<<'GHERKIN'
+                1 : Feature: Long feature with outline
+                2 : #  Scenario: Scenario#1
+                3 : #    Given initial step
+                4 : #    When action occurs
+                5 : #    Then outcomes should be visible
+                6 : #
+                7 : #  Scenario: Scenario#2
+                8 : #    Given initial step
+                9 : #    And another initial step
+                10: #    When action occurs
+                11: #    Then outcomes should be visible
+                12: 
+                13:   Scenario Outline: Scenario#3
+                14:     When <action> occurs
+                15:     Then <outcome> should be visible
+                16: 
+                17:     @etag1
+                18:     Examples:
+                19:       | action | outcome |
+                20:       | act#1  | out#1   |
+                21:       | act#2  | out#2   |
+                22: 
+                23:     @etag2
+                24:     Examples:
+                25:       | action | outcome |
+                26:       | act#3  | out#3   |
+                GHERKIN,
+                expectScenarioMatches: [
+                    'Scenario#1' => false,
+                    'Scenario#2' => false,
+                    'Scenario#3' => true,
+                ],
+                stripLineNumbers: true,
+            ),
+            16,
+            26,
+        ];
+
+        yield 'feature with outline, range includes one table' => [
+            FeatureFilterTestFixture::fromCommentedExpectation(
+                <<<'GHERKIN'
+                1 : Feature: Long feature with outline
+                2 : #  Scenario: Scenario#1
+                3 : #    Given initial step
+                4 : #    When action occurs
+                5 : #    Then outcomes should be visible
+                6 : #
+                7 : #  Scenario: Scenario#2
+                8 : #    Given initial step
+                9 : #    And another initial step
+                10: #    When action occurs
+                11: #    Then outcomes should be visible
+                12: 
+                13:   Scenario Outline: Scenario#3
+                14:     When <action> occurs
+                15:     Then <outcome> should be visible
+                16: 
+                17: #    @etag1
+                18: #    Examples:
+                19: #      | action | outcome |
+                20: #      | act#1  | out#1   |
+                21: #      | act#2  | out#2   |
+                22: 
+                23:     @etag2
+                24:     Examples:
+                25:       | action | outcome |
+                26:       | act#3  | out#3   |
+                GHERKIN,
+                expectScenarioMatches: [
+                    'Scenario#1' => false,
+                    'Scenario#2' => false,
+                    'Scenario#3' => true,
+                ],
+                stripLineNumbers: true,
+            ),
+            25,
+            26,
+        ];
+    }
+
+    /**
+     * @phpstan-param int|"*" $filterMaxLine
+     */
+    #[DataProvider('providerFilterFeature')]
+    public function testFilterFeature(FeatureFilterTestFixture $testcase, int $filterMinLine, string|int $filterMaxLine): void
+    {
+        $this->assertFiltersFeatureAsExpected($testcase, new LineRangeFilter($filterMinLine, $filterMaxLine));
+    }
+
+    public function testFilterFeatureLeavesEmptyOutlineIfOnlyOutlineInRange(): void
+    {
+        // Edge case: If the range includes the Outline: line but none of the Examples: tables, the filtered feature
+        // will have an empty Outline. We can't prove this with the normal test, because the parser converts an empty
+        // Outline to a Scenario node.
+        $feature = $this->parseFeature(
+            <<<'GHERKIN'
+            Feature: Long feature with outline
+              Scenario: Scenario#1
+                Given initial step
+                When action occurs
+                Then outcomes should be visible
+                
+              Scenario: Scenario#2
+                Given initial step
+                And another initial step
+                When action occurs
+                Then outcomes should be visible
+
+              Scenario Outline: Scenario#3
+                When <action> occurs
+                Then <outcome> should be visible
+                
+                Examples: 
+                  | action | outcome  |
+                  | click  | something|
+            GHERKIN
         );
-    }
 
-    public function testFilterFeatureScenario(): void
-    {
-        $filter = new LineRangeFilter(1, 3);
-        $feature = $filter->filterFeature($this->getParsedFeature());
-        $this->assertCount(1, $scenarios = $feature->getScenarios());
-        $this->assertSame('Scenario#1', $scenarios[0]->getTitle());
-
-        $filter = new LineRangeFilter(5, 9);
-        $feature = $filter->filterFeature($this->getParsedFeature());
-        $this->assertCount(1, $scenarios = $feature->getScenarios());
-        $this->assertSame('Scenario#2', $scenarios[0]->getTitle());
-
-        $filter = new LineRangeFilter(5, 6);
-        $feature = $filter->filterFeature($this->getParsedFeature());
-        $this->assertCount(0, $scenarios = $feature->getScenarios());
-    }
-
-    public function testFilterFeatureOutline(): void
-    {
         $filter = new LineRangeFilter(12, 14);
-        $feature = $filter->filterFeature($this->getParsedFeature());
-        $this->assertCount(1, $scenarios = $feature->getScenarios());
-        $this->assertSame('Scenario#3', $scenarios[0]->getTitle());
-        $this->assertInstanceOf(OutlineNode::class, $scenarios[0]);
-        $this->assertFalse($scenarios[0]->hasExamples());
+        $filtered = $filter->filterFeature($feature);
 
-        $filter = new LineRangeFilter(16, 21);
-        $feature = $filter->filterFeature($this->getParsedFeature());
-        $this->assertCount(1, $scenarios = $feature->getScenarios());
-        $this->assertSame('Scenario#3', $scenarios[0]->getTitle());
-        $this->assertInstanceOf(OutlineNode::class, $scenarios[0]);
-        $exampleTableNodes = $scenarios[0]->getExampleTables();
-        $this->assertCount(1, $exampleTableNodes);
-        $this->assertCount(3, $exampleTableNodes[0]->getRows());
-        $this->assertSame([
-            ['action', 'outcome'],
-            ['act#1', 'out#1'],
-            ['act#2', 'out#2'],
-        ], $exampleTableNodes[0]->getRows());
-        $this->assertEquals(['etag1'], $exampleTableNodes[0]->getTags());
+        $this->assertTrue($filtered->hasScenarios(), 'Feature still has scenarios');
 
-        $filter = new LineRangeFilter(16, 26);
-        $feature = $filter->filterFeature($this->getParsedFeature());
-        $this->assertCount(1, $scenarios = $feature->getScenarios());
-        $this->assertSame('Scenario#3', $scenarios[0]->getTitle());
-        $this->assertInstanceOf(OutlineNode::class, $scenarios[0]);
-        $exampleTableNodes = $scenarios[0]->getExampleTables();
-        $this->assertCount(2, $exampleTableNodes);
+        $filteredScenarios = $filtered->getScenarios();
+        $this->assertCount(1, $filteredScenarios, 'Only a single scenario matches');
 
-        $this->assertCount(3, $exampleTableNodes[0]->getRows());
-        $this->assertSame([
-            ['action', 'outcome'],
-            ['act#1', 'out#1'],
-            ['act#2', 'out#2'],
-        ], $exampleTableNodes[0]->getRows());
-        $this->assertEquals(['etag1'], $exampleTableNodes[0]->getTags());
-
-        $this->assertCount(2, $exampleTableNodes[1]->getRows());
-        $this->assertSame([
-            ['action', 'outcome'],
-            ['act#3', 'out#3'],
-        ], $exampleTableNodes[1]->getRows());
-
-        $this->assertEquals(['etag2'], $exampleTableNodes[1]->getTags());
-
-        $filter = new LineRangeFilter(25, 26);
-        $feature = $filter->filterFeature($this->getParsedFeature());
-        $this->assertCount(1, $scenarios = $feature->getScenarios());
-        $this->assertSame('Scenario#3', $scenarios[0]->getTitle());
-        $this->assertInstanceOf(OutlineNode::class, $scenarios[0]);
-        $exampleTableNodes = $scenarios[0]->getExampleTables();
-        $this->assertCount(1, $exampleTableNodes);
-        $this->assertCount(2, $exampleTableNodes[0]->getRows());
-        $this->assertSame([
-            ['action', 'outcome'],
-            ['act#3', 'out#3'],
-        ], $exampleTableNodes[0]->getRows());
-        $this->assertEquals(['etag2'], $exampleTableNodes[0]->getTags());
+        $filteredOutline = $filteredScenarios[0];
+        $this->assertInstanceOf(OutlineNode::class, $filteredOutline, 'Filtered scenario is an Outline');
+        $this->assertFalse($filteredOutline->hasExamples(), 'Filtered scenario has no examples');
     }
 }

--- a/tests/Filter/NameFilterTest.php
+++ b/tests/Filter/NameFilterTest.php
@@ -17,25 +17,333 @@ use Behat\Gherkin\Node\OutlineNode;
 use Behat\Gherkin\Node\ScenarioInterface;
 use Behat\Gherkin\Node\ScenarioNode;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\TestCase;
 
-class NameFilterTest extends TestCase
+class NameFilterTest extends FilterTestCase
 {
-    public function testFilterFeature(): void
+    /**
+     * @phpstan-return iterable<string,array{FeatureFilterTestFixture, string}>
+     */
+    public static function providerFilterFeature(): iterable
     {
-        $feature = new FeatureNode('feature1', null, [], null, [], '', '', null, 1);
-        $filter = new NameFilter('feature1');
-        $this->assertSame($feature, $filter->filterFeature($feature));
-
-        $scenarios = [
-            new ScenarioNode('scenario1', [], [], '', 2),
-            $matchedScenario = new ScenarioNode('scenario2', [], [], '', 4),
+        yield 'matches feature title' => [
+            FeatureFilterTestFixture::expectingNoFiltering(
+                <<<'GHERKIN'
+                Feature: Some browser feature
+                  That describes things happening in the browser
+                  
+                  Scenario: Open a new tab
+                    The session will still be available
+                    
+                    When I do something
+                    Then things should happen
+                    
+                  Scenario Outline: Open a new window
+                    The session will not be available
+                    
+                    When I do <something>
+                    Then things should happen
+                    
+                    Examples:
+                      | something |
+                      | click     |
+                      | type      |
+                GHERKIN,
+                expectScenarioMatches: [
+                    // NOTE: isScenarioMatch does NOT consider the feature text
+                    'Open a new tab' => false,
+                    'Open a new window' => false,
+                ],
+            ),
+            'browser',
         ];
-        $feature = new FeatureNode('feature1', null, [], null, $scenarios, '', '', null, 1);
-        $filter = new NameFilter('scenario2');
-        $filteredFeature = $filter->filterFeature($feature);
 
-        $this->assertSame([$matchedScenario], $filteredFeature->getScenarios());
+        yield 'feature title does not match' => [
+            FeatureFilterTestFixture::fromCommentedExpectation(
+                <<<'GHERKIN'
+                Feature: Some browser feature
+                  That describes things happening in the browser
+                  
+                #  Scenario: Open a new tab
+                #    The session will still be available
+                #    
+                #    When I do something
+                #    Then things should happen
+                #    
+                #  Scenario Outline: Open a new window
+                #    The session will not be available
+                #    
+                #    When I do <something>
+                #    Then things should happen
+                #    
+                #    Examples:
+                #      | something |
+                #      | click     |
+                #      | type      |
+                GHERKIN,
+                expectScenarioMatches: [
+                    // NOTE: isScenarioMatch does NOT consider the feature text
+                    'Open a new tab' => false,
+                    'Open a new window' => false,
+                ],
+            ),
+            'calculator',
+        ];
+
+        yield 'matches feature title by regex' => [
+            FeatureFilterTestFixture::expectingNoFiltering(
+                <<<'GHERKIN'
+                Feature: Some browser feature
+                  That describes things happening in the browser
+                  
+                  Scenario: Open a new tab
+                    The session will still be available
+                    
+                    When I do something
+                    Then things should happen
+                    
+                  Scenario Outline: Open a new window
+                    The session will not be available
+                    
+                    When I do <something>
+                    Then things should happen
+                    
+                    Examples:
+                      | something |
+                      | click     |
+                      | type      |
+                GHERKIN,
+                expectScenarioMatches: [
+                    // NOTE: isScenarioMatch does NOT consider the feature text
+                    'Open a new tab' => false,
+                    'Open a new window' => false,
+                ],
+            ),
+            '/^Some browser [f]/',
+        ];
+
+        yield 'does not match feature title by regex' => [
+            FeatureFilterTestFixture::fromCommentedExpectation(
+                <<<'GHERKIN'
+                Feature: Some browser feature
+                  That describes things happening in the browser
+                  
+                #  Scenario: Open a new tab
+                #    The session will still be available
+                #    
+                #    When I do something
+                #    Then things should happen
+                #    
+                #  Scenario Outline: Open a new window
+                #    The session will not be available
+                #    
+                #    When I do <something>
+                #    Then things should happen
+                #    
+                #    Examples:
+                #      | something |
+                #      | click     |
+                #      | type      |
+                GHERKIN,
+                expectScenarioMatches: [
+                    // NOTE: isScenarioMatch does NOT consider the feature text
+                    'Open a new tab' => false,
+                    'Open a new window' => false,
+                ],
+            ),
+            '/^In my browser [f]/',
+        ];
+
+        yield 'ignores feature description' => [
+            FeatureFilterTestFixture::fromCommentedExpectation(
+                <<<'GHERKIN'
+                Feature: Some browser feature
+                  That describes things happening in the browser
+                  
+                #  Scenario: Open a new tab
+                #    The session will still be available
+                #    
+                #    When I do something
+                #    Then things should happen
+                #    
+                #  Scenario Outline: Open a new window
+                #    The session will not be available
+                #    
+                #    When I do <something>
+                #    Then things should happen
+                #    
+                #    Examples:
+                #      | something |
+                #      | click     |
+                #      | type      |
+                GHERKIN,
+                expectScenarioMatches: [
+                    // NOTE: isScenarioMatch does NOT consider the feature text
+                    'Open a new tab' => false,
+                    'Open a new window' => false,
+                ],
+            ),
+            'things happening in the browser',
+        ];
+
+        yield 'matches scenario title' => [
+            FeatureFilterTestFixture::fromCommentedExpectation(
+                <<<'GHERKIN'
+                Feature: Some browser feature
+                  That describes things happening in the browser
+                  
+                  Scenario: Open a new tab
+                    The session will still be available
+                    
+                    When I do something
+                    Then things should happen
+                    
+                #  Scenario Outline: Open a new window
+                #    The session will not be available
+                #    
+                #    When I do <something>
+                #    Then things should happen
+                #    
+                #    Examples:
+                #      | something |
+                #      | click     |
+                #      | type      |
+                GHERKIN,
+                expectScenarioMatches: [
+                    'Open a new tab' => true,
+                    'Open a new window' => false,
+                ],
+            ),
+            'new tab',
+        ];
+
+        yield 'matches scenario description' => [
+            FeatureFilterTestFixture::fromCommentedExpectation(
+                <<<'GHERKIN'
+                Feature: Some browser feature
+                  That describes things happening in the browser
+                  
+                  Scenario: Open a new tab
+                    The session will still be available
+                    
+                    When I do something
+                    Then things should happen
+                    
+                #  Scenario Outline: Open a new window
+                #    The session will not be available
+                #    
+                #    When I do <something>
+                #    Then things should happen
+                #    
+                #    Examples:
+                #      | something |
+                #      | click     |
+                #      | type      |
+                GHERKIN,
+                expectScenarioMatches: [
+                    'Open a new tab' => true,
+                    'Open a new window' => false,
+                ],
+            ),
+            'session will still be',
+        ];
+
+        yield 'matches outline title' => [
+            FeatureFilterTestFixture::fromCommentedExpectation(
+                <<<'GHERKIN'
+                Feature: Some browser feature
+                  That describes things happening in the browser
+                  
+                #  Scenario: Open a new tab
+                #    The session will still be available
+                #    
+                #    When I do something
+                #    Then things should happen
+                    
+                  Scenario Outline: Open a new window
+                    The session will not be available
+                    
+                    When I do <something>
+                    Then things should happen
+                    
+                    Examples:
+                      | something |
+                      | click     |
+                      | type      |
+                GHERKIN,
+                expectScenarioMatches: [
+                    'Open a new tab' => false,
+                    'Open a new window' => true,
+                ],
+            ),
+            'new window',
+        ];
+
+        yield 'matches outline description' => [
+            FeatureFilterTestFixture::fromCommentedExpectation(
+                <<<'GHERKIN'
+                Feature: Some browser feature
+                  That describes things happening in the browser
+                  
+                #  Scenario: Open a new tab
+                #    The session will still be available
+                #    
+                #    When I do something
+                #    Then things should happen
+                    
+                  Scenario Outline: Open a new window
+                    The session will not be available
+                    
+                    When I do <something>
+                    Then things should happen
+                    
+                    Examples:
+                      | something |
+                      | click     |
+                      | type      |
+                GHERKIN,
+                expectScenarioMatches: [
+                    'Open a new tab' => false,
+                    'Open a new window' => true,
+                ],
+            ),
+            'session will not be',
+        ];
+
+        yield 'does not match untitled scenario' => [
+            FeatureFilterTestFixture::fromCommentedExpectation(
+                <<<'GHERKIN'
+                Feature: Something
+                 
+                #  Scenario:
+                #    When I do things            
+                GHERKIN,
+                expectScenarioMatches: [
+                    '' => false,
+                ],
+            ),
+            'anything',
+        ];
+
+        yield 'matches scenario with title only' => [
+            FeatureFilterTestFixture::expectingNoFiltering(
+                <<<'GHERKIN'
+                Feature: Something
+                 
+                  Scenario: Prove a requirement
+                    When I do things            
+                GHERKIN,
+                expectScenarioMatches: [
+                    'Prove a requirement' => true,
+                ],
+            ),
+            'requirement',
+        ];
+    }
+
+    #[DataProvider('providerFilterFeature')]
+    public function testFilterFeature(FeatureFilterTestFixture $testcase, string $filterString): void
+    {
+        $this->assertFiltersFeatureAsExpected($testcase, new NameFilter($filterString));
     }
 
     public function testIsFeatureMatchFilter(): void
@@ -148,14 +456,6 @@ class NameFilterTest extends TestCase
         $filter = new NameFilter('/^start/m');
         $scenario = new ScenarioNode($scenario['title'], [], [], '', 2, $scenario['description']);
         $this->assertSame($expectMatch, $filter->isScenarioMatch($scenario));
-    }
-
-    public function testUntitledScenarioDoesNotMatch(): void
-    {
-        $scenario = new ScenarioNode(null, [], [], '', 1);
-        $filter = new NameFilter('');
-
-        $this->assertFalse($filter->isScenarioMatch($scenario));
     }
 
     /**

--- a/tests/Filter/NarrativeFilterTest.php
+++ b/tests/Filter/NarrativeFilterTest.php
@@ -12,10 +12,79 @@ namespace Tests\Behat\Gherkin\Filter;
 
 use Behat\Gherkin\Filter\NarrativeFilter;
 use Behat\Gherkin\Node\FeatureNode;
-use Behat\Gherkin\Node\ScenarioNode;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class NarrativeFilterTest extends FilterTestCase
 {
+    /**
+     * @phpstan-return iterable<string,array{FeatureFilterTestFixture, string}>
+     */
+    public static function providerFilterFeature(): iterable
+    {
+        yield 'matches title and description' => [
+            FeatureFilterTestFixture::expectingNoFiltering(
+                <<<'GHERKIN'
+                Feature: Switch language to french
+                  In order to be able to read news in my own language
+                  As a french user
+                  I need to be able to switch website language to french
+                  
+                  Scenario: Pick a language                
+                    
+                  Scenario Outline: Remember preferences
+                    Given I <precondition> set my default language to french
+                    When  I go to the site
+                    Then  I should see the site in <language>
+                    
+                    Examples:
+                      | precondition | language |
+                      | have         | french   |
+                      | have not     | english  |
+                GHERKIN,
+                expectScenarioMatches: [
+                    // Note, isScenarioMatch is always false for a RoleFilter
+                    'Pick a language' => false,
+                    'Remember preferences' => false,
+                ],
+            ),
+            '/as (?:a|an) french user/i',
+        ];
+
+        yield 'filters to empty feature if it does not match' => [
+            FeatureFilterTestFixture::fromCommentedExpectation(
+                <<<'GHERKIN'
+                Feature: Switch language to french
+                  In order to be able to read news in my own language
+                  As a french user
+                  I need to be able to switch website language to french
+                  
+                #  Scenario: Pick a language                
+                #    
+                #  Scenario Outline: Remember preferences
+                #    Given I <precondition> set my default language to french
+                #    When  I go to the site
+                #    Then  I should see the site in <language>
+                #    
+                #    Examples:
+                #      | precondition | language |
+                #      | have         | french   |
+                #      | have not     | english  |
+                GHERKIN,
+                expectScenarioMatches: [
+                    'Pick a language' => false,
+                    'Remember preferences' => false,
+                ],
+            ),
+            '/As (?:a|an) English user/',
+        ];
+    }
+
+    #[DataProvider('providerFilterFeature')]
+    public function testFilterFeature(FeatureFilterTestFixture $testcase, string $filterString): void
+    {
+        $this->assertFiltersFeatureAsExpected($testcase, new NarrativeFilter($filterString));
+    }
+
     public function testIsFeatureMatchFilter(): void
     {
         $description = <<<'NAR'
@@ -39,14 +108,5 @@ class NarrativeFilterTest extends FilterTestCase
 
         $filter = new NarrativeFilter('/user$/');
         $this->assertFalse($filter->isFeatureMatch($feature));
-    }
-
-    public function testIsScenarioMatchFilter(): void
-    {
-        $scenario = new ScenarioNode(null, [], [], '', 1);
-
-        $filter = new NarrativeFilter('user');
-
-        $this->assertFalse($filter->isScenarioMatch($scenario));
     }
 }

--- a/tests/Filter/PathsFilterTest.php
+++ b/tests/Filter/PathsFilterTest.php
@@ -16,6 +16,8 @@ use Behat\Gherkin\Node\ScenarioNode;
 
 class PathsFilterTest extends FilterTestCase
 {
+    // @TODO: TEST filterFeature
+
     public function testIsFeatureMatchFilter(): void
     {
         $feature = new FeatureNode(null, null, [], null, [], '', '', __FILE__, 1);

--- a/tests/Filter/PathsFilterTest.php
+++ b/tests/Filter/PathsFilterTest.php
@@ -12,11 +12,75 @@ namespace Tests\Behat\Gherkin\Filter;
 
 use Behat\Gherkin\Filter\PathsFilter;
 use Behat\Gherkin\Node\FeatureNode;
-use Behat\Gherkin\Node\ScenarioNode;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class PathsFilterTest extends FilterTestCase
 {
-    // @TODO: TEST filterFeature
+    /**
+     * @phpstan-return iterable<string,array{FeatureFilterTestFixture, string, list<string>}>
+     */
+    public static function providerFilterFeature(): iterable
+    {
+        yield 'matches whole feature if it is in an existing file in the search paths' => [
+            FeatureFilterTestFixture::expectingNoFiltering(
+                <<<'GHERKIN'
+                Feature: Literally any feature
+                  In order to do things with Behat
+                  As a developer
+                  I need to have feature files
+                  
+                  Scenario: Scenario 1             
+                    
+                  Scenario Outline: Outline 1
+                    Given I <something>
+                    
+                    Examples:
+                      | something |
+                      | have      | 
+                      | have not  | 
+                GHERKIN,
+                expectScenarioMatches: [
+                    // Note, isScenarioMatch is always false for a PathsFilter
+                    'Scenario 1' => false,
+                    'Outline 1' => false,
+                ],
+            ),
+            __FILE__,
+            [__DIR__],
+        ];
+
+        yield 'filters to empty feature if the file is not in the search path' => [
+            FeatureFilterTestFixture::fromCommentedExpectation(
+                <<<'GHERKIN'
+                Feature: Literally any feature
+                  In order to do things with Behat
+                  As a developer
+                  I need to have feature files
+                  
+                #  Scenario: Scenario 1
+                #    Given anything
+                GHERKIN,
+                expectScenarioMatches: [
+                    'Scenario 1' => false,
+                ],
+            ),
+            __FILE__,
+            ['/some/other/path'],
+        ];
+    }
+
+    /**
+     * @param list<string> $filterPaths
+     */
+    #[DataProvider('providerFilterFeature')]
+    public function testFilterFeature(FeatureFilterTestFixture $testcase, ?string $path, array $filterPaths): void
+    {
+        $this->assertFiltersFeatureAsExpected(
+            $testcase,
+            new PathsFilter($filterPaths),
+            featureFilePath: $path,
+        );
+    }
 
     public function testIsFeatureMatchFilter(): void
     {
@@ -68,15 +132,6 @@ class PathsFilterTest extends FilterTestCase
 
         $filter = new PathsFilter([$fixtures . 'full']);
         $this->assertFalse($filter->isFeatureMatch($feature));
-    }
-
-    public function testIsScenarioMatchFilter(): void
-    {
-        $scenario = new ScenarioNode(null, [], [], '', 1);
-
-        $filter = new PathsFilter([__DIR__]);
-
-        $this->assertFalse($filter->isScenarioMatch($scenario));
     }
 
     public function testMissingFileShouldBeSkipped(): void

--- a/tests/Filter/RoleFilterTest.php
+++ b/tests/Filter/RoleFilterTest.php
@@ -12,10 +12,79 @@ namespace Tests\Behat\Gherkin\Filter;
 
 use Behat\Gherkin\Filter\RoleFilter;
 use Behat\Gherkin\Node\FeatureNode;
-use Behat\Gherkin\Node\ScenarioNode;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class RoleFilterTest extends FilterTestCase
 {
+    /**
+     * @phpstan-return iterable<string,array{FeatureFilterTestFixture, string}>
+     */
+    public static function providerFilterFeature(): iterable
+    {
+        yield 'matches whole feature if anything matches' => [
+            FeatureFilterTestFixture::expectingNoFiltering(
+                <<<'GHERKIN'
+                Feature: Switch language to french
+                  In order to be able to read news in my own language
+                  As a french user
+                  I need to be able to switch website language to french
+                  
+                  Scenario: Pick a language                
+                    
+                  Scenario Outline: Remember preferences
+                    Given I <precondition> set my default language to french
+                    When  I go to the site
+                    Then  I should see the site in <language>
+                    
+                    Examples:
+                      | precondition | language |
+                      | have         | french   |
+                      | have not     | english  |
+                GHERKIN,
+                expectScenarioMatches: [
+                    // Note, isScenarioMatch is always false for a RoleFilter
+                    'Pick a language' => false,
+                    'Remember preferences' => false,
+                ],
+            ),
+            'french user',
+        ];
+
+        yield 'filters to empty feature if it does not match' => [
+            FeatureFilterTestFixture::fromCommentedExpectation(
+                <<<'GHERKIN'
+                Feature: Switch language to french
+                  In order to be able to read news in my own language
+                  As a french user
+                  I need to be able to switch website language to french
+                  
+                #  Scenario: Pick a language                
+                #    
+                #  Scenario Outline: Remember preferences
+                #    Given I <precondition> set my default language to french
+                #    When  I go to the site
+                #    Then  I should see the site in <language>
+                #    
+                #    Examples:
+                #      | precondition | language |
+                #      | have         | french   |
+                #      | have not     | english  |
+                GHERKIN,
+                expectScenarioMatches: [
+                    'Pick a language' => false,
+                    'Remember preferences' => false,
+                ],
+            ),
+            'german user',
+        ];
+    }
+
+    #[DataProvider('providerFilterFeature')]
+    public function testFilterFeature(FeatureFilterTestFixture $testcase, string $filterString): void
+    {
+        $this->assertFiltersFeatureAsExpected($testcase, new RoleFilter($filterString));
+    }
+
     public function testIsFeatureMatchFilter(): void
     {
         $description = <<<'NAR'
@@ -81,14 +150,5 @@ class RoleFilterTest extends FilterTestCase
         $feature = new FeatureNode(null, null, [], null, [], '', '', null, 1);
         $filter = new RoleFilter('American User');
         $this->assertFalse($filter->isFeatureMatch($feature));
-    }
-
-    public function testIsScenarioMatchFilter(): void
-    {
-        $scenario = new ScenarioNode(null, [], [], '', 1);
-
-        $filter = new RoleFilter('user');
-
-        $this->assertFalse($filter->isScenarioMatch($scenario));
     }
 }

--- a/tests/Filter/TagFilterMatcherTest.php
+++ b/tests/Filter/TagFilterMatcherTest.php
@@ -1,0 +1,296 @@
+<?php
+
+/*
+ * This file is part of the Behat Gherkin Parser.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Behat\Gherkin\Filter;
+
+use Behat\Gherkin\Filter\TagFilter;
+use Behat\Gherkin\Filter\TagFilterMatcher;
+use Behat\Gherkin\Node\FeatureNode;
+use Closure;
+use ErrorException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class TagFilterMatcherTest extends TestCase
+{
+    /**
+     * @phpstan-return iterable<array{string, list<string>, bool}>
+     */
+    public static function providerIsMatch(): iterable
+    {
+        // Single tag matches if tag is present
+        yield ['@wip', [], false];
+        yield ['@wip', ['wip'], true];
+
+        // Negated `~` tag matches if tag is NOT present
+        yield ['~@done', ['wip'], true];
+        yield ['~@done', ['wip', 'done'], false];
+
+        // Or `,` matches if ANY of the list of tags is present
+        yield ['@tag5,@tag4,@tag6', ['tag1', 'tag2', 'tag3'], false];
+        yield ['@tag5,@tag4,@tag6', ['tag1', 'tag2', 'tag3', 'tag5'], true];
+        yield ['@tag5,@tag4,@tag6', ['tag1', 'tag2', 'tag3', 'tag5'], true];
+
+        // And `&&` matches if ALL of the list of tags is present
+        yield ['@wip&&@vip', ['wip', 'done'], false];
+        yield ['@wip&&@vip', ['wip', 'done'], false];
+        yield ['@wip&&@vip', ['wip', 'done', 'vip'], true];
+
+        // `,` has precedence over `&&` - resolves as "(@wip OR @vip) AND user"
+        yield ['@wip,@vip&&@user', ['wip'], false];
+        yield ['@wip,@vip&&@user', ['vip'], false];
+        yield ['@wip,@vip&&@user', ['wip', 'user'], true];
+        yield ['@wip,@vip&&@user', ['vip', 'user'], true];
+
+        // `&&` with negated tag matches if positive tag is present AND negated tag is absent
+        yield ['@wip&&~@slow', [], false];
+        yield ['@wip&&~@slow', ['wip'], true];
+        yield ['@wip&&~@slow', ['wip', 'fast'], true];
+        yield ['@wip&&~@slow', ['wip', 'slow'], false];
+
+        // Whitespace around operators is ignored
+        // Should match behaviour of the unspaced examples above
+        yield ['@tag5, @tag4, @tag6', ['tag1', 'tag2', 'tag3'], false];
+        yield ['@tag5, @tag4, @tag6', ['tag1', 'tag2', 'tag3', 'tag5'], true];
+
+        yield ['@wip && @vip', ['wip', 'done'], false];
+        yield ['@wip && @vip', ['wip', 'done', 'vip'], true];
+        yield ['@wip &&@vip', ['wip', 'done'], false];
+        yield ['@wip &&@vip', ['wip', 'done', 'vip'], true];
+        yield ['@wip&& @vip', ['wip', 'done'], false];
+        yield ['@wip&& @vip', ['wip', 'done', 'vip'], true];
+
+        yield ['@wip, @vip&&@user', ['wip'], false];
+        yield ['@wip, @vip&&@user', ['vip', 'user'], true];
+        yield ['@wip, @vip&& @user', ['wip'], false];
+        yield ['@wip, @vip&& @user', ['vip', 'user'], true];
+        yield ['@wip, @vip &&@user', ['wip'], false];
+        yield ['@wip, @vip &&@user', ['vip', 'user'], true];
+        yield ['@wip, @vip&& @user', ['wip'], false];
+        yield ['@wip, @vip&& @user', ['vip', 'user'], true];
+        yield ['@wip,@vip &&@user', ['wip'], false];
+        yield ['@wip,@vip &&@user', ['vip', 'user'], true];
+        yield ['@wip,@vip&& @user', ['wip'], false];
+        yield ['@wip,@vip&& @user', ['vip', 'user'], true];
+        yield ['@wip,@vip && @user', ['wip'], false];
+        yield ['@wip,@vip && @user', ['vip', 'user'], true];
+
+        yield ['@wip &&~@slow', ['wip'], true];
+        yield ['@wip &&~@slow', ['wip', 'slow'], false];
+        yield ['@wip && ~@slow', ['wip'], true];
+        yield ['@wip && ~@slow', ['wip', 'slow'], false];
+        yield ['@wip&& ~@slow', ['wip'], true];
+        yield ['@wip&& ~@slow', ['wip', 'slow'], false];
+
+        // Edge case - whitespace before a `,` doesn't really make sense, but was historically supported
+        yield ['@wip , @vip && @user', ['vip', 'user'], true];
+
+        // Very much an edge case, but the legacy implementation would have allowed this as it always just used
+        // `trim`. And arguably someone *could* have a config file with an indented multiline filter expression.
+        yield ["\t@tag1,\n\t@tag2  &&  ~@tag3\n", ['tag1', 'tag3'], false];
+        yield ["\t@tag1,\n\t@tag2  &&  ~@tag3\n", ['tag1', 'tag2'], true];
+
+        // Leading and trailing whitespace is ignored
+        yield [' @tag1', ['tag1'], true];
+        yield [' @tag1 ', ['tag1'], true];
+        yield ['@tag1 ', ['tag1'], true];
+
+        // Filter that is entirely whitespace matches anything
+        yield ['', ['tag1'], true];
+        yield [' ', ['tag1'], true];
+        yield ['', [], true];
+        yield [' ', [], true];
+    }
+
+    /**
+     * @param list<string> $tags
+     */
+    #[DataProvider('providerIsMatch')]
+    public function testIsMatch(string $filterString, array $tags, bool $expect): void
+    {
+        $matcher = new TagFilterMatcher($filterString);
+        $this->assertSame($expect, $matcher->isMatch($tags));
+    }
+
+    /**
+     * @phpstan-return list<array{string, list<string>, bool}>
+     */
+    public static function providerMatchWithNoPrefixInFilter(): array
+    {
+        // This is officially unsupported (but potentially widespread) use of a filter expression that does not
+        // contain the `@` prefix. Behat's documentation shows that the `@` prefix should be provided - however Behat's
+        // own tests include an example where this is not the case, which has been passing. Gherkin has not historically
+        // validated the tag expression, so we will continue to support these for now.
+        // These cases rely on the bulk of the coverage being provided by the other tests, and the knowledge that the
+        // implementation ultimately uses the same logic to compare tags from all types of nodes.
+        // They are only intended to be temporary until we enforce that filter expressions are valid.
+        return [
+            ['wip', [], false],
+            ['wip', ['slow'], false],
+            ['wip', ['wip'], true],
+            ['wip', ['slow', 'wip'], true],
+            ['tag1&&~tag2&&tag3', [], false],
+            ['tag1&&~tag2&&tag3', ['tag1'], false],
+            ['tag1&&~tag2&&tag3', ['tag1', 'tag3'], true],
+            ['tag1&&~tag2&&tag3', ['tag1', 'tag2'], false],
+            ['tag1&&~tag2&&tag3', ['tag1', 'tag4'], false],
+            ['tag1&&~tag2&&tag3', ['tag1', 'tag2', 'tag3'], false],
+            // Also cover when the file was parsed in compatibility mode including the prefix
+            ['wip', [], false],
+            ['wip', ['@slow'], false],
+            ['wip', ['@wip'], true],
+            ['wip', ['@slow', '@wip'], true],
+            ['tag1&&~tag2&&tag3', [], false],
+            ['tag1&&~tag2&&tag3', ['@tag1'], false],
+            ['tag1&&~tag2&&tag3', ['@tag1', '@tag3'], true],
+            ['tag1&&~tag2&&tag3', ['@tag1', '@tag2'], false],
+            ['tag1&&~tag2&&tag3', ['@tag1', '@tag4'], false],
+            ['tag1&&~tag2&&tag3', ['@tag1', '@tag2', '@tag3'], false],
+
+            // And cover with whitespace around operators
+            ['tag1 && ~tag2 && tag3', [], false],
+            ['tag1 && ~tag2 && tag3', ['tag1'], false],
+            ['tag1 && ~tag2 && tag3', ['tag1', 'tag3'], true],
+            ['tag1 && ~tag2 && tag3', ['tag1', 'tag2'], false],
+            ['tag1 && ~tag2 && tag3', ['tag1', 'tag4'], false],
+            ['tag1 && ~tag2 && tag3', ['tag1', 'tag2', 'tag3'], false],
+        ];
+    }
+
+    /**
+     * @phpstan-param list<string> $tags
+     */
+    #[DataProvider('providerMatchWithNoPrefixInFilter')]
+    public function testItMatchesWhenFilterDoesNotContainPrefix(string $filter, array $tags, bool $expect): void
+    {
+        $tagFilter = $this->assertTriggersDeprecation(
+            'Filter strings should contain `@` prefixes',
+            fn () => new TagFilter($filter),
+        );
+
+        $feature = new FeatureNode(null, null, $tags, null, [], '', '', null, 1);
+        $this->assertSame($expect, $tagFilter->isFeatureMatch($feature));
+    }
+
+    /**
+     * @return iterable<string, array{string, bool}>
+     */
+    public static function providerWhitespaceDeprecated(): iterable
+    {
+        yield 'deprecation if filter has spaces in tag name' => [
+            '@tag with space',
+            true,
+        ];
+
+        yield 'deprecation if negated filter has spaces in tag name' => [
+            '~@tag with space',
+            false,
+        ];
+
+        yield 'deprecation with spaces in tag name and around && operator' => [
+            '@tag1 && @tag with space',
+            true,
+        ];
+
+        yield 'deprecation with spaces in tag name and around , operator' => [
+            '@any-tag, @tag with space',
+            true,
+        ];
+
+        yield 'deprecation on whitespace after ~ operator (and the negated tag is ignored)' => [
+            // Edge case - we don't expect people to have whitespace after a `~` and historically that would not
+            // have been trimmed so the filter would have matched even if a feature / scenario had the negated tag.
+            '~ @tag1',
+            true,
+        ];
+    }
+
+    #[DataProvider('providerWhitespaceDeprecated')]
+    public function testFilterWithWhitespaceIsDeprecated(string $filterString, bool $expectMatch): void
+    {
+        $matcher = $this->assertTriggersDeprecation(
+            'Tags with whitespace',
+            fn () => new TagFilterMatcher($filterString),
+        );
+
+        $this->assertSame(
+            $expectMatch,
+            $matcher->isMatch(['tag with space', 'tag1', 'tag2']),
+            'Expected correct matching behaviour',
+        );
+    }
+
+    /**
+     * @phpstan-return list<array{string, list<string>, bool}>
+     */
+    public static function providerMatchWithoutRemovingPrefix(): array
+    {
+        // These cases are only intended to be temporary until we drop legacy parsing mode, at which point we can add
+        // the `@` to all the tags in the other tests in this file.
+        return [
+            ['@wip', [], false],
+            ['@wip', ['@slow'], false],
+            ['@wip', ['@wip'], true],
+            ['@wip', ['@slow', '@wip'], true],
+            ['@tag1&&~@tag2&&@tag3', [], false],
+            ['@tag1&&~@tag2&&@tag3', ['@tag1'], false],
+            ['@tag1&&~@tag2&&@tag3', ['@tag1', '@tag3'], true],
+            ['@tag1&&~@tag2&&@tag3', ['@tag1', '@tag2'], false],
+            ['@tag1&&~@tag2&&@tag3', ['@tag1', '@tag4'], false],
+            ['@tag1&&~@tag2&&@tag3', ['@tag1', '@tag2', '@tag3'], false],
+            ['@tag1 && ~@tag2 && @tag3', ['@tag1', '@tag3'], true],
+        ];
+    }
+
+    /**
+     * @phpstan-param list<string> $tags
+     */
+    #[DataProvider('providerMatchWithoutRemovingPrefix')]
+    public function testItMatchesTagsParsedWithoutRemovingPrefix(string $filterString, array $tags, bool $expect): void
+    {
+        $matcher = new TagFilterMatcher($filterString);
+        $this->assertSame($expect, $matcher->isMatch($tags));
+    }
+
+    /**
+     * @template T
+     *
+     * @param Closure():T $callable
+     * @param non-empty-string $expectDeprecation
+     *
+     * @return T
+     */
+    private function assertTriggersDeprecation(string $expectDeprecation, Closure $callable): mixed
+    {
+        $deprecationCaptured = false;
+
+        set_error_handler(
+            static function (int $errNo, string $errStr, string $errFile, int $errLine) use (&$deprecationCaptured): bool {
+                if (($errNo === E_USER_DEPRECATED) && ($deprecationCaptured === false)) {
+                    $deprecationCaptured = $errStr;
+
+                    return false;
+                }
+                throw new ErrorException($errStr, $errNo, filename: $errFile, line: $errLine);
+            },
+        );
+
+        try {
+            $result = $callable();
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertIsString($deprecationCaptured, 'Expected deprecation to be emitted');
+        $this->assertStringStartsWith($expectDeprecation, $deprecationCaptured, 'Expected correct deprecation message');
+
+        return $result;
+    }
+}

--- a/tests/Filter/TagFilterTest.php
+++ b/tests/Filter/TagFilterTest.php
@@ -11,39 +11,536 @@
 namespace Tests\Behat\Gherkin\Filter;
 
 use Behat\Gherkin\Filter\TagFilter;
-use Behat\Gherkin\Node\ExampleTableNode;
 use Behat\Gherkin\Node\FeatureNode;
 use Behat\Gherkin\Node\OutlineNode;
-use Behat\Gherkin\Node\ScenarioNode;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestWith;
 
-class TagFilterTest extends TestCase
+class TagFilterTest extends FilterTestCase
 {
-    public function testFilterFeature(): void
+    /**
+     * @phpstan-return iterable<string,array{FeatureFilterTestFixture, string}>
+     */
+    public static function providerFilterFeature(): iterable
     {
-        $feature = new FeatureNode(null, null, ['wip'], null, [], '', '', null, 1);
-        $filter = new TagFilter('@wip');
-        $this->assertEquals($feature, $filter->filterFeature($feature));
+        yield from self::filterFeatureTaggedScenarios();
+        yield from self::providerFilterFeatureTaggedExamples();
+    }
 
-        $scenarios = [
-            new ScenarioNode(null, [], [], '', 2),
-            $matchedScenario = new ScenarioNode(null, ['wip'], [], '', 4),
+    /**
+     * @phpstan-return iterable<string,array{FeatureFilterTestFixture, string}>
+     */
+    private static function filterFeatureTaggedScenarios(): iterable
+    {
+        yield 'filters on feature tag' => [
+            FeatureFilterTestFixture::expectingNoFiltering(
+                <<<'GHERKIN'
+                @wip
+                Feature: Some work in progress
+
+                  Scenario: Things are implemented
+                    Given things are implemented 
+                GHERKIN,
+                expectScenarioMatches: [
+                    'Things are implemented' => true,
+                ],
+            ),
+            '@wip',
         ];
-        $feature = new FeatureNode(null, null, [], null, $scenarios, '', '', null, 1);
-        $filteredFeature = $filter->filterFeature($feature);
 
-        $this->assertSame([$matchedScenario], $filteredFeature->getScenarios());
+        yield 'filters on negated feature tag' => [
+            FeatureFilterTestFixture::fromCommentedExpectation(
+                <<<'GHERKIN'
+                @wip
+                Feature: Some work in progress
 
-        $filter = new TagFilter('~@wip');
-        $scenarios = [
-            $matchedScenario = new ScenarioNode(null, [], [], '', 2),
-            new ScenarioNode(null, ['wip'], [], '', 4),
+                #  Scenario: Things are implemented
+                #    Given things are implemented 
+                GHERKIN,
+                expectScenarioMatches: [
+                    'Things are implemented' => false,
+                ],
+            ),
+            '~@wip',
         ];
-        $feature = new FeatureNode(null, null, [], null, $scenarios, '', '', null, 1);
-        $filteredFeature = $filter->filterFeature($feature);
 
-        $this->assertSame([$matchedScenario], $filteredFeature->getScenarios());
+        yield 'filters on a scenario tag' => [
+            FeatureFilterTestFixture::fromCommentedExpectation(
+                <<<'GHERKIN'
+                Feature: Some work in progress
+
+                #  Scenario: Things are implemented
+                #    Given things are implemented
+                    
+                  @wip
+                  Scenario: Still working on this   
+                GHERKIN,
+                expectScenarioMatches: [
+                    'Things are implemented' => false,
+                    'Still working on this' => true,
+                ],
+            ),
+            '@wip',
+        ];
+
+        yield 'filters on a negated scenario tag' => [
+            FeatureFilterTestFixture::fromCommentedExpectation(
+                <<<'GHERKIN'
+                Feature: Some work in progress
+
+                  Scenario: Things are implemented
+                    Given things are implemented
+                    
+                #  @wip
+                #  Scenario: Still working on this   
+                GHERKIN,
+                expectScenarioMatches: [
+                    'Things are implemented' => true,
+                    'Still working on this' => false,
+                ],
+            ),
+            '~@wip',
+        ];
+
+        yield 'filters AND on union of feature and scenario tags' => [
+            FeatureFilterTestFixture::fromCommentedExpectation(
+                <<<'GHERKIN'
+                @users
+                Feature: Something with users
+
+                  @complete
+                  Scenario: Things are implemented
+                    Given things are implemented
+                    
+                #  @wip
+                #  Scenario: Still working on this
+                #    Given other things   
+                GHERKIN,
+                expectScenarioMatches: [
+                    'Things are implemented' => true,
+                    'Still working on this' => false,
+                ],
+            ),
+            '@users && @complete',
+        ];
+
+        yield 'filters on OR condition' => [
+            FeatureFilterTestFixture::fromCommentedExpectation(
+                <<<'GHERKIN'
+                @users
+                Feature: Something with users
+
+                  @complete
+                  Scenario: Things are implemented
+                    Given things are implemented
+
+                #  Scenario: Still working on this
+                #    Given other things
+
+                  @web
+                  Scenario: Scenario 3     
+                GHERKIN,
+                expectScenarioMatches: [
+                    'Things are implemented' => true,
+                    'Still working on this' => false,
+                    'Scenario 3' => true,
+                ],
+            ),
+            '@complete, @web',
+        ];
+
+        yield 'Not affected by duplicate tags in hierarchy' => [
+            FeatureFilterTestFixture::expectingNoFiltering(
+                <<<'GHERKIN'
+                @users
+                Feature: Something with users
+
+                  @complete
+                  Scenario: Things are implemented
+                    Given things are implemented
+
+                  Scenario: Still working on this
+                    Given other things
+
+                  @users
+                  Scenario: Scenario 3     
+                GHERKIN,
+                expectScenarioMatches: [
+                    'Things are implemented' => true,
+                    'Still working on this' => true,
+                    'Scenario 3' => true,
+                ],
+            ),
+            '@users',
+        ];
+    }
+
+    /**
+     * @phpstan-return iterable<string,array{FeatureFilterTestFixture, string}>
+     */
+    private static function providerFilterFeatureTaggedExamples(): iterable
+    {
+        yield 'includes all tables if Feature matches the tag' => [
+            FeatureFilterTestFixture::expectingNoFiltering(
+                <<<'GHERKIN'
+                @feature-tag
+                Feature: Some work in progress
+
+                  @wip
+                  Scenario Outline: Things are implemented
+                    Given <something>
+                    
+                    @etag1 @etag2
+                    Examples: First set of examples
+                      | something | 
+                      | here      |
+                      
+                    @etag2 @etag3
+                    Examples: Second set of examples
+                      | something | 
+                      | else      |     
+                GHERKIN,
+                expectScenarioMatches: [
+                    'Things are implemented' => true,
+                ],
+            ),
+            '@feature-tag',
+        ];
+
+        yield 'includes all tables if Outline matches the tag' => [
+            FeatureFilterTestFixture::expectingNoFiltering(
+                <<<'GHERKIN'
+                @feature-tag
+                Feature: Some work in progress
+
+                  @wip
+                  Scenario Outline: Things are implemented
+                    Given <something>
+                    
+                    @etag1 @etag2
+                    Examples: First set of examples
+                      | something | 
+                      | here      |
+                      
+                    @etag2 @etag3
+                    Examples: Second set of examples
+                      | something | 
+                      | else      |     
+                GHERKIN,
+                expectScenarioMatches: [
+                    'Things are implemented' => true,
+                ],
+            ),
+            '@wip',
+        ];
+
+        yield 'includes all tables if all tables match the tag' => [
+            FeatureFilterTestFixture::expectingNoFiltering(
+                <<<'GHERKIN'
+                @feature-tag
+                Feature: Some work in progress
+
+                  @wip
+                  Scenario Outline: Things are implemented
+                    Given <something>
+                    
+                    @etag1 @etag2
+                    Examples: First set of examples
+                      | something | 
+                      | here      |
+                      
+                    @etag2 @etag3
+                    Examples: Second set of examples
+                      | something | 
+                      | else      |     
+                GHERKIN,
+                expectScenarioMatches: [
+                    'Things are implemented' => true,
+                ],
+            ),
+            '@etag2',
+        ];
+
+        yield 'includes only tagged table matching tags' => [
+            FeatureFilterTestFixture::fromCommentedExpectation(
+                <<<'GHERKIN'
+                @feature-tag
+                Feature: Some work in progress
+
+                  @wip
+                  Scenario Outline: Things are implemented
+                    Given <something>
+                    
+                    @etag1 @etag2
+                    Examples: First set of examples
+                      | something | 
+                      | here      |
+                      
+                #    @etag2 @etag3
+                #    Examples: Second set of examples
+                #      | something | 
+                #      | else      |     
+                GHERKIN,
+                expectScenarioMatches: [
+                    'Things are implemented' => true,
+                ],
+            ),
+            '@etag1',
+        ];
+
+        yield 'removes example table matching negated tag' => [
+            FeatureFilterTestFixture::fromCommentedExpectation(
+                <<<'GHERKIN'
+                @feature-tag
+                Feature: Some work in progress
+
+                  @wip
+                  Scenario Outline: Things are implemented
+                    Given <something>
+                    
+                    @etag1 @etag2
+                    Examples: First set of examples
+                      | something | 
+                      | here      |
+                      
+                #    @etag2 @etag3
+                #    Examples: Second set of examples
+                #      | something | 
+                #      | else      |     
+                GHERKIN,
+                expectScenarioMatches: [
+                    'Things are implemented' => true,
+                ],
+            ),
+            '~@etag3',
+        ];
+
+        yield 'matches outline & one example table' => [
+            // @todo: Existing test doesn't strictly prove that the @etag3 *only* matches in combination with the @wip...
+            FeatureFilterTestFixture::fromCommentedExpectation(
+                <<<'GHERKIN'
+                @feature-tag
+                Feature: Some work in progress
+
+                  @wip
+                  Scenario Outline: Things are implemented
+                    Given <something>
+                    
+                #    @etag1 @etag2
+                #    Examples: First set of examples
+                #      | something | 
+                #      | here      |
+                      
+                    @etag2 @etag3
+                    Examples: Second set of examples
+                      | something | 
+                      | else      |     
+                GHERKIN,
+                expectScenarioMatches: [
+                    'Things are implemented' => true,
+                ],
+            ),
+            '@wip && @etag3',
+        ];
+
+        yield 'matches feature, outline, and table' => [
+            // @todo: Existing test doesn't strictly prove that the @etag3 *only* matches in combination with the @wip...
+            FeatureFilterTestFixture::fromCommentedExpectation(
+                <<<'GHERKIN'
+                @feature-tag
+                Feature: Some work in progress
+
+                  @wip
+                  Scenario Outline: Things are implemented
+                    Given <something>
+                    
+                    @etag1 @etag2
+                    Examples: First set of examples
+                      | something | 
+                      | here      |
+                      
+                #    @etag2 @etag3
+                #    Examples: Second set of examples
+                #      | something | 
+                #      | else      |     
+                GHERKIN,
+                expectScenarioMatches: [
+                    'Things are implemented' => true,
+                ],
+            ),
+            '@feature-tag && @etag1 && @wip',
+        ];
+
+        yield 'ignores negated tag that is not present in the feature' => [
+            FeatureFilterTestFixture::expectingNoFiltering(
+                <<<'GHERKIN'
+                @feature-tag
+                Feature: Some work in progress
+
+                  @wip
+                  Scenario Outline: Things are implemented
+                    Given <something>
+                    
+                    @etag1 @etag2
+                    Examples: First set of examples
+                      | something | 
+                      | here      |
+                      
+                    @etag2 @etag3
+                    Examples: Second set of examples
+                      | something | 
+                      | else      |     
+                GHERKIN,
+                expectScenarioMatches: [
+                    'Things are implemented' => true,
+                ],
+            ),
+            '@feature-tag && ~@etag11111 && @wip',
+        ];
+
+        yield 'matches feature but one example matches negated tag' => [
+            FeatureFilterTestFixture::fromCommentedExpectation(
+                <<<'GHERKIN'
+                @feature-tag
+                Feature: Some work in progress
+
+                  @wip
+                  Scenario Outline: Things are implemented
+                    Given <something>
+                    
+                #    @etag1 @etag2
+                #    Examples: First set of examples
+                #      | something | 
+                #      | here      |
+                      
+                    @etag2 @etag3
+                    Examples: Second set of examples
+                      | something | 
+                      | else      |     
+                GHERKIN,
+                expectScenarioMatches: [
+                    'Things are implemented' => true,
+                ],
+            ),
+            '@feature-tag && ~@etag1 && @wip',
+        ];
+
+        yield 'matches feature and tag present on both example tables' => [
+            FeatureFilterTestFixture::expectingNoFiltering(
+                <<<'GHERKIN'
+                @feature-tag
+                Feature: Some work in progress
+
+                  @wip
+                  Scenario Outline: Things are implemented
+                    Given <something>
+                    
+                    @etag1 @etag2
+                    Examples: First set of examples
+                      | something | 
+                      | here      |
+                      
+                    @etag2 @etag3
+                    Examples: Second set of examples
+                      | something | 
+                      | else      |     
+                GHERKIN,
+                expectScenarioMatches: [
+                    'Things are implemented' => true,
+                ],
+            ),
+            '@feature-tag && @etag2',
+        ];
+
+        yield 'matches all example tables across multiple Outlines' => [
+            FeatureFilterTestFixture::expectingNoFiltering(
+                <<<'GHERKIN'
+                @feature-tag
+                Feature: Some feature
+                    
+                  @wip
+                  Scenario Outline: First scenario
+                    Given <something>
+                    
+                    @etag1 @etag
+                    Examples:
+                      | something |
+                      | here      |
+                    
+                    @etag2 @etag22 @etag
+                    Examples: 
+                      | something |
+                      | else      |
+                      
+                  @wip
+                  Scenario Outline: Second scenario
+                    Given <other>
+                    
+                    @etag3 @etag22 @etag
+                    Examples:   
+                      | other |
+                      | foo   | 
+                      
+                    @etag4 @etag
+                    Examples: 
+                      | other |
+                      | bar   |
+                GHERKIN,
+                expectScenarioMatches: [
+                    'First scenario' => true,
+                    'Second scenario' => true,
+                ],
+            ),
+            '@etag',
+        ];
+
+        yield 'matches only some example tables across multiple Outlines' => [
+            FeatureFilterTestFixture::fromCommentedExpectation(
+                <<<'GHERKIN'
+                @feature-tag
+                Feature: Some feature
+                    
+                  @wip
+                  Scenario Outline: First scenario
+                    Given <something>
+                    
+                #    @etag1 @etag
+                #    Examples:
+                #      | something |
+                #      | here      |
+                    
+                    @etag2 @etag22 @etag
+                    Examples: 
+                      | something |
+                      | else      |
+                      
+                  @wip
+                  Scenario Outline: Second scenario
+                    Given <other>
+                    
+                    @etag3 @etag22 @etag
+                    Examples:   
+                      | other |
+                      | foo   | 
+                      
+                #    @etag4 @etag
+                #    Examples: 
+                #      | other |
+                #      | bar   |
+                GHERKIN,
+                expectScenarioMatches: [
+                    'First scenario' => true,
+                    'Second scenario' => true,
+                ],
+            ),
+            '@etag22',
+        ];
+    }
+
+    #[DataProvider('providerFilterFeature')]
+    public function testFilterFeature(FeatureFilterTestFixture $testcase, string $filterString): void
+    {
+        $this->assertFiltersFeatureAsExpected($testcase, new TagFilter($filterString));
     }
 
     /**
@@ -86,225 +583,6 @@ class TagFilterTest extends TestCase
         $this->assertSame($expect, $filter->isFeatureMatch($feature));
     }
 
-    /**
-     * @return iterable<array{string, list<string>, list<string>, bool}>
-     */
-    public static function providerScenarioMatches(): iterable
-    {
-        // Behaviour matches filtering Features, if the tags are present on the Scenario instead of the Feature
-        foreach (self::providerFeatureMatches() as [$filterString, $featureTags, $expect]) {
-            yield [$filterString, [], $featureTags, $expect];
-        }
-
-        // Additionally, filter expressions match based on the combined list of Feature and Scenario tags
-
-        // `&&` matches if one tag present on the feature and one on the scenario
-        yield ['@feature-tag&&@user', ['feature-tag'], ['wip', 'user'], true];
-
-        // Does not match if the feature matches a negated expression
-        yield ['@user&&~@feature-tag', ['feature-tag'], ['user'], false];
-        yield ['@user&&~@feature-tag', ['other-feature'], ['user'], true];
-
-        // Matches if the feature or the scenario matches an OR expression
-        yield ['@api,@browser', ['api'], [], true];
-        yield ['@api,@browser', [], ['api'], true];
-        yield ['@api,@browser', ['browser'], ['api'], true];
-
-        // Not affected if same tag is present on Feature and Scenario
-        yield ['@api', ['api'], ['api'], true];
-    }
-
-    /**
-     * @param list<string> $featureTags
-     * @param list<string> $scenarioTags
-     */
-    #[DataProvider('providerScenarioMatches')]
-    public function testIsScenarioMatchFilterWithScenarioNode(string $filterString, array $featureTags, array $scenarioTags, bool $expect): void
-    {
-        $feature = new FeatureNode(null, null, $featureTags, null, [], '', '', null, 1);
-        $scenario = new ScenarioNode(null, $scenarioTags, [], '', 2);
-        $filter = new TagFilter($filterString);
-        $this->assertSame($expect, $filter->isScenarioMatch($feature, $scenario));
-    }
-
-    /**
-     * @return iterable<string, array{string, bool}>
-     */
-    public static function providerScenarioOutlineFilterMatches(): iterable
-    {
-        yield 'match if ANY Examples tables match the tag' => [
-            '@etag3',
-            true,
-        ];
-
-        yield 'match if ANY Examples tables match a NOT filter' => [
-            '~@etag3',
-            true,
-        ];
-
-        yield 'match if the Outline matches the tag' => [
-            '@wip',
-            true,
-        ];
-
-        yield 'no match if the Outline does not match regardless of Examples' => [
-            '@etag2&&~@wip',
-            false,
-        ];
-
-        yield 'match if tags present on Outline & ANY Examples' => [
-            '@wip&&~@etag3',
-            true,
-        ];
-
-        yield 'match if tags present on Feature, Outline & ANY Examples' => [
-            '@feature-tag&&@etag1&&@wip',
-            true,
-        ];
-
-        yield 'no match if the Feature does not match regardless of Examples' => [
-            '@etag2&&~@feature-tag',
-            false,
-        ];
-
-        yield 'match if tags present on Feature & Outline & ALL Examples match the NOT filter' => [
-            '@feature-tag&&~@etag11111&&@wip',
-            true,
-        ];
-
-        yield 'match if tags present on Feature & Outline & ANY Examples match the NOT filter' => [
-            '@feature-tag&&~@etag1&&@wip',
-            true,
-        ];
-
-        yield 'match if tags present on Feature & ALL Examples' => [
-            '@feature-tag&&@etag2',
-            true,
-        ];
-
-        yield 'match if tags present on Feature & ANY Examples' => [
-            '@feature-tag&&@etag3',
-            true,
-        ];
-
-        yield 'no match if ALL Examples match ONE of the NOT filters' => [
-            '~@etag1&&~@etag3',
-            false,
-        ];
-
-        yield 'no match if NO Examples match ALL of the AND filters' => [
-            '@etag1&&@etag3',
-            false,
-        ];
-
-        yield 'match if ANY Examples match an OR filter' => [
-            '@etag1,@etag3',
-            true,
-        ];
-    }
-
-    #[DataProvider('providerScenarioOutlineFilterMatches')]
-    public function testIsScenarioMatchFilterConsidersOutlineAndExampleTableTags(string $filterString, bool $expect): void
-    {
-        $feature = new FeatureNode(null, null, ['feature-tag'], null, [], '', '', null, 1);
-        $scenario = new OutlineNode(null, ['wip'], [], [
-            new ExampleTableNode([], '', ['etag1', 'etag2']),
-            new ExampleTableNode([], '', ['etag2', 'etag3']),
-        ], '', 2);
-
-        $tagFilter = new TagFilter($filterString);
-        $this->assertSame($expect, $tagFilter->isScenarioMatch($feature, $scenario));
-    }
-
-    public function testFilterFeatureWithTaggedExamples(): void
-    {
-        $exampleTableNode1 = new ExampleTableNode([], '', ['etag1', 'etag2']);
-        $exampleTableNode2 = new ExampleTableNode([], '', ['etag2', 'etag3']);
-        $scenario = new OutlineNode(null, ['wip'], [], [
-            $exampleTableNode1,
-            $exampleTableNode2,
-        ], '', 2);
-        $feature = new FeatureNode(null, null, ['feature-tag'], null, [$scenario], '', '', null, 1);
-
-        $tagFilter = new TagFilter('@etag2');
-        $matched = $tagFilter->filterFeature($feature);
-        $scenarioInterfaces = $matched->getScenarios();
-        $this->assertEquals($scenario, $scenarioInterfaces[0]);
-
-        $tagFilter = new TagFilter('@etag1');
-        $matched = $tagFilter->filterFeature($feature);
-        $scenarioInterfaces = $matched->getScenarios();
-        $this->assertInstanceOf(OutlineNode::class, $scenarioInterfaces[0]);
-        $this->assertEquals([$exampleTableNode1], $scenarioInterfaces[0]->getExampleTables());
-
-        $tagFilter = new TagFilter('~@etag3');
-        $matched = $tagFilter->filterFeature($feature);
-        $scenarioInterfaces = $matched->getScenarios();
-        $this->assertInstanceOf(OutlineNode::class, $scenarioInterfaces[0]);
-        $this->assertEquals([$exampleTableNode1], $scenarioInterfaces[0]->getExampleTables());
-
-        $tagFilter = new TagFilter('@wip');
-        $matched = $tagFilter->filterFeature($feature);
-        $scenarioInterfaces = $matched->getScenarios();
-        $this->assertEquals($scenario, $scenarioInterfaces[0]);
-
-        $tagFilter = new TagFilter('@wip&&@etag3');
-        $matched = $tagFilter->filterFeature($feature);
-        $scenarioInterfaces = $matched->getScenarios();
-        $this->assertInstanceOf(OutlineNode::class, $scenarioInterfaces[0]);
-        $this->assertEquals([$exampleTableNode2], $scenarioInterfaces[0]->getExampleTables());
-
-        $tagFilter = new TagFilter('@feature-tag&&@etag1&&@wip');
-        $matched = $tagFilter->filterFeature($feature);
-        $scenarioInterfaces = $matched->getScenarios();
-        $this->assertInstanceOf(OutlineNode::class, $scenarioInterfaces[0]);
-        $this->assertEquals([$exampleTableNode1], $scenarioInterfaces[0]->getExampleTables());
-
-        $tagFilter = new TagFilter('@feature-tag&&~@etag11111&&@wip');
-        $matched = $tagFilter->filterFeature($feature);
-        $scenarioInterfaces = $matched->getScenarios();
-        $this->assertEquals($scenario, $scenarioInterfaces[0]);
-
-        $tagFilter = new TagFilter('@feature-tag&&~@etag1&&@wip');
-        $matched = $tagFilter->filterFeature($feature);
-        $scenarioInterfaces = $matched->getScenarios();
-        $this->assertInstanceOf(OutlineNode::class, $scenarioInterfaces[0]);
-        $this->assertEquals([$exampleTableNode2], $scenarioInterfaces[0]->getExampleTables());
-
-        $tagFilter = new TagFilter('@feature-tag&&@etag2');
-        $matched = $tagFilter->filterFeature($feature);
-        $scenarioInterfaces = $matched->getScenarios();
-        $this->assertEquals($scenario, $scenarioInterfaces[0]);
-
-        $exampleTableNode1 = new ExampleTableNode([], '', ['etag1', 'etag']);
-        $exampleTableNode2 = new ExampleTableNode([], '', ['etag2', 'etag22', 'etag']);
-        $exampleTableNode3 = new ExampleTableNode([], '', ['etag3', 'etag22', 'etag']);
-        $exampleTableNode4 = new ExampleTableNode([], '', ['etag4', 'etag']);
-        $scenario1 = new OutlineNode(null, ['wip'], [], [
-            $exampleTableNode1,
-            $exampleTableNode2,
-        ], '', 2);
-        $scenario2 = new OutlineNode(null, ['wip'], [], [
-            $exampleTableNode3,
-            $exampleTableNode4,
-        ], '', 2);
-        $feature = new FeatureNode(null, null, ['feature-tag'], null, [$scenario1, $scenario2], '', '', null, 1);
-
-        $tagFilter = new TagFilter('@etag');
-        $matched = $tagFilter->filterFeature($feature);
-        $scenarioInterfaces = $matched->getScenarios();
-        $this->assertEquals([$scenario1, $scenario2], $scenarioInterfaces);
-
-        $tagFilter = new TagFilter('@etag22');
-        $matched = $tagFilter->filterFeature($feature);
-        $scenarioInterfaces = $matched->getScenarios();
-        $this->assertCount(2, $scenarioInterfaces);
-        $this->assertInstanceOf(OutlineNode::class, $scenarioInterfaces[0]);
-        $this->assertEquals([$exampleTableNode2], $scenarioInterfaces[0]->getExampleTables());
-        $this->assertInstanceOf(OutlineNode::class, $scenarioInterfaces[1]);
-        $this->assertEquals([$exampleTableNode3], $scenarioInterfaces[1]->getExampleTables());
-    }
-
     public function testItFiltersAsExpectedIfChildClassModifiesFilterString(): void
     {
         $filter = new class('@wip') extends TagFilter {
@@ -321,5 +599,37 @@ class TagFilterTest extends TestCase
         $filter->setFilterString('@wip&&@slow');
 
         $this->assertFalse($filter->isFeatureMatch($feature), 'Matches after filter is modified');
+    }
+
+    #[TestWith(['@bar', false])]
+    #[TestWith(['@foo', true])]
+    #[TestWith(['@outline-tag', true])]
+    #[TestWith(['@foo && @outline-tag', true])]
+    #[TestWith(['@foo && ~@outline-tag', false])]
+    public function testItCanScenarioMatchAnExampleNode(string $filterString, bool $expect): void
+    {
+        // Although our own filtering logic never passes an ExampleNode, other callers might. For example Behat
+        // does when checking if a Tagged Hook should be executed for a Scenario. Make sure that this is covered.
+        // NB that the Scenario and Table tags are merged within OutlineNode::getExamples().
+        $feature = $this->parseFeature(
+            <<<'GHERKIN'
+            Feature:
+
+              @outline-tag
+              Scenario: Something
+                Given <something>
+                
+                @foo
+                Examples:
+                  | something |
+                  | anything  | 
+            GHERKIN,
+        );
+        $outline = $feature->getScenarios()[0];
+        $this->assertInstanceOf(OutlineNode::class, $outline);
+        $example = $outline->getExamples()[0];
+
+        $tagFilter = new TagFilter($filterString);
+        $this->assertSame($expect, $tagFilter->isScenarioMatch($feature, $example));
     }
 }

--- a/tests/Filter/TagFilterTest.php
+++ b/tests/Filter/TagFilterTest.php
@@ -15,10 +15,7 @@ use Behat\Gherkin\Node\ExampleTableNode;
 use Behat\Gherkin\Node\FeatureNode;
 use Behat\Gherkin\Node\OutlineNode;
 use Behat\Gherkin\Node\ScenarioNode;
-use Closure;
-use ErrorException;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 
 class TagFilterTest extends TestCase
@@ -65,71 +62,17 @@ class TagFilterTest extends TestCase
         // Or `,` matches if ANY of the list of tags is present
         yield ['@tag5,@tag4,@tag6', ['tag1', 'tag2', 'tag3'], false];
         yield ['@tag5,@tag4,@tag6', ['tag1', 'tag2', 'tag3', 'tag5'], true];
-        yield ['@tag5,@tag4,@tag6', ['tag1', 'tag2', 'tag3', 'tag5'], true];
 
         // And `&&` matches if ALL of the list of tags is present
-        yield ['@wip&&@vip', ['wip', 'done'], false];
         yield ['@wip&&@vip', ['wip', 'done'], false];
         yield ['@wip&&@vip', ['wip', 'done', 'vip'], true];
 
         // `,` has precedence over `&&` - resolves as "(@wip OR @vip) AND user"
-        yield ['@wip,@vip&&@user', ['wip'], false];
-        yield ['@wip,@vip&&@user', ['vip'], false];
         yield ['@wip,@vip&&@user', ['wip', 'user'], true];
-        yield ['@wip,@vip&&@user', ['vip', 'user'], true];
 
         // `&&` with negated tag matches if positive tag is present AND negated tag is absent
-        yield ['@wip&&~@slow', [], false];
         yield ['@wip&&~@slow', ['wip'], true];
-        yield ['@wip&&~@slow', ['wip', 'fast'], true];
         yield ['@wip&&~@slow', ['wip', 'slow'], false];
-
-        // Whitespace around operators is ignored
-        // Should match behaviour of the unspaced examples above
-        yield ['@tag5, @tag4, @tag6', ['tag1', 'tag2', 'tag3'], false];
-        yield ['@tag5, @tag4, @tag6', ['tag1', 'tag2', 'tag3', 'tag5'], true];
-
-        yield ['@wip && @vip', ['wip', 'done'], false];
-        yield ['@wip && @vip', ['wip', 'done', 'vip'], true];
-        yield ['@wip &&@vip', ['wip', 'done'], false];
-        yield ['@wip &&@vip', ['wip', 'done', 'vip'], true];
-        yield ['@wip&& @vip', ['wip', 'done'], false];
-        yield ['@wip&& @vip', ['wip', 'done', 'vip'], true];
-
-        yield ['@wip, @vip&&@user', ['wip'], false];
-        yield ['@wip, @vip&&@user', ['vip', 'user'], true];
-        yield ['@wip, @vip&& @user', ['wip'], false];
-        yield ['@wip, @vip&& @user', ['vip', 'user'], true];
-        yield ['@wip, @vip &&@user', ['wip'], false];
-        yield ['@wip, @vip &&@user', ['vip', 'user'], true];
-        yield ['@wip, @vip&& @user', ['wip'], false];
-        yield ['@wip, @vip&& @user', ['vip', 'user'], true];
-        yield ['@wip,@vip &&@user', ['wip'], false];
-        yield ['@wip,@vip &&@user', ['vip', 'user'], true];
-        yield ['@wip,@vip&& @user', ['wip'], false];
-        yield ['@wip,@vip&& @user', ['vip', 'user'], true];
-        yield ['@wip,@vip && @user', ['wip'], false];
-        yield ['@wip,@vip && @user', ['vip', 'user'], true];
-
-        yield ['@wip &&~@slow', ['wip'], true];
-        yield ['@wip &&~@slow', ['wip', 'slow'], false];
-        yield ['@wip && ~@slow', ['wip'], true];
-        yield ['@wip && ~@slow', ['wip', 'slow'], false];
-        yield ['@wip&& ~@slow', ['wip'], true];
-        yield ['@wip&& ~@slow', ['wip', 'slow'], false];
-
-        // Edge case - whitespace before a `,` doesn't really make sense, but was historically supported
-        yield ['@wip , @vip && @user', ['vip', 'user'], true];
-
-        // Very much an edge case, but the legacy implementation would have allowed this as it always just used
-        // `trim`. And arguably someone *could* have a config file with an indented multiline filter expression.
-        yield ["\t@tag1,\n\t@tag2  &&  ~@tag3\n", ['tag1', 'tag3'], false];
-        yield ["\t@tag1,\n\t@tag2  &&  ~@tag3\n", ['tag1', 'tag2'], true];
-
-        // Leading and trailing whitespace is ignored
-        yield [' @tag1', ['tag1'], true];
-        yield [' @tag1 ', ['tag1'], true];
-        yield ['@tag1 ', ['tag1'], true];
     }
 
     /**
@@ -157,26 +100,18 @@ class TagFilterTest extends TestCase
 
         // `&&` matches if one tag present on the feature and one on the scenario
         yield ['@feature-tag&&@user', ['feature-tag'], ['wip', 'user'], true];
-        yield ['@feature-tag&&@user', ['feature-tag'], ['wip'], false];
 
         // Does not match if the feature matches a negated expression
-        yield ['@user&&~@feature-tag', [], [], false];
         yield ['@user&&~@feature-tag', ['feature-tag'], ['user'], false];
         yield ['@user&&~@feature-tag', ['other-feature'], ['user'], true];
-        yield ['@user&&~@feature-tag', ['other-feature'], ['api'], false];
 
         // Matches if the feature or the scenario matches an OR expression
-        yield ['@api,@browser', [], [], false];
         yield ['@api,@browser', ['api'], [], true];
-        yield ['@api,@browser', ['browser'], [], true];
         yield ['@api,@browser', [], ['api'], true];
-        yield ['@api,@browser', [], ['browser'], true];
-        yield ['@api,@browser', ['api'], ['browser'], true];
         yield ['@api,@browser', ['browser'], ['api'], true];
 
         // Not affected if same tag is present on Feature and Scenario
         yield ['@api', ['api'], ['api'], true];
-        yield ['@api', ['slow'], ['slow'], false];
     }
 
     /**
@@ -264,11 +199,6 @@ class TagFilterTest extends TestCase
 
         yield 'match if ANY Examples match an OR filter' => [
             '@etag1,@etag3',
-            true,
-        ];
-
-        yield 'allows whitespace around operators' => [
-            '@feature-tag && @etag3',
             true,
         ];
     }
@@ -375,158 +305,6 @@ class TagFilterTest extends TestCase
         $this->assertEquals([$exampleTableNode3], $scenarioInterfaces[1]->getExampleTables());
     }
 
-    /**
-     * @phpstan-return list<array{string, list<string>, bool}>
-     */
-    public static function providerMatchWithNoPrefixInFilter(): array
-    {
-        // This is officially unsupported (but potentially widespread) use of a filter expression that does not
-        // contain the `@` prefix. Behat's documentation shows that the `@` prefix should be provided - however Behat's
-        // own tests include an example where this is not the case, which has been passing. Gherkin has not historically
-        // validated the tag expression, so we will continue to support these for now.
-        // These cases rely on the bulk of the coverage being provided by the other tests, and the knowledge that the
-        // implementation ultimately uses the same logic to compare tags from all types of nodes.
-        // They are only intended to be temporary until we enforce that filter expressions are valid.
-        return [
-            ['wip', [], false],
-            ['wip', ['slow'], false],
-            ['wip', ['wip'], true],
-            ['wip', ['slow', 'wip'], true],
-            ['tag1&&~tag2&&tag3', [], false],
-            ['tag1&&~tag2&&tag3', ['tag1'], false],
-            ['tag1&&~tag2&&tag3', ['tag1', 'tag3'], true],
-            ['tag1&&~tag2&&tag3', ['tag1', 'tag2'], false],
-            ['tag1&&~tag2&&tag3', ['tag1', 'tag4'], false],
-            ['tag1&&~tag2&&tag3', ['tag1', 'tag2', 'tag3'], false],
-            // Also cover when the file was parsed in compatibility mode including the prefix
-            ['wip', [], false],
-            ['wip', ['@slow'], false],
-            ['wip', ['@wip'], true],
-            ['wip', ['@slow', '@wip'], true],
-            ['tag1&&~tag2&&tag3', [], false],
-            ['tag1&&~tag2&&tag3', ['@tag1'], false],
-            ['tag1&&~tag2&&tag3', ['@tag1', '@tag3'], true],
-            ['tag1&&~tag2&&tag3', ['@tag1', '@tag2'], false],
-            ['tag1&&~tag2&&tag3', ['@tag1', '@tag4'], false],
-            ['tag1&&~tag2&&tag3', ['@tag1', '@tag2', '@tag3'], false],
-
-            // And cover with whitespace around operators
-            ['tag1 && ~tag2 && tag3', [], false],
-            ['tag1 && ~tag2 && tag3', ['tag1'], false],
-            ['tag1 && ~tag2 && tag3', ['tag1', 'tag3'], true],
-            ['tag1 && ~tag2 && tag3', ['tag1', 'tag2'], false],
-            ['tag1 && ~tag2 && tag3', ['tag1', 'tag4'], false],
-            ['tag1 && ~tag2 && tag3', ['tag1', 'tag2', 'tag3'], false],
-        ];
-    }
-
-    /**
-     * @phpstan-param list<string> $tags
-     */
-    #[DataProvider('providerMatchWithNoPrefixInFilter')]
-    public function testItMatchesWhenFilterDoesNotContainPrefix(string $filter, array $tags, bool $expect): void
-    {
-        $tagFilter = $this->assertTriggersDeprecation(
-            'Filter strings should contain `@` prefixes',
-            fn () => new TagFilter($filter),
-        );
-
-        $feature = new FeatureNode(null, null, $tags, null, [], '', '', null, 1);
-        $this->assertSame($expect, $tagFilter->isFeatureMatch($feature));
-    }
-
-    /**
-     * @return iterable<string, array{string, bool}>
-     */
-    public static function providerWhitespaceDeprecated(): iterable
-    {
-        yield 'deprecation if filter has spaces in tag name' => [
-            '@tag with space',
-            true,
-        ];
-
-        yield 'deprecation if negated filter has spaces in tag name' => [
-            '~@tag with space',
-            false,
-        ];
-
-        yield 'deprecation with spaces in tag name and around && operator' => [
-            '@tag1 && @tag with space',
-            true,
-        ];
-
-        yield 'deprecation with spaces in tag name and around , operator' => [
-            '@any-tag, @tag with space',
-            true,
-        ];
-
-        yield 'deprecation on whitespace after ~ operator (and the negated tag is ignored)' => [
-            // Edge case - we don't expect people to have whitespace after a `~` and historically that would not
-            // have been trimmed so the filter would have matched even if a feature / scenario had the negated tag.
-            '~ @tag1',
-            true,
-        ];
-    }
-
-    #[DataProvider('providerWhitespaceDeprecated')]
-    public function testFilterWithWhitespaceIsDeprecated(string $filterString, bool $expectMatch): void
-    {
-        $tagFilter = $this->assertTriggersDeprecation(
-            'Tags with whitespace',
-            fn () => new TagFilter($filterString)
-        );
-
-        $feature = new FeatureNode(null, null, ['tag with space', 'tag1', 'tag2'], null, [], '', '', null, 1);
-
-        $this->assertSame($expectMatch, $tagFilter->isFeatureMatch($feature), 'Expected correct matching behaviour');
-    }
-
-    #[TestWith(['', true])]
-    #[TestWith([' ', true])]
-    public function testTagFilterThatIsAllWhitespaceIsIgnored(string $filterString): void
-    {
-        $feature = new FeatureNode(null, null, [], null, [], '', '', null, 1);
-        $tagFilter = new TagFilter($filterString);
-        $result = $tagFilter->isFeatureMatch($feature);
-
-        $this->assertTrue($result);
-    }
-
-    /**
-     * @phpstan-return list<array{string, list<string>, bool}>
-     */
-    public static function providerMatchWithoutRemovingPrefix(): array
-    {
-        // These cases rely on the bulk of the coverage being provided by the other tests, and the knowledge that the
-        // implementation ultimately uses the same logic to compare tags from all types of nodes. They are only intended
-        // to be temporary until we drop legacy parsing mode, at which point we can add the `@` to all the tags in the
-        // other tests in this file.
-        return [
-            ['@wip', [], false],
-            ['@wip', ['@slow'], false],
-            ['@wip', ['@wip'], true],
-            ['@wip', ['@slow', '@wip'], true],
-            ['@tag1&&~@tag2&&@tag3', [], false],
-            ['@tag1&&~@tag2&&@tag3', ['@tag1'], false],
-            ['@tag1&&~@tag2&&@tag3', ['@tag1', '@tag3'], true],
-            ['@tag1&&~@tag2&&@tag3', ['@tag1', '@tag2'], false],
-            ['@tag1&&~@tag2&&@tag3', ['@tag1', '@tag4'], false],
-            ['@tag1&&~@tag2&&@tag3', ['@tag1', '@tag2', '@tag3'], false],
-            ['@tag1 && ~@tag2 && @tag3', ['@tag1', '@tag3'], true],
-        ];
-    }
-
-    /**
-     * @phpstan-param list<string> $tags
-     */
-    #[DataProvider('providerMatchWithoutRemovingPrefix')]
-    public function testItMatchesTagsParsedWithoutRemovingPrefix(string $filter, array $tags, bool $expect): void
-    {
-        $feature = new FeatureNode(null, null, $tags, null, [], '', '', null, 1);
-        $tagFilter = new TagFilter($filter);
-        $this->assertSame($expect, $tagFilter->isFeatureMatch($feature));
-    }
-
     public function testItFiltersAsExpectedIfChildClassModifiesFilterString(): void
     {
         $filter = new class('@wip') extends TagFilter {
@@ -543,40 +321,5 @@ class TagFilterTest extends TestCase
         $filter->setFilterString('@wip&&@slow');
 
         $this->assertFalse($filter->isFeatureMatch($feature), 'Matches after filter is modified');
-    }
-
-    /**
-     * @template T
-     *
-     * @param Closure():T $callable
-     * @param non-empty-string $expectDeprecation
-     *
-     * @return T
-     */
-    private function assertTriggersDeprecation(string $expectDeprecation, Closure $callable): mixed
-    {
-        $deprecationCaptured = false;
-
-        set_error_handler(
-            static function (int $errNo, string $errStr, string $errFile, int $errLine) use (&$deprecationCaptured): bool {
-                if (($errNo === E_USER_DEPRECATED) && ($deprecationCaptured === false)) {
-                    $deprecationCaptured = $errStr;
-
-                    return false;
-                }
-                throw new ErrorException($errStr, $errNo, filename: $errFile, line: $errLine);
-            },
-        );
-
-        try {
-            $result = $callable();
-        } finally {
-            restore_error_handler();
-        }
-
-        $this->assertIsString($deprecationCaptured, 'Expected deprecation to be emitted');
-        $this->assertStringStartsWith($expectDeprecation, $deprecationCaptured, 'Expected correct deprecation message');
-
-        return $result;
     }
 }

--- a/tests/Filter/TagFilterTest.php
+++ b/tests/Filter/TagFilterTest.php
@@ -316,7 +316,6 @@ class TagFilterTest extends FilterTestCase
         ];
 
         yield 'matches outline & one example table' => [
-            // @todo: Existing test doesn't strictly prove that the @etag3 *only* matches in combination with the @wip...
             FeatureFilterTestFixture::fromCommentedExpectation(
                 <<<'GHERKIN'
                 @feature-tag
@@ -334,17 +333,31 @@ class TagFilterTest extends FilterTestCase
                     @etag2 @etag3
                     Examples: Second set of examples
                       | something | 
-                      | else      |     
+                      | else      |
+                      
+                #  @other-scenario
+                #  Scenario Outline: Scenario that does not match
+                #    Given <something>
+                #    
+                #    @etag1 @etag2
+                #    Examples: First set of examples
+                #      | something | 
+                #      | here      |
+                #      
+                #    @etag2 @etag3
+                #    Examples: Second set of examples
+                #      | something | 
+                #      | else      |
                 GHERKIN,
                 expectScenarioMatches: [
                     'Things are implemented' => true,
+                    'Scenario that does not match' => false,
                 ],
             ),
             '@wip && @etag3',
         ];
 
         yield 'matches feature, outline, and table' => [
-            // @todo: Existing test doesn't strictly prove that the @etag3 *only* matches in combination with the @wip...
             FeatureFilterTestFixture::fromCommentedExpectation(
                 <<<'GHERKIN'
                 @feature-tag
@@ -362,10 +375,26 @@ class TagFilterTest extends FilterTestCase
                 #    @etag2 @etag3
                 #    Examples: Second set of examples
                 #      | something | 
-                #      | else      |     
+                #      | else      |
+
+                #  @other-scenario
+                #  Scenario Outline: Scenario that does not match
+                #    Given <something>
+                #    
+                #    @etag1 @etag2
+                #    Examples: First set of examples
+                #      | something | 
+                #      | here      |
+                #      
+                #    @etag2 @etag3
+                #    Examples: Second set of examples
+                #      | something | 
+                #      | else      |
+
                 GHERKIN,
                 expectScenarioMatches: [
                     'Things are implemented' => true,
+                    'Scenario that does not match' => false,
                 ],
             ),
             '@feature-tag && @etag1 && @wip',
@@ -450,6 +479,36 @@ class TagFilterTest extends FilterTestCase
                 ],
             ),
             '@feature-tag && @etag2',
+        ];
+
+        yield 'drops Outlines where no Examples match' => [
+            FeatureFilterTestFixture::fromCommentedExpectation(
+                <<<'GHERKIN'
+                @feature-tag
+                Feature: Some work in progress
+                
+                  @scenario-tag
+                  Scenario: Matches filter
+
+                #  Scenario Outline: Things are implemented
+                #    Given <something>
+                #    
+                #    @etag1
+                #    Examples: First set of examples
+                #      | something | 
+                #      | here      |
+                #      
+                #    @etag1
+                #    Examples: Second set of examples
+                #      | something | 
+                #      | else      |     
+                GHERKIN,
+                expectScenarioMatches: [
+                    'Matches filter' => true,
+                    'Things are implemented' => false,
+                ],
+            ),
+            '@scenario-tag',
         ];
 
         yield 'matches all example tables across multiple Outlines' => [


### PR DESCRIPTION
The tests for filtering were hard to follow, and in particular hard to see exactly which cases were and were not covered. Additionally, some tests were not sufficiently robust to detect unexpected differences in the structure / properties of the filtered nodes.

This becomes more of an issue once we introduce Rule support, where we need to know that the filter has not accidentally triggered the BC behaviour and stripped out the Rule nodes.

This branch refactors the TagFilter implementation, so that we can have one set of tests covering all the edges and legacy anomalies of our filter expressions. These can be separate from the filter itself, which really only needs to prove that the filter conditions take account of tags merged down the hierarchy.

Then, it refactors the tests to a new structure that:

* Uses data providers rather than asserting different filter patterns in a single test.
* Ensures that the behaviour of `filterFeature` and `isScenarioMatch`   are kept in sync, and any differences are made clear in the tests.
* Guarantees that every test covers the full shape and properties of the filtered node tree.
* Organises the examples around human-readable representations of the filtering behaviour.

Finally, it adds coverage for some cases that were not previously tested.

I will follow this with a separate PR that fixes some bugs that I found when reviewing and adding coverage for missing cases.

Once this is merged, the changes to filters (and their tests) in #430 will be much easier to implement and to review for potential BC impact.